### PR TITLE
Improve water bucket flow

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/WaterFluidMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/WaterFluidMixin.java
@@ -1,0 +1,21 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.WaterFluid;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Tweaks water tick delay so newly placed water flows every tick
+ * instead of every 5 ticks, giving smoother water propagation when
+ * using a bucket.
+ */
+@Mixin(WaterFluid.class)
+public abstract class WaterFluidMixin {
+    @Inject(method = "getTickDelay", at = @At("HEAD"), cancellable = true)
+    private void wildernessapi$fastTicks(Level level, CallbackInfoReturnable<Integer> cir) {
+        cir.setReturnValue(1);
+    }
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -4,10 +4,11 @@
   "package": "com.thunder.wildernessodysseyapi.mixin",
   "compatibilityLevel": "JAVA_17",
   "refmap": "mixins.wildernessodysseyapi.refmap.json",
-  "mixins": [
-    "CampfireBlockMixin",
-    "DayNightCycleMixin",
-    "EntityAccessor"
+    "mixins": [
+      "CampfireBlockMixin",
+      "DayNightCycleMixin",
+      "EntityAccessor",
+      "WaterFluidMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary
- add WaterFluidMixin to shorten water tick delay for faster water propagation
- register new mixin in mixins config

## Testing
- `./gradlew build --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6883d67f22e08328aac1f883fe0693aa