### PR TITLE
Implement biome-aware bunker spawning

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerStructureGenerator.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerStructureGenerator.java
@@ -1,0 +1,51 @@
+package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Worldedit.WorldEditStructurePlacer;
+import com.thunder.wildernessodysseyapi.WorldGen.worldgen.ModBiomes;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.level.biome.Biomes;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.level.ChunkEvent;
+
+/**
+ * Generates bunker structures when suitable chunks load.
+ */
+@EventBusSubscriber(modid = ModConstants.MOD_ID)
+public class BunkerStructureGenerator {
+    private static final int MIN_DISTANCE_CHUNKS = 12000;
+
+    @SubscribeEvent
+    public static void onChunkLoad(ChunkEvent.Load event) {
+        if (!(event.getLevel() instanceof ServerLevel level)) return;
+        if (!(event.getChunk() instanceof LevelChunk chunk)) return;
+
+        BlockPos chunkPos = chunk.getPos().getWorldPosition();
+        BlockPos surfacePos = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, chunkPos);
+
+        var biomeHolder = level.getBiome(surfacePos);
+        if (!biomeHolder.is(ModBiomes.METEOR_IMPACT_ZONE) && !biomeHolder.is(Biomes.JUNGLE)) return;
+
+        StructureSpawnTracker tracker = StructureSpawnTracker.get(level);
+        if (tracker.hasSpawned()) {
+            BlockPos last = tracker.getLastSpawnPos();
+            long dx = (surfacePos.getX() - last.getX()) / 16L;
+            long dz = (surfacePos.getZ() - last.getZ()) / 16L;
+            long dist = Math.max(Math.abs(dx), Math.abs(dz));
+            if (dist < MIN_DISTANCE_CHUNKS) return;
+        }
+
+        WorldEditStructurePlacer placer = new WorldEditStructurePlacer(ModConstants.MOD_ID, "bunkerfinal.schem");
+        AABB bounds = placer.placeStructure(level, surfacePos);
+        if (bounds != null) {
+            tracker.markAsSpawned();
+            tracker.setLastSpawnPos(surfacePos);
+            BunkerProtectionHandler.setBunkerBounds(bounds);
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/StructureSpawnTracker.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/StructureSpawnTracker.java
@@ -2,6 +2,7 @@ package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure;
 
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.saveddata.SavedData;
 import org.jetbrains.annotations.NotNull;
@@ -12,6 +13,8 @@ import org.jetbrains.annotations.NotNull;
 public class StructureSpawnTracker extends SavedData {
     private static final String DATA_NAME = "wildernessodyssey_structure_spawn_tracker";
     private boolean hasSpawned;
+    private long lastSpawnX;
+    private long lastSpawnZ;
 
     /**
      * Instantiates a new Structure spawn tracker.
@@ -19,6 +22,8 @@ public class StructureSpawnTracker extends SavedData {
 // Constructor for creating a new tracker
     public StructureSpawnTracker() {
         this.hasSpawned = false;
+        this.lastSpawnX = 0L;
+        this.lastSpawnZ = 0L;
     }
 
     /**
@@ -29,6 +34,8 @@ public class StructureSpawnTracker extends SavedData {
     @Override
     public @NotNull CompoundTag save(@NotNull CompoundTag tag, HolderLookup.@NotNull Provider registries) {
         tag.putBoolean("hasSpawned", this.hasSpawned);
+        tag.putLong("lastSpawnX", this.lastSpawnX);
+        tag.putLong("lastSpawnZ", this.lastSpawnZ);
         return tag;
     }
 
@@ -41,6 +48,8 @@ public class StructureSpawnTracker extends SavedData {
 // Constructor for loading tracker from saved data
     public StructureSpawnTracker(CompoundTag tag, HolderLookup.Provider registries) {
         this.hasSpawned = tag.getBoolean("hasSpawned");
+        this.lastSpawnX = tag.getLong("lastSpawnX");
+        this.lastSpawnZ = tag.getLong("lastSpawnZ");
     }
 
     /**
@@ -60,6 +69,24 @@ public class StructureSpawnTracker extends SavedData {
     public void markAsSpawned() {
         this.hasSpawned = true;
         this.setDirty(); // Mark data as dirty so it gets saved
+    }
+
+    /**
+     * Update the last spawn position of the bunker.
+     *
+     * @param pos the world position
+     */
+    public void setLastSpawnPos(BlockPos pos) {
+        this.lastSpawnX = pos.getX();
+        this.lastSpawnZ = pos.getZ();
+        this.setDirty();
+    }
+
+    /**
+     * Get the last spawn position.
+     */
+    public BlockPos getLastSpawnPos() {
+        return new BlockPos((int) this.lastSpawnX, 0, (int) this.lastSpawnZ);
     }
 
     /**

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/ModBiomes.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/ModBiomes.java
@@ -23,6 +23,12 @@ public class ModBiomes {
             ResourceKey.create(Registries.BIOME, ResourceLocation.tryBuild(MOD_ID, "anomaly_zone"));
 
     /**
+     * Custom biome key for the meteor impact zone.
+     */
+    public static final ResourceKey<Biome> METEOR_IMPACT_ZONE =
+            ResourceKey.create(Registries.BIOME, ResourceLocation.tryBuild(MOD_ID, "meteor_impact_zone"));
+
+    /**
      * Register.
      *
      * @param context the context


### PR DESCRIPTION
## Summary
- detect custom `meteor_impact_zone` biome
- keep track of bunker spawn locations
- spawn bunkers in the meteor biome or jungle, 12k chunks apart

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_6886afd1e90883289b8ab90f5205241a