### PR TITLE
Fix cryotube texture paths

### DIFF
--- a/src/main/resources/assets/wildernessodysseyapi/models/block/cryo_tube_block.json
+++ b/src/main/resources/assets/wildernessodysseyapi/models/block/cryo_tube_block.json
@@ -7,11 +7,11 @@
     "emissive": "wildernessodysseyapi:block/emissive"
   },
   "materials": {
-    "GlowMaterial": {
+    "m_3514b7c8-1e71-f1a7-304a-94c510b4f38c": {
       "texture": "#diffuse",
       "emissive": "#emissive"
     },
-    "BaseMaterial": {
+    "m_3b852ac4-fdad-7ffd-2dbb-8057c6633b08": {
       "texture": "#diffuse"
     }
   }

--- a/src/main/resources/assets/wildernessodysseyapi/models/block/cryotube.mtl
+++ b/src/main/resources/assets/wildernessodysseyapi/models/block/cryotube.mtl
@@ -1,6 +1,5 @@
 # Made in Blockbench 4.12.5
 newmtl m_3b852ac4-fdad-7ffd-2dbb-8057c6633b08
-map_Kd player_cabine.png
+map_Kd ../textures/block/player_cabine.png
 newmtl m_3514b7c8-1e71-f1a7-304a-94c510b4f38c
-map_Kd emissive.png
-newmtl none
+map_Kd ../textures/block/emissive.png


### PR DESCRIPTION
## Summary
- fix cryotube texture file paths
- align OBJ material references with texture definitions

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688eea12aed483288bd8b7cb9a90e05d