### PR TITLE
Spawn players near meteor

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/PlayerSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/PlayerSpawnHandler.java
@@ -17,6 +17,8 @@ import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorImpactData;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
 
@@ -51,6 +53,16 @@ public class PlayerSpawnHandler {
         // Find spawn blocks if not already done
         if (spawnBlocks == null || spawnBlocks.isEmpty()) {
             spawnBlocks = WorldSpawnHandler.findAllWorldSpawnBlocks(world);
+            BlockPos meteorPos = MeteorImpactData.get(world).getImpactPos();
+            if (meteorPos != null && !spawnBlocks.isEmpty()) {
+                BlockPos closest = spawnBlocks.stream()
+                        .min((a, b) -> Double.compare(a.distSqr(meteorPos), b.distSqr(meteorPos)))
+                        .orElse(spawnBlocks.get(0));
+                final double maxDist = 400.0; // radius squared (20 blocks)
+                spawnBlocks = spawnBlocks.stream()
+                        .filter(p -> p.distSqr(closest) <= maxDist)
+                        .collect(Collectors.toList());
+            }
         }
 
         if (!spawnBlocks.isEmpty()) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
@@ -4,6 +4,7 @@ import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.chunk.LevelChunk;
+import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorImpactData;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.level.LevelEvent;
@@ -33,9 +34,16 @@ public class WorldSpawnHandler {
             List<BlockPos> spawnBlockPositions = findAllWorldSpawnBlocks(world);
 
             if (!spawnBlockPositions.isEmpty()) {
-                // Select a random spawn block
-                Random random = new Random();
-                BlockPos spawnBlockPos = spawnBlockPositions.get(random.nextInt(spawnBlockPositions.size()));
+                BlockPos meteorPos = MeteorImpactData.get(world).getImpactPos();
+                BlockPos spawnBlockPos;
+                if (meteorPos != null) {
+                    spawnBlockPos = spawnBlockPositions.stream()
+                            .min((a, b) -> Double.compare(a.distSqr(meteorPos), b.distSqr(meteorPos)))
+                            .orElse(spawnBlockPositions.get(0));
+                } else {
+                    Random random = new Random();
+                    spawnBlockPos = spawnBlockPositions.get(random.nextInt(spawnBlockPositions.size()));
+                }
 
                 // Set the world's default spawn position
                 world.setDefaultSpawnPos(spawnBlockPos.above(), 0.0F);

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorImpactData.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorImpactData.java
@@ -1,0 +1,52 @@
+package com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.saveddata.SavedData;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Stores the location of the meteor impact zone so other systems
+ * can reference it (e.g. player spawn logic).
+ */
+public class MeteorImpactData extends SavedData {
+    private static final String DATA_NAME = "wo_meteor_location";
+    private long impactPos = Long.MIN_VALUE;
+
+    public MeteorImpactData() {}
+
+    public MeteorImpactData(CompoundTag tag, HolderLookup.Provider registries) {
+        if (tag.contains("pos")) {
+            impactPos = tag.getLong("pos");
+        }
+    }
+
+    @Override
+    public @NotNull CompoundTag save(@NotNull CompoundTag tag, HolderLookup.@NotNull Provider registries) {
+        tag.putLong("pos", impactPos);
+        return tag;
+    }
+
+    /** Set the impact position and mark the data dirty. */
+    public void setImpactPos(BlockPos pos) {
+        impactPos = pos.asLong();
+        setDirty();
+    }
+
+    /**
+     * @return the stored impact position or null if not yet set.
+     */
+    public BlockPos getImpactPos() {
+        return impactPos == Long.MIN_VALUE ? null : BlockPos.of(impactPos);
+    }
+
+    /** Retrieve the data instance for the given world. */
+    public static MeteorImpactData get(ServerLevel level) {
+        return level.getDataStorage().computeIfAbsent(
+                new SavedData.Factory<>(MeteorImpactData::new, MeteorImpactData::new),
+                DATA_NAME
+        );
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
@@ -5,6 +5,7 @@ import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.StructureSpawnTracker;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Worldedit.WorldEditStructurePlacer;
+import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorImpactData;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.levelgen.Heightmap;
@@ -29,6 +30,7 @@ public class MeteorStructureSpawner {
 
         // Decide where to place the meteor
         BlockPos spawnPos = new BlockPos(0, level.getHeight(), 0);
+        MeteorImpactData.get(level).setImpactPos(spawnPos);
 
         ResourceLocation structureID = ResourceLocation.tryBuild(MOD_ID, "meteor_bunker");
         StructureTemplateManager manager = level.getStructureManager();


### PR DESCRIPTION
## Summary
- remember the meteor impact position with `MeteorImpactData`
- store the meteor position when generating the meteor
- pick cryo tubes closest to the meteor as world and player spawn points

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688775870c68832891d94f668cfc9ccb