### PR TITLE
Fix missing braces in structure placers

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
@@ -73,11 +73,12 @@ public class WorldEditStructurePlacer {
             if (clipboard == null) {
                 System.out.println("Schematic file not found: " + id);
                 return null;
+            }
+
             // Detect the Sponge schematic format used by our bundled file
             ClipboardFormat format = ClipboardFormats.findByAlias("schem");
             if (format == null) {
                 throw new IllegalArgumentException("Unsupported schematic format!");
-
             }
 
             final BlockPos surfacePos = world.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, position);

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/SecretOrderVillage/SecretOrderVillagePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/SecretOrderVillage/SecretOrderVillagePlacer.java
@@ -29,12 +29,9 @@ import java.util.Random;
  */
 public class SecretOrderVillagePlacer {
 
-    private static final String NAMESPACE = "wildernessodysseyapi";
-
     // Use the mod id so resources resolve correctly when packaged
     private static final String NAMESPACE = "wildernessodysseyapi";
     // Path to the schematic bundled with the mod resources
-
     private static final String PATH = "schematics/village.schem";
 
     /**
@@ -82,12 +79,12 @@ public class SecretOrderVillagePlacer {
                 try (ClipboardReader reader = format.getReader(schemStream)) {
                     clipboard = reader.read();
                 }
+            }
 
             ClipboardFormat format = ClipboardFormats.findByAlias("schem");
             if (format == null) {
                 System.err.println("Unsupported schematic format!");
                 return false;
-
             }
 
             BlockPos basePos = world.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, position);


### PR DESCRIPTION
## Summary
- repair `WorldEditStructurePlacer` logic with proper braces and format detection
- clean up `SecretOrderVillagePlacer` and close `if` block when loading schematics

## Testing
- `./gradlew compileJava`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_688eae9550d48328a180028bf3dc0069