### PR TITLE
Fix group ID in gradle properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ mod_version=3.0.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html
-mod_group_id=com.thunder.wildernessodysseyapi;
+mod_group_id=com.thunder.wildernessodysseyapi
 # The authors of the mod. This is a simple text string that is used for display purposes in the mod list.
 mod_authors=Thunderrock424242
 # The description of the mod. This is a simple multiline text string that is used for display purposes in the mod list.


### PR DESCRIPTION
## Summary
- fix the `mod_group_id` value to remove invalid trailing semicolon

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_6881ab372490832880eb8e065d906694