### PR TITLE
Add cryo tube spawn logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ Additional Resources:
 ==========
 Community Documentation: https://docs.neoforged.net/  
 NeoForged Discord: https://discord.neoforged.net/
+
+Spawn Behavior:
+----------
+Players spawn inside a cryo tube when joining the world for the first time. Leaving the tube prevents re-entry.
+An introductory title sequence plays as they wake, which can be replaced with a custom cinematic in the future.

--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -11,7 +11,7 @@ import com.thunder.wildernessodysseyapi.MemUtils.MemoryUtils;
 import com.thunder.wildernessodysseyapi.ModListTracker.commands.ModListDiffCommand;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.biome.ModBiomeModifiers;
 import com.thunder.wildernessodysseyapi.ModPackPatches.ClientSaveHandler;
-import com.thunder.wildernessodysseyapi.WorldGen.blocks.WorldSpawnBlock;
+import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.client.ClientSetup;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.configurable.StructureConfig;
 import com.thunder.wildernessodysseyapi.command.StructureInfoCommand;
@@ -99,7 +99,7 @@ public class WildernessOdysseyAPIMainModClass {
         ModFeatures.CONFIGURED_FEATURES.register(modEventBus);
         ModFeatures.PLACED_FEATURES.register(modEventBus);
 
-        WorldSpawnBlock.register(modEventBus);
+        CryoTubeBlock.register(modEventBus);
         ModItems.register(modEventBus);
 
        // todo remove  modEventBus.addListener(ModBiomes::register);
@@ -124,7 +124,7 @@ public class WildernessOdysseyAPIMainModClass {
 
     private void addCreative(BuildCreativeModeTabContentsEvent event) {
         if (event.getTabKey() == CreativeModeTabs.TOOLS_AND_UTILITIES) {
-            event.accept(WorldSpawnBlock.WORLD_SPAWN_BLOCK.get());
+            event.accept(CryoTubeBlock.CRYO_TUBE_BLOCK.get());
         }
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/PlayerSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/PlayerSpawnHandler.java
@@ -1,10 +1,18 @@
 package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundSetTitleTextPacket;
+import net.minecraft.network.protocol.game.ClientboundSetTitlesAnimationPacket;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
 import java.util.List;
@@ -21,6 +29,9 @@ public class PlayerSpawnHandler {
 
     private static final AtomicInteger spawnIndex = new AtomicInteger(0);
     private static List<BlockPos> spawnBlocks = null;
+    private static final String CRYO_TAG = "wo_in_cryo";
+    private static final String CRYO_USED_TAG = "wo_cryo_used";
+    private static final String CRYO_POS_TAG = "wo_cryo_pos";
 
     /**
      * On player join.
@@ -32,33 +43,62 @@ public class PlayerSpawnHandler {
         ServerPlayer player = (ServerPlayer) event.getEntity();
         ServerLevel world = player.serverLevel();
 
+        CompoundTag tag = player.getPersistentData();
+        if (tag.getBoolean(CRYO_USED_TAG)) {
+            return;
+        }
+
         // Find spawn blocks if not already done
         if (spawnBlocks == null || spawnBlocks.isEmpty()) {
             spawnBlocks = WorldSpawnHandler.findAllWorldSpawnBlocks(world);
         }
 
         if (!spawnBlocks.isEmpty()) {
-            // Get the next spawn block in round-robin order
             BlockPos spawnPos = getNextSpawnBlock();
             player.teleportTo(world, spawnPos.getX() + 0.5, spawnPos.getY(), spawnPos.getZ() + 0.5, player.getYRot(), player.getXRot());
+            tag.putBoolean(CRYO_TAG, true);
+            tag.putBoolean(CRYO_USED_TAG, true);
+            tag.putLong(CRYO_POS_TAG, spawnPos.asLong());
+            player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, 60, 255, false, false));
+            playIntroCinematic(player);
+        }
+    }
+
+    // Intentionally empty - players should only wake in the cryo tube on their first join
+
+    /**
+     * Prevent re-entry into the tube after exiting.
+     */
+    @SubscribeEvent
+    public static void onPlayerTick(PlayerTickEvent event) {
+        if (!(event instanceof PlayerTickEvent.Post)) return;
+        if (!(event.getEntity() instanceof ServerPlayer player)) return;
+
+        CompoundTag tag = player.getPersistentData();
+        if (!tag.contains(CRYO_POS_TAG)) return;
+        BlockPos spawnPos = BlockPos.of(tag.getLong(CRYO_POS_TAG));
+
+        boolean inCryo = tag.getBoolean(CRYO_TAG);
+        if (inCryo) {
+            if (!player.blockPosition().equals(spawnPos)) {
+                tag.putBoolean(CRYO_TAG, false);
+            }
+        } else {
+            if (player.blockPosition().equals(spawnPos)) {
+                player.teleportTo(spawnPos.getX() + 1.5, spawnPos.getY(), spawnPos.getZ() + 0.5);
+            }
         }
     }
 
     /**
-     * On player respawn.
-     *
-     * @param event the event
+     * Play an intro cinematic when the player first awakens.
+     * This simply displays a title packet on the client as a placeholder.
+     * A proper video or scripted camera sequence can be implemented client-side later.
      */
-    @SubscribeEvent
-    public static void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event) {
-        ServerPlayer player = (ServerPlayer) event.getEntity();
-        ServerLevel world = player.serverLevel();
-
-        if (!spawnBlocks.isEmpty()) {
-            // Get the next spawn block in round-robin order
-            BlockPos spawnPos = getNextSpawnBlock();
-            player.teleportTo(world, spawnPos.getX() + 0.5, spawnPos.getY(), spawnPos.getZ() + 0.5, player.getYRot(), player.getXRot());
-        }
+    private static void playIntroCinematic(ServerPlayer player) {
+        ServerGamePacketListenerImpl connection = player.connection;
+        connection.send(new ClientboundSetTitlesAnimationPacket(20, 60, 20));
+        connection.send(new ClientboundSetTitleTextPacket(Component.literal("Waking from cryostasis...")));
     }
 
     private static BlockPos getNextSpawnBlock() {

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
@@ -1,6 +1,6 @@
 package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock;
 
-import com.thunder.wildernessodysseyapi.WorldGen.blocks.WorldSpawnBlock;
+import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -41,7 +41,7 @@ public class WorldSpawnHandler {
                 world.setDefaultSpawnPos(spawnBlockPos.above(), 0.0F);
             } else {
                 // Log a warning or handle cases where no spawn blocks are found
-                System.err.println("No World Spawn Blocks found in the world!");
+                System.err.println("No Cryo Tube Blocks found in the world!");
             }
         }
     }
@@ -61,7 +61,7 @@ public class WorldSpawnHandler {
                 if (chunk != null) {
                     for (BlockPos pos : BlockPos.betweenClosed(chunk.getPos().getMinBlockX(), world.getMinBuildHeight(),
                             chunk.getPos().getMinBlockZ(), chunk.getPos().getMaxBlockX(), world.getMaxBuildHeight(), chunk.getPos().getMaxBlockZ())) {
-                        if (world.getBlockState(pos).is(WorldSpawnBlock.WORLD_SPAWN_BLOCK.get())) {
+                        if (world.getBlockState(pos).is(CryoTubeBlock.CRYO_TUBE_BLOCK.get())) {
                             spawnBlocks.add(pos);
                         }
                     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlock.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlock.java
@@ -1,0 +1,52 @@
+package com.thunder.wildernessodysseyapi.WorldGen.blocks;
+
+import com.thunder.wildernessodysseyapi.item.ModItems;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredBlock;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.function.Supplier;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
+
+/**
+ * Block representing a cryo tube spawn point.
+ */
+public class CryoTubeBlock {
+    /**
+     * Registry for blocks.
+     */
+    public static final DeferredRegister.Blocks BLOCKS =
+            DeferredRegister.createBlocks(MOD_ID);
+
+    /**
+     * The cryo tube block instance.
+     */
+    public static final DeferredBlock<Block> CRYO_TUBE_BLOCK = registerBlock(
+            () -> new Block(BlockBehaviour.Properties.of()
+                    .strength(-1.0F, 3600000.0F)
+                    .noLootTable()
+                    .sound(SoundType.METAL)));
+
+    private static <T extends Block> DeferredBlock<T> registerBlock(Supplier<T> block) {
+        DeferredBlock<T> toReturn = BLOCKS.register("cryo_tube_block", block);
+        registerBlockItem(toReturn);
+        return toReturn;
+    }
+
+    private static <T extends Block> void registerBlockItem(DeferredBlock<T> block) {
+        ModItems.ITEMS.register("cryo_tube_block", () -> new BlockItem(block.get(), new Item.Properties()));
+    }
+
+    /**
+     * Register the block with the given event bus.
+     */
+    public static void register(IEventBus eventBus) {
+        BLOCKS.register(eventBus);
+    }
+}

--- a/src/main/resources/assets/wildernessodysseyapi/BlockStates/cryo_tube_block.json
+++ b/src/main/resources/assets/wildernessodysseyapi/BlockStates/cryo_tube_block.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "wildernessodysseyapi:block/cryo_tube_block"
+    }
+  }
+}

--- a/src/main/resources/assets/wildernessodysseyapi/item/cryo_tube_block.json
+++ b/src/main/resources/assets/wildernessodysseyapi/item/cryo_tube_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "wildernessodysseyapi:item/cryo_tube_block"
+}

--- a/src/main/resources/assets/wildernessodysseyapi/models/block/cryo_tube_block.json
+++ b/src/main/resources/assets/wildernessodysseyapi/models/block/cryo_tube_block.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "wildernessodysseyapi:block/cryo_tube_block"
+  }
+}


### PR DESCRIPTION
## Summary
- register `CryoTubeBlock` and use it as the new world spawn block
- teleport new players into cryo tubes, prevent re-entry, and show a short wake-up title
- document the new intro sequence in README
- remove placeholder PNG texture so external assets can be used

## Testing
- `./gradlew test --no-daemon` *(build interrupted before completing)*

------
https://chatgpt.com/codex/tasks/task_e_68779241addc83288b8bc42e3031b12e