### PR TITLE
Fix schematic format handling

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
@@ -55,7 +55,8 @@ public class WorldEditStructurePlacer {
                 return null;
             }
 
-            ClipboardFormat format = ClipboardFormats.findByAlias("schematic");
+            // Detect the Sponge schematic format used by our bundled file
+            ClipboardFormat format = ClipboardFormats.findByAlias("schem");
             if (format == null) {
                 throw new IllegalArgumentException("Unsupported schematic format!");
             }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/SecretOrderVillage/SecretOrderVillagePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/SecretOrderVillage/SecretOrderVillagePlacer.java
@@ -26,7 +26,8 @@ import java.util.Random;
  * Places the secret order village structure in the world.
  */
 public class SecretOrderVillagePlacer {
-    private static final String NAMESPACE = "wildernessodyssey";
+    // Use the mod id so resources resolve correctly when packaged
+    private static final String NAMESPACE = "wildernessodysseyapi";
     // Path to the schematic bundled with the mod resources
     private static final String PATH = "schematics/village.schem";
 
@@ -61,7 +62,7 @@ public class SecretOrderVillagePlacer {
                 return false;
             }
 
-            ClipboardFormat format = ClipboardFormats.findByAlias("schematic");
+            ClipboardFormat format = ClipboardFormats.findByAlias("schem");
             if (format == null) {
                 System.err.println("Unsupported schematic format!");
                 return false;


### PR DESCRIPTION
## Summary
- detect Sponge schematic format when loading worldedit schematics
- correct SecretOrderVillage resource namespace

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688c24555bc883289404347c89898c52