### PR TITLE
Fix compile errors in loottable package

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/loottable/LootTableOverrideHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/loottable/LootTableOverrideHandler.java
@@ -6,6 +6,7 @@ import net.neoforged.bus.api.EventPriority;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.event.LootTableLoadEvent;
+import net.neoforged.neoforge.common.NeoForge;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -16,7 +17,7 @@ public class LootTableOverrideHandler {
     private static final Path CONFIG_DIR = Path.of("config", "loot_tables");
 
     public static void init(FMLCommonSetupEvent event) {
-        MinecraftForge.EVENT_BUS.addListener(EventPriority.HIGH, LootTableOverrideHandler::onLootLoad);
+        NeoForge.EVENT_BUS.addListener(EventPriority.HIGH, LootTableOverrideHandler::onLootLoad);
     }
 
     public static void onLootLoad(LootTableLoadEvent event) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/loottable/LootYamlSerializer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/loottable/LootYamlSerializer.java
@@ -1,5 +1,9 @@
 package com.thunder.wildernessodysseyapi.loottable;
 
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.mojang.serialization.JsonOps;
 import net.minecraft.world.level.storage.loot.LootTable;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -24,24 +28,27 @@ public class LootYamlSerializer {
     }
 
     public static void writeLootTable(Path path, LootTable table) throws IOException {
-        var gson = LootDataType.LOOT_TABLE.createCodec().toGson();
-        Map<String, Object> map = YAML.load(gson.toJson(treeToJson(table)));
+        JsonElement json = LootTable.DIRECT_CODEC.encodeStart(JsonOps.INSTANCE, table).getOrThrow(error -> new IllegalStateException(error));
+        var gson = new GsonBuilder().setPrettyPrinting().create();
+        Map<String, Object> map = YAML.load(gson.toJson(json));
         Files.writeString(path, YAML.dump(map));
     }
 
     public static LootTable readLootTableWithFallback(Path yamlPath, Path jsonFallbackPath) throws IOException {
-        var gson = LootDataType.LOOT_TABLE.createCodec().toGson();
+        var gson = new GsonBuilder().create();
 
         try {
             String yaml = Files.readString(yamlPath);
             Object parsed = YAML.load(yaml);
             String json = gson.toJson(parsed);
-            return gson.fromJson(json, LootTable.class);
+            JsonElement element = JsonParser.parseString(json);
+            return LootTable.DIRECT_CODEC.parse(JsonOps.INSTANCE, element).getOrThrow(error -> new IllegalStateException(error));
         } catch (YAMLException | IllegalStateException e) {
             System.err.println("[LootYamlSerializer] Invalid YAML: " + yamlPath + ": " + e.getMessage());
             if (Files.exists(jsonFallbackPath)) {
                 System.err.println("[LootYamlSerializer] Fallback to JSON: " + jsonFallbackPath);
-                return gson.fromJson(Files.readString(jsonFallbackPath), LootTable.class);
+                JsonElement element = JsonParser.parseString(Files.readString(jsonFallbackPath));
+                return LootTable.DIRECT_CODEC.parse(JsonOps.INSTANCE, element).getOrThrow(error -> new IllegalStateException(error));
             } else {
                 throw new IOException("YAML failed and JSON fallback not found for: " + yamlPath);
             }
@@ -49,7 +56,7 @@ public class LootYamlSerializer {
     }
 
     private static Object treeToJson(LootTable table) {
-        var gson = LootDataType.LOOT_TABLE.createCodec().toGson();
-        return gson.fromJson(gson.toJson(table), Object.class);
+        JsonElement json = LootTable.DIRECT_CODEC.encodeStart(JsonOps.INSTANCE, table).getOrThrow(error -> new IllegalStateException(error));
+        return JsonParser.parseString(json.toString());
     }
 }


### PR DESCRIPTION
## Summary
- update loot table exporter to manually load loot tables from resources
- fix NeoForge event bus use in override handler
- rework YAML serializer to use new codecs
- update structure loot scanner for current API

## Testing
- `./gradlew test --no-daemon --stacktrace`

------
https://chatgpt.com/codex/tasks/task_e_6881ae843a7c83289f962e36bd9b3e53