### PR TITLE
Fix campfire smoke ignoring roofs

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/CampfireBlockMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/CampfireBlockMixin.java
@@ -28,6 +28,10 @@ public class CampfireBlockMixin {
     private static void modifyMakeParticles(Level level, BlockPos pos, boolean isSignalFire, boolean spawnExtraSmoke, CallbackInfo ci) {
         if (!level.isClientSide) return;
 
+        if (!level.canSeeSky(pos.above())) {
+            return; // Let vanilla handle smoke when covered
+        }
+
         long gameTime = level.getGameTime();
         long lastTime = LAST_PARTICLE_TIME.getOrDefault(pos.immutable(), 0L);
 


### PR DESCRIPTION
## Summary
- ensure custom campfire smoke only spawns when sky is unobstructed

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_688bde0b44dc8328b9e73b45f1638199