### PR TITLE
Fix cryo tube resource references

### DIFF
--- a/src/main/resources/assets/wildernessodysseyapi/item/cryo_tube_block.json
+++ b/src/main/resources/assets/wildernessodysseyapi/item/cryo_tube_block.json
@@ -1,4 +1,4 @@
 {
-  "parent": "wildernessodysseyapi:item/cryo_tube_block"
+  "parent": "wildernessodysseyapi:block/cryo_tube_block"
 }
 

--- a/src/main/resources/assets/wildernessodysseyapi/models/block/cryo_tube_block.json
+++ b/src/main/resources/assets/wildernessodysseyapi/models/block/cryo_tube_block.json
@@ -1,6 +1,6 @@
 {
   "loader": "neoforge:obj",
-  "model": "wildernessodysseyapi:models/block/cryo_tube.obj",
+  "model": "wildernessodysseyapi:models/block/cryotube.obj",
   "flip-v": true,
   "textures": {
     "diffuse": "wildernessodysseyapi:block/player_cabine",


### PR DESCRIPTION
## Summary
- point cryo tube block model to correct obj file
- use block model for cryo tube item

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688eccc7fc5c8328bf6dade1636a7826