### PR TITLE
Add bunker protection handler

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -19,6 +19,7 @@ import com.thunder.wildernessodysseyapi.item.ModItems;
 import com.thunder.wildernessodysseyapi.AntiCheat.BlacklistChecker;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.ModStructures;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Worldedit.WorldEditStructurePlacer;
+import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
 import com.thunder.wildernessodysseyapi.donations.config.DonationReminderConfig;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
@@ -164,13 +165,12 @@ public class WildernessOdysseyAPIMainModClass {
         BlockPos pos = findPlainsBiomePosition(serverLevel);
         if (pos == null) return;
 
-        // Place the BunkerStructure
+        // Place the BunkerStructure and capture its bounds
         WorldEditStructurePlacer placer = new WorldEditStructurePlacer("wildernessodyssey", "schematics/my_structure.schem");
-        if (placer.placeStructure(serverLevel, pos)) {
-            structureBoundingBox = new AABB(
-                    pos.getX() - 10, pos.getY() - 5, pos.getZ() - 10,
-                    pos.getX() + 10, pos.getY() + 10, pos.getZ() + 10
-            ); // Define a bounding box around the BunkerStructure
+        AABB bounds = placer.placeStructure(serverLevel, pos);
+        if (bounds != null) {
+            structureBoundingBox = bounds;
+            BunkerProtectionHandler.setBunkerBounds(bounds);
             // Mark as generated
         }
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerProtectionHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerProtectionHandler.java
@@ -1,0 +1,53 @@
+package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.level.BlockEvent;
+
+import java.util.Set;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
+
+/**
+ * Prevents breaking certain blocks within the bunker bounds.
+ */
+@EventBusSubscriber(modid = MOD_ID)
+public class BunkerProtectionHandler {
+
+    private static final Set<Block> UNBREAKABLE_BLOCKS = Set.of(
+            Blocks.OBSIDIAN,
+            Blocks.BEDROCK
+    );
+
+    private static AABB bunkerBounds;
+
+    /**
+     * Sets the bounding box of the bunker structure.
+     *
+     * @param bounds the structure bounds
+     */
+    public static void setBunkerBounds(AABB bounds) {
+        bunkerBounds = bounds;
+    }
+
+    /**
+     * Cancels block break events for protected blocks inside the bunker.
+     */
+    @SubscribeEvent
+    public static void onBlockBreak(BlockEvent.BreakEvent event) {
+        if (bunkerBounds == null) return;
+
+        BlockPos pos = event.getPos();
+        if (!bunkerBounds.contains(pos.getX(), pos.getY(), pos.getZ())) return;
+
+        BlockState state = event.getLevel().getBlockState(pos);
+        if (UNBREAKABLE_BLOCKS.contains(state.getBlock())) {
+            event.setCanceled(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- compute structure bounds from the schematic when pasting
- register a BunkerProtectionHandler to cancel block breaks for protected blocks inside the bunker
- hook up bounding box calculation with structure placement

## Testing
- `./gradlew classes -x test`

------
https://chatgpt.com/codex/tasks/task_e_687ee145266883288ee66bf6e7908c9b