### PR TITLE
Implement structure-based bunker spawning

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -18,11 +18,9 @@ import com.thunder.wildernessodysseyapi.donations.command.DonateCommand;
 import com.thunder.wildernessodysseyapi.item.ModItems;
 import com.thunder.wildernessodysseyapi.AntiCheat.BlacklistChecker;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.ModStructures;
-import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Worldedit.WorldEditStructurePlacer;
-import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import com.thunder.wildernessodysseyapi.donations.config.DonationReminderConfig;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -31,8 +29,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.item.CreativeModeTabs;
-import net.minecraft.world.level.biome.Biomes;
-import net.minecraft.world.level.levelgen.Heightmap;
+import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorStructureSpawner;
 import net.minecraft.world.phys.AABB;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.ModList;
@@ -161,18 +158,7 @@ public class WildernessOdysseyAPIMainModClass {
     public void onWorldLoad(LevelEvent.Load event) {
         if (!(event.getLevel() instanceof ServerLevel serverLevel)) return;
 
-        // Find a position in the Plains biome
-        BlockPos pos = findPlainsBiomePosition(serverLevel);
-        if (pos == null) return;
-
-        // Place the BunkerStructure and capture its bounds
-        WorldEditStructurePlacer placer = new WorldEditStructurePlacer("wildernessodyssey", "schematics/my_structure.schem");
-        AABB bounds = placer.placeStructure(serverLevel, pos);
-        if (bounds != null) {
-            structureBoundingBox = bounds;
-            BunkerProtectionHandler.setBunkerBounds(bounds);
-            // Mark as generated
-        }
+        MeteorStructureSpawner.tryPlace(serverLevel);
     }
     /**
      * On mob spawn.
@@ -190,17 +176,6 @@ public class WildernessOdysseyAPIMainModClass {
         }
     }
 
-    private BlockPos findPlainsBiomePosition(ServerLevel serverLevel) {
-        for (int x = -1000; x < 1000; x += 16) {
-            for (int z = -1000; z < 1000; z += 16) {
-                BlockPos pos = new BlockPos(x, serverLevel.getHeight(Heightmap.Types.WORLD_SURFACE, x, z), z);
-                if (serverLevel.getBiome(pos).is(Biomes.PLAINS)) {
-                    return pos;
-                }
-            }
-        }
-        return null; // No Plains biome found in the search range
-    }
 
 
     /**

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerProtectionHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerProtectionHandler.java
@@ -24,15 +24,15 @@ public class BunkerProtectionHandler {
             Blocks.BEDROCK
     );
 
-    private static AABB bunkerBounds;
+    private static final java.util.List<AABB> bunkerBounds = new java.util.ArrayList<>();
 
     /**
      * Sets the bounding box of the bunker structure.
      *
      * @param bounds the structure bounds
      */
-    public static void setBunkerBounds(AABB bounds) {
-        bunkerBounds = bounds;
+    public static void addBunkerBounds(AABB bounds) {
+        bunkerBounds.add(bounds);
     }
 
     /**
@@ -40,14 +40,17 @@ public class BunkerProtectionHandler {
      */
     @SubscribeEvent
     public static void onBlockBreak(BlockEvent.BreakEvent event) {
-        if (bunkerBounds == null) return;
+        if (bunkerBounds.isEmpty()) return;
 
         BlockPos pos = event.getPos();
-        if (!bunkerBounds.contains(pos.getX(), pos.getY(), pos.getZ())) return;
-
-        BlockState state = event.getLevel().getBlockState(pos);
-        if (UNBREAKABLE_BLOCKS.contains(state.getBlock())) {
-            event.setCanceled(true);
+        for (AABB box : bunkerBounds) {
+            if (box.contains(pos.getX(), pos.getY(), pos.getZ())) {
+                BlockState state = event.getLevel().getBlockState(pos);
+                if (UNBREAKABLE_BLOCKS.contains(state.getBlock())) {
+                    event.setCanceled(true);
+                }
+                break;
+            }
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerStructureGenerator.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerStructureGenerator.java
@@ -1,0 +1,39 @@
+package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Worldedit.WorldEditStructurePlacer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.phys.AABB;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.level.ChunkEvent;
+
+/**
+ * Generates bunker structures when suitable chunks load.
+ */
+@EventBusSubscriber(modid = ModConstants.MOD_ID)
+public class BunkerStructureGenerator {
+    private static final int MIN_DISTANCE_CHUNKS = 12000;
+
+    @SubscribeEvent
+    public static void onChunkLoad(ChunkEvent.Load event) {
+        if (!(event.getLevel() instanceof ServerLevel level)) return;
+        if (!(event.getChunk() instanceof LevelChunk chunk)) return;
+
+        BlockPos chunkPos = chunk.getPos().getWorldPosition();
+        BlockPos surfacePos = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, chunkPos);
+
+        StructureSpawnTracker tracker = StructureSpawnTracker.get(level);
+        if (!tracker.isFarEnough(surfacePos, MIN_DISTANCE_CHUNKS)) return;
+
+        WorldEditStructurePlacer placer = new WorldEditStructurePlacer(ModConstants.MOD_ID, "bunkerfinal.schem");
+        AABB bounds = placer.placeStructure(level, surfacePos);
+        if (bounds != null) {
+            tracker.addSpawnPos(surfacePos);
+            BunkerProtectionHandler.addBunkerBounds(bounds);
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/ModBiomes.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/ModBiomes.java
@@ -23,6 +23,12 @@ public class ModBiomes {
             ResourceKey.create(Registries.BIOME, ResourceLocation.tryBuild(MOD_ID, "anomaly_zone"));
 
     /**
+     * Custom biome key for the meteor impact zone.
+     */
+    public static final ResourceKey<Biome> METEOR_IMPACT_ZONE =
+            ResourceKey.create(Registries.BIOME, ResourceLocation.tryBuild(MOD_ID, "meteor_impact_zone"));
+
+    /**
      * Register.
      *
      * @param context the context

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
@@ -1,8 +1,13 @@
 package com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures;
 
 import net.minecraft.core.BlockPos;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
+import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.StructureSpawnTracker;
+import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Worldedit.WorldEditStructurePlacer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
@@ -22,7 +27,7 @@ public class MeteorStructureSpawner {
         if (placed) return;
         placed = true;
 
-        // Decide where to place the bunker. For example: at (0, surfaceY(0,0), 0)
+        // Decide where to place the meteor
         BlockPos spawnPos = new BlockPos(0, level.getHeight(), 0);
 
         ResourceLocation structureID = ResourceLocation.tryBuild(MOD_ID, "meteor_bunker");
@@ -32,14 +37,17 @@ public class MeteorStructureSpawner {
         if (templateOpt.isPresent()) {
             StructureTemplate template = templateOpt.get();
             StructurePlaceSettings settings = new StructurePlaceSettings();
-            template.placeInWorld(
-                    level,
-                    spawnPos,
-                    spawnPos,
-                    settings,
-                    level.random,
-                    2
-            );
+            template.placeInWorld(level, spawnPos, spawnPos, settings, level.random, 2);
+
+            // place bunker two chunks east of the meteor
+            BlockPos bunkerPos = spawnPos.offset(32, 0, 0);
+            bunkerPos = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, bunkerPos);
+            WorldEditStructurePlacer placer = new WorldEditStructurePlacer(ModConstants.MOD_ID, "bunkerfinal.schem");
+            var bounds = placer.placeStructure(level, bunkerPos);
+            if (bounds != null) {
+                BunkerProtectionHandler.addBunkerBounds(bounds);
+                StructureSpawnTracker.get(level).addSpawnPos(bunkerPos);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- track multiple bunker locations in `StructureSpawnTracker`
- protect all spawned bunkers
- drop biome checks and place bunkers on chunk load if far enough apart
- spawn first bunker two chunks from the meteor structure
- clean up world-load logic to delegate to `MeteorStructureSpawner`

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_6886afd1e90883289b8ab90f5205241a