### PR TITLE
Fix mixin improvements without config

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/WaterFluidMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/WaterFluidMixin.java
@@ -1,6 +1,7 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
 import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.WaterFluid;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -16,6 +17,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class WaterFluidMixin {
     @Inject(method = "getTickDelay", at = @At("HEAD"), cancellable = true)
     private void wildernessapi$fastTicks(LevelReader level, CallbackInfoReturnable<Integer> cir) {
-        cir.setReturnValue(1);
+        if (level instanceof Level world && !world.isClientSide()) {
+            cir.setReturnValue(1);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- revert config-based water flow changes
- only speed up water ticks server-side

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_688409ef43648328b4feebcaddb68d37