### PR TITLE
Fix run workflows

### DIFF
--- a/.github/workflows/run-client.yml
+++ b/.github/workflows/run-client.yml
@@ -23,14 +23,18 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
       - name: Build
         run: ./gradlew build --no-daemon
 
       - name: Run client until main menu
-        env:
-          JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
         run: |
-          xvfb-run --auto-servernum ./gradlew runClient --no-daemon > client.log 2>&1 &
+          touch client.log
+          tail -F client.log &
+          TAIL_PID=$!
+          xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' ./gradlew runClient --no-daemon > client.log 2>&1 &
           PID=$!
           if timeout 20m bash -c 'until grep -q "Sound engine started" client.log; do sleep 5; done'; then
             sleep 1m
@@ -42,6 +46,8 @@ jobs:
             wait $PID || true
             exit 1
           fi
+          kill $TAIL_PID || true
+          wait $TAIL_PID || true
 
       - name: Upload client log
         if: always()

--- a/.github/workflows/run-server.yml
+++ b/.github/workflows/run-server.yml
@@ -23,14 +23,18 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
       - name: Build
         run: ./gradlew build --no-daemon
 
       - name: Run server for world load
-        env:
-          JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
         run: |
-          xvfb-run --auto-servernum ./gradlew runServer --no-daemon > server.log 2>&1 &
+          touch server.log
+          tail -F server.log &
+          TAIL_PID=$!
+          xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' ./gradlew runServer --no-daemon > server.log 2>&1 &
           PID=$!
           if timeout 15m bash -c 'until grep -q "Done (" server.log; do sleep 5; done'; then
             sleep 3m
@@ -42,6 +46,8 @@ jobs:
             wait $PID || true
             exit 1
           fi
+          kill $TAIL_PID || true
+          wait $TAIL_PID || true
 
       - name: Upload server log
         if: always()


### PR DESCRIPTION
## Summary
- install xvfb in run workflows
- run client and server with xvfb using a virtual screen
- show logs live when running client and server
- remove unnecessary headless option

## Testing
- `./gradlew build --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_688905ecc1588328889b98bffff1de17