### PR TITLE
Avoid early config access in donation reminders

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/donations/DonationReminder.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/donations/DonationReminder.java
@@ -28,7 +28,7 @@ public class DonationReminder {
     @SubscribeEvent
     public static void onJoin(ClientPlayerNetworkEvent.LoggingIn event) {
         DonationReminderConfig.validateVersion();
-        if (DonationReminderConfig.disableReminder.get()) return;
+        if (!DonationReminderConfig.CONFIG_SPEC.isLoaded() || DonationReminderConfig.disableReminder.get()) return;
 
         tickCountdown = DELAY_TICKS;
         pendingReminder = true;

--- a/src/main/java/com/thunder/wildernessodysseyapi/donations/config/DonationReminderConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/donations/config/DonationReminderConfig.java
@@ -30,6 +30,8 @@ public class DonationReminderConfig {
      * Resets opt-out if the stored version differs from the current modpack version.
      */
     public static void validateVersion() {
+        if (!CONFIG_SPEC.isLoaded()) return;
+
         String currentVersion = WorldVersionChecker.MOD_DEFAULT_WORLD_VERSION;
         if (!optOutWorldVersion.get().equals(currentVersion)) {
             disableReminder.set(false);


### PR DESCRIPTION
## Summary
- avoid accessing donation reminder config before it is loaded
- skip reminder if config not yet available

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688eb676f15883289799a8d2e10a8846