### PR TITLE
Add MemoryUtils and Utils JUnit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,8 @@ dependencies {
     implementation "curse.maven:debug-guardian-1093679:6633853"
     implementation "curse.maven:tick-tok-lib-1298954:6731548"
 
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+
     // Example optional mod dependency with JEI
     // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime
     // compileOnly "mezz.jei:jei-${mc_version}-common-api:${jei_version}"
@@ -211,6 +213,10 @@ publishing {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
+}
+
+tasks.named('test', Test).configure {
+    useJUnitPlatform()
 }
 
 // IDEA no longer automatically downloads sources/javadoc jars for dependencies, so we need to explicitly enable the behavior.

--- a/src/test/java/com/thunder/wildernessodysseyapi/util/MemoryUtilsTest.java
+++ b/src/test/java/com/thunder/wildernessodysseyapi/util/MemoryUtilsTest.java
@@ -1,0 +1,38 @@
+package com.thunder.wildernessodysseyapi.util;
+
+import com.thunder.wildernessodysseyapi.MemUtils.MemoryUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemoryUtilsTest {
+
+    @Test
+    @DisplayName("Recommended RAM uses base value when usage is low")
+    void testRecommendedBase() {
+        int result = MemoryUtils.calculateRecommendedRAM(1000, 0);
+        assertEquals(4096, result);
+    }
+
+    @Test
+    @DisplayName("Adds extra RAM per mod batch")
+    void testExtraPerMods() {
+        int result = MemoryUtils.calculateRecommendedRAM(4000, 25);
+        assertEquals(4352, result); // BASE 4096 + (25/10)*128 = 4352
+    }
+
+    @Test
+    @DisplayName("Uses usage + 512 when usage is higher than recommendation")
+    void testUsageAboveRecommended() {
+        int result = MemoryUtils.calculateRecommendedRAM(5000, 0);
+        assertEquals(5512, result);
+    }
+
+    @Test
+    @DisplayName("Equal usage does not trigger bump")
+    void testUsageEqualRecommended() {
+        int result = MemoryUtils.calculateRecommendedRAM(4224, 10);
+        assertEquals(4224, result);
+    }
+}

--- a/src/test/java/com/thunder/wildernessodysseyapi/util/UtilsTest.java
+++ b/src/test/java/com/thunder/wildernessodysseyapi/util/UtilsTest.java
@@ -1,0 +1,25 @@
+package com.thunder.wildernessodysseyapi.util;
+
+import com.thunder.wildernessodysseyapi.ModConflictChecker.Util.Utils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UtilsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"minecraft:stone", "wildernessodysseyapi:test_item", "minecraft:block/stone"})
+    @DisplayName("Valid resource locations return true")
+    void testValidResourceLocations(String value) {
+        assertTrue(Utils.isValidResourceLocation(value));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid", "minecraft:", "bad namespace:path", "minecraft:sp ace"})
+    @DisplayName("Invalid resource locations return false")
+    void testInvalidResourceLocations(String value) {
+        assertFalse(Utils.isValidResourceLocation(value));
+    }
+}


### PR DESCRIPTION
## Summary
- add `MemoryUtilsTest` and `UtilsTest`
- configure JUnit 5 support in `build.gradle`
- enable JUnit Platform for the `test` task

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6876db47f3088328a843390cd33bd465