### PR TITLE
Allow package override in CodeQL scan

### DIFF
--- a/.github/workflows/codeql-base-config.yml
+++ b/.github/workflows/codeql-base-config.yml
@@ -3,8 +3,12 @@ name: "Minecraft Mod CodeQL Config"
 queries:
   - uses: security-and-quality
 
+query-filters:
+  exclude:
+    - id: java/unused-*
+
 paths:
-  - src/main/java
+  - PACKAGE_PATH
   - src/generated/java
   - buildSrc/src
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '0 3 * * 1' # Every Monday at 3 AM UTC
   workflow_dispatch:
+    inputs:
+      package_path:
+        description: 'Relative path of the package to analyze'
+        required: false
+        default: ''
 
 permissions:
   actions: read
@@ -30,11 +35,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Prepare CodeQL config
+        env:
+          PACKAGE_PATH: ${{ github.event.inputs.package_path }}
+        run: |
+          cp .github/workflows/codeql-base-config.yml codeql-package-config.yml
+          PACKAGE_PATH="${PACKAGE_PATH:-src/main/java}"
+          sed -i "s|PACKAGE_PATH|$PACKAGE_PATH|g" codeql-package-config.yml
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          config-file: .github/workflows/codeql-config.yml
+          config-file: codeql-package-config.yml
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- allow customizing the package path for CodeQL scans via workflow input
- reuse the existing CodeQL config and replace the main source path when a package path is provided
- rename the base config to `codeql-base-config.yml`
- ignore CodeQL queries about unused code so classes or methods that aren't used don't appear in the scan report

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687ff85c0d2483289a7e38ffd7fe6c8f