### PR TITLE
Add dedicated terrain replacer block

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -10,6 +10,7 @@ import com.thunder.wildernessodysseyapi.MemUtils.MemoryUtils;
 import com.thunder.wildernessodysseyapi.ModListTracker.commands.ModListDiffCommand;
 import com.thunder.wildernessodysseyapi.ModListTracker.commands.ModListVersionCommand;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
+import com.thunder.wildernessodysseyapi.WorldGen.blocks.TerrainReplacerBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.configurable.StructureConfig;
 import com.thunder.wildernessodysseyapi.command.StructureInfoCommand;
 import com.thunder.wildernessodysseyapi.donations.command.DonateCommand;
@@ -86,6 +87,7 @@ public class WildernessOdysseyAPIMainModClass {
         NeoForge.EVENT_BUS.register(InfiniteSourceHandler.class);
 
         CryoTubeBlock.register(modEventBus);
+        TerrainReplacerBlock.register(modEventBus);
         ModItems.register(modEventBus);
 
         container.registerConfig(ModConfig.Type.COMMON, StructureConfig.CONFIG_SPEC);

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/TerrainBlockReplacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/TerrainBlockReplacer.java
@@ -27,8 +27,11 @@ public class TerrainBlockReplacer {
     public static void replaceBlockWithTerrain(EditSession editSession, ServerLevel world,
                                                BlockVector3 blockVector, BlockPos terrainPos)
             throws MaxChangedBlocksException {
-        // Get terrain block from Minecraft world
-        net.minecraft.world.level.block.state.BlockState terrainBlock = world.getBlockState(terrainPos.below());
+        // Sample the block at the terrain position. If it's air, fall back to the block below
+        net.minecraft.world.level.block.state.BlockState terrainBlock = world.getBlockState(terrainPos);
+        if (terrainBlock.isAir()) {
+            terrainBlock = world.getBlockState(terrainPos.below());
+        }
 
         // Convert Minecraft BlockState to WorldEdit BlockState
         BlockType weBlockState = convertMinecraftToWorldEdit(terrainBlock);

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
@@ -10,6 +10,7 @@ import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.session.ClipboardHolder;
 import com.sk89q.worldedit.world.World;
+import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.TerrainBlockReplacer;
 import com.thunder.wildernessodysseyapi.WorldGen.schematic.SchematicManager;
@@ -94,8 +95,15 @@ public class WorldEditStructurePlacer {
                 ClipboardHolder holder = new ClipboardHolder(clipboard);
 
                 // Iterate through the clipboard's region and replace placeholder blocks
+                BlockType terrainReplacerType = null;
+                try {
+                    terrainReplacerType = BlockTypes.get("wildernessodysseyapi:terrain_replacer");
+                } catch (Exception ignored) {
+                }
+
                 for (BlockVector3 vec : clipboard.getRegion()) {
-                    if (clipboard.getFullBlock(vec).getBlockType().equals(BlockTypes.WHITE_WOOL)) {
+                    if (terrainReplacerType != null &&
+                            clipboard.getFullBlock(vec).getBlockType().equals(terrainReplacerType)) {
                         try {
                             TerrainBlockReplacer.replaceBlockWithTerrainRelative(editSession, world, vec, surfacePos);
                         } catch (MaxChangedBlocksException e) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/TerrainReplacerBlock.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/TerrainReplacerBlock.java
@@ -1,0 +1,49 @@
+package com.thunder.wildernessodysseyapi.WorldGen.blocks;
+
+import com.thunder.wildernessodysseyapi.item.ModItems;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredBlock;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.function.Supplier;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
+
+/**
+ * Simple block used as a placeholder in structures to be replaced with terrain.
+ *
+ * <p>The block behaves like white wool but has its own identity so regular wool
+ * blocks in schematics are unaffected.</p>
+ */
+public class TerrainReplacerBlock {
+    /** Registry for blocks. */
+    public static final DeferredRegister.Blocks BLOCKS =
+            DeferredRegister.createBlocks(MOD_ID);
+
+    /** Terrain replacer placeholder block. */
+    public static final DeferredBlock<Block> TERRAIN_REPLACER = registerBlock(
+            () -> new Block(BlockBehaviour.Properties.ofFullCopy(Blocks.WHITE_WOOL)
+                    .sound(SoundType.WOOL)));
+
+    private static <T extends Block> DeferredBlock<T> registerBlock(Supplier<T> block) {
+        DeferredBlock<T> toReturn = BLOCKS.register("terrain_replacer", block);
+        registerBlockItem(toReturn);
+        return toReturn;
+    }
+
+    private static <T extends Block> void registerBlockItem(DeferredBlock<T> block) {
+        ModItems.ITEMS.register("terrain_replacer", () -> new BlockItem(block.get(), new Item.Properties()));
+    }
+
+    /** Register the block with the given event bus. */
+    public static void register(IEventBus eventBus) {
+        BLOCKS.register(eventBus);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Introduce a custom `terrain_replacer` block mirroring wool behavior for schematic placeholders
- Use the new block in WorldEdit structure placement and sample terrain more accurately
- Register the block during mod initialization

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6890e6e0c794832886f9a1eb8de3dd1c