### PR TITLE
Fix CodeQL build mode

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           config-file: codeql-package-config.yml
+          build-mode: manual
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- set `build-mode: manual` for CodeQL workflow

## Testing
- `./gradlew help --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68842abdd4dc83288509f2d2cb0fd9e8