### PR TITLE
Fix cryo tube texture and bounding box

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlock.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlock.java
@@ -6,6 +6,7 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.Block;
@@ -13,6 +14,9 @@ import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.DeferredRegister;
@@ -39,6 +43,8 @@ public class CryoTubeBlock {
                     .strength(-1.0F, 3600000.0F)
                     .noLootTable()
                     .lightLevel(s -> 7)
+                    .noOcclusion()
+                    .noCollission()
                     .sound(SoundType.METAL)));
 
     private static <T extends Block> DeferredBlock<T> registerBlock(Supplier<T> block) {
@@ -62,8 +68,31 @@ public class CryoTubeBlock {
      * Simple implementation that allows players to sleep inside the tube.
      */
     public static class BlockImpl extends Block {
+        // Narrow voxel shape matching the tube's slender footprint.
+        private static final VoxelShape SHAPE = Block.box(2.0D, 0.0D, 2.0D, 14.0D, 16.0D, 14.0D);
+
         public BlockImpl(Properties properties) {
             super(properties);
+        }
+
+        @Override
+        public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+            return SHAPE;
+        }
+
+        @Override
+        public VoxelShape getVisualShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+            return SHAPE;
+        }
+
+        @Override
+        public VoxelShape getInteractionShape(BlockState state, BlockGetter level, BlockPos pos) {
+            return SHAPE;
+        }
+
+        @Override
+        public VoxelShape getCollisionShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+            return Shapes.empty();
         }
 
         // NeoForge 21 updated the Block interaction API. The previous

--- a/src/main/resources/assets/wildernessodysseyapi/models/block/cryotube.mtl
+++ b/src/main/resources/assets/wildernessodysseyapi/models/block/cryotube.mtl
@@ -1,5 +1,5 @@
 # Made in Blockbench 4.12.5
 newmtl m_3b852ac4-fdad-7ffd-2dbb-8057c6633b08
-map_Kd ../textures/block/player_cabine.png
+map_Kd wildernessodysseyapi:block/player_cabine
 newmtl m_3514b7c8-1e71-f1a7-304a-94c510b4f38c
-map_Kd ../textures/block/emissive.png
+map_Kd wildernessodysseyapi:block/emissive


### PR DESCRIPTION
## Summary
- narrow cryo tube voxel shape and apply it to visual and interaction shapes
- point cryo tube OBJ materials directly at the model's textures

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688f8612f6008328b4385d3c35684ba8