### PR TITLE
Add mod list history and version command

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -9,6 +9,7 @@ import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Features.ModFea
 import com.thunder.wildernessodysseyapi.MemUtils.MemCheckCommand;
 import com.thunder.wildernessodysseyapi.MemUtils.MemoryUtils;
 import com.thunder.wildernessodysseyapi.ModListTracker.commands.ModListDiffCommand;
+import com.thunder.wildernessodysseyapi.ModListTracker.commands.ModListVersionCommand;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.biome.ModBiomeModifiers;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.client.ClientSetup;
@@ -143,6 +144,7 @@ public class WildernessOdysseyAPIMainModClass {
     public void onRegisterCommands(RegisterCommandsEvent event) {
         CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
         ModListDiffCommand.register(dispatcher);
+        ModListVersionCommand.register(dispatcher);
         MemCheckCommand.register(event.getDispatcher());
         StructureInfoCommand.register(event.getDispatcher());
         FaqCommand.register(event.getDispatcher());

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModListTracker/commands/ModListDiffCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModListTracker/commands/ModListDiffCommand.java
@@ -28,11 +28,13 @@ public class ModListDiffCommand {
      * Sends the mod difference summary to chat and opens a GUI view.
      */
     private static void showModDifferences(CommandSourceStack source) {
+        ModTracker.checkModChanges();
         List<String> addedMods = ModTracker.getAddedMods();
         List<String> removedMods = ModTracker.getRemovedMods();
         List<String> updatedMods = ModTracker.getUpdatedMods();
+        String versionChange = ModTracker.getVersionChange();
 
-        if (addedMods.isEmpty() && removedMods.isEmpty() && updatedMods.isEmpty()) {
+        if (addedMods.isEmpty() && removedMods.isEmpty() && updatedMods.isEmpty() && versionChange.isEmpty()) {
             source.sendSuccess(() -> Component.literal("No mod changes detected."), false);
         } else {
             if (!addedMods.isEmpty()) {
@@ -43,6 +45,9 @@ public class ModListDiffCommand {
             }
             if (!updatedMods.isEmpty()) {
                 source.sendSuccess(() -> Component.literal("\u00A7e[Updated Mods]: " + String.join(", ", updatedMods)), false);
+            }
+            if (!versionChange.isEmpty()) {
+                source.sendSuccess(() -> Component.literal("\u00A7b" + versionChange), false);
             }
         }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModListTracker/commands/ModListVersionCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModListTracker/commands/ModListVersionCommand.java
@@ -1,0 +1,38 @@
+package com.thunder.wildernessodysseyapi.ModListTracker.commands;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.thunder.wildernessodysseyapi.ModListTracker.ModTracker;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Command to display the mod list stored for a specific pack version.
+ */
+public class ModListVersionCommand {
+    /** Registers the /modlistversion command. */
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("modlistversion")
+                .then(Commands.argument("version", StringArgumentType.string())
+                        .executes(ctx -> {
+                            showVersion(ctx.getSource(), StringArgumentType.getString(ctx, "version"));
+                            return Command.SINGLE_SUCCESS;
+                        })));
+    }
+
+    private static void showVersion(CommandSourceStack source, String version) {
+        Map<String, String> mods = ModTracker.getModsForVersion(version);
+        if (mods.isEmpty()) {
+            source.sendFailure(Component.literal("No data for version " + version));
+            return;
+        }
+        String list = mods.entrySet().stream()
+                .map(e -> e.getKey() + " v" + e.getValue())
+                .collect(Collectors.joining(", "));
+        source.sendSuccess(() -> Component.literal("\u00A7a[Mods in " + version + "]: " + list), false);
+    }
+}


### PR DESCRIPTION
## Summary
- maintain a versioned history of mod lists in `ModTracker`
- show stored mod list for a version via new `/modlistversion` command
- register the new command alongside `/modlistdiff`

## Testing
- `./gradlew --dry-run test`


------
https://chatgpt.com/codex/tasks/task_e_68878918ea788328be6a9b4093a1a532