### PR TITLE
Add language entries for blocks and log messages

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -53,6 +53,8 @@ import java.util.Map;
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.VERSION;
 
+import net.minecraft.network.chat.Component;
+
 /**
  * The type Wilderness odyssey api main mod class.
  */
@@ -76,7 +78,7 @@ public class WildernessOdysseyAPIMainModClass {
      * @param container   the container
      */
     public WildernessOdysseyAPIMainModClass(IEventBus modEventBus, ModContainer container) {
-        LOGGER.info("WildernessOdysseyAPI initialized. I will also start to track mod conflicts");
+        LOGGER.info(Component.translatable("log.wildernessodysseyapi.init").getString());
         // Register mod setup and creative tabs
         modEventBus.addListener(this::commonSetup);
         modEventBus.addListener(this::addCreative);
@@ -99,9 +101,9 @@ public class WildernessOdysseyAPIMainModClass {
 
 
     private void commonSetup(final FMLCommonSetupEvent event) {
-        event.enqueueWork(() -> System.out.println("Wilderness Odyssey setup complete!"));
-        LOGGER.warn("Mod Pack Version: {}", VERSION); // Logs as a warning
-        LOGGER.warn("This message is for development purposes only."); // Logs as info
+        event.enqueueWork(() -> LOGGER.info(Component.translatable("log.wildernessodysseyapi.setup_complete").getString()));
+        LOGGER.warn(Component.translatable("log.wildernessodysseyapi.mod_pack_version", VERSION).getString());
+        LOGGER.warn(Component.translatable("log.wildernessodysseyapi.dev_only").getString());
         UncaughtExceptionLogger.init();
         dynamicModCount = ModList.get().getMods().size();
     }
@@ -197,7 +199,7 @@ public class WildernessOdysseyAPIMainModClass {
                 // Use the dynamic mod count
                 int recommendedMB = MemoryUtils.calculateRecommendedRAM(usedMB, dynamicModCount);
 
-            LOGGER.info("[ResourceManager] Memory usage: {}MB / {}MB. Recommended ~{}MB for {} loaded mods.", usedMB, totalMB, recommendedMB, dynamicModCount);
+            LOGGER.info(Component.translatable("log.wildernessodysseyapi.memory_usage", usedMB, totalMB, recommendedMB, dynamicModCount).getString());
             }
         }
     @SubscribeEvent

--- a/src/main/java/com/thunder/wildernessodysseyapi/ErrorLog/UncaughtExceptionLogger.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ErrorLog/UncaughtExceptionLogger.java
@@ -3,6 +3,8 @@ package com.thunder.wildernessodysseyapi.ErrorLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.minecraft.network.chat.Component;
+
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -27,7 +29,7 @@ public class UncaughtExceptionLogger {
      */
     public static void init() {
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
-            String msg = String.format("Uncaught exception in thread '%s': %s", thread.getName(), throwable);
+            String msg = Component.translatable("log.wildernessodysseyapi.uncaught_exception", thread.getName(), throwable).getString();
 
             // 1) Log to the standard Neoforge logs
             LOGGER.error(msg, throwable);
@@ -51,7 +53,7 @@ public class UncaughtExceptionLogger {
             }
         } catch (IOException e) {
             // If writing fails, at least log that in the main logs
-            LOGGER.error("Failed to write to {}", LOG_FILE_PATH, e);
+            LOGGER.error(Component.translatable("log.wildernessodysseyapi.failed_write", LOG_FILE_PATH).getString(), e);
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/Util/LoggerUtil.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/Util/LoggerUtil.java
@@ -8,6 +8,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
+
+import net.minecraft.network.chat.Component;
 /**
  * The type Logger util.
  */
@@ -38,9 +40,9 @@ public class LoggerUtil {
 
     private static String formatLogMessage(ConflictSeverity severity, String timestamp, String message) {
         return switch (severity) {
-            case INFO -> String.format("[INFO] >>> %s - %s", timestamp, message);
-            case WARN -> String.format("[!!! WARNING !!!] >>> %s - %s", timestamp, message);
-            case ERROR -> String.format("[!!! ERROR !!!] >>> %s - %s", timestamp, message);
+            case INFO -> Component.translatable("log.wildernessodysseyapi.conflict_info", timestamp, message).getString();
+            case WARN -> Component.translatable("log.wildernessodysseyapi.conflict_warn", timestamp, message).getString();
+            case ERROR -> Component.translatable("log.wildernessodysseyapi.conflict_error", timestamp, message).getString();
         };
     }
 
@@ -50,7 +52,7 @@ public class LoggerUtil {
             // Ensure parent directory exists
             File parentDir = logFile.getParentFile();
             if (!parentDir.exists() && !parentDir.mkdirs()) {
-                LOGGER.error("Failed to create log directory: {}", parentDir.getAbsolutePath());
+                LOGGER.error(Component.translatable("log.wildernessodysseyapi.failed_create_log_dir", parentDir.getAbsolutePath()).getString());
                 return;
             }
 
@@ -60,7 +62,7 @@ public class LoggerUtil {
                 writer.newLine();
             }
         } catch (IOException e) {
-            LOGGER.error("Failed to write to conflict log file: {}", e.getMessage());
+            LOGGER.error(Component.translatable("log.wildernessodysseyapi.failed_write_conflict_log", e.getMessage()).getString());
         }
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/Util/Utils.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/Util/Utils.java
@@ -1,6 +1,7 @@
 package com.thunder.wildernessodysseyapi.ModConflictChecker.Util;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.network.chat.Component;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
 
@@ -18,7 +19,7 @@ public class Utils {
     public static boolean isValidResourceLocation(String name) {
         ResourceLocation key = ResourceLocation.tryParse(name);
         if (key == null) {
-            LOGGER.error("Invalid ResourceLocation: '{}'", name);
+            LOGGER.error(Component.translatable("log.wildernessodysseyapi.invalid_resource_location", name).getString());
             return false;
         }
         return true;

--- a/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
+++ b/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
@@ -1,7 +1,21 @@
 {
-  "itemGroup.examplemod": "Example Mod Tab",
-  "block.examplemod.example_block": "Example Block",
-  "item.examplemod.example_item": "Example Item",
-  "message.wildernessodysseyapi.wake_up": "Waking from cryostasis..."
- }
+  "block.wildernessodysseyapi.cryo_tube_block": "Cryo Tube",
+  "item.wildernessodysseyapi.cryo_tube_block": "Cryo Tube",
+  "block.wildernessodysseyapi.terrain_replacer": "Terrain Replacer",
+  "item.wildernessodysseyapi.terrain_replacer": "Terrain Replacer",
+  "message.wildernessodysseyapi.wake_up": "Waking from cryostasis...",
+  "log.wildernessodysseyapi.init": "WildernessOdysseyAPI initialized. I will also start to track mod conflicts",
+  "log.wildernessodysseyapi.setup_complete": "Wilderness Odyssey setup complete!",
+  "log.wildernessodysseyapi.mod_pack_version": "Mod Pack Version: %s",
+  "log.wildernessodysseyapi.dev_only": "This message is for development purposes only.",
+  "log.wildernessodysseyapi.memory_usage": "[ResourceManager] Memory usage: %sMB / %sMB. Recommended ~%sMB for %s loaded mods.",
+  "log.wildernessodysseyapi.invalid_resource_location": "Invalid ResourceLocation: '%s'",
+  "log.wildernessodysseyapi.conflict_info": "[INFO] >>> %s - %s",
+  "log.wildernessodysseyapi.conflict_warn": "[!!! WARNING !!!] >>> %s - %s",
+  "log.wildernessodysseyapi.conflict_error": "[!!! ERROR !!!] >>> %s - %s",
+  "log.wildernessodysseyapi.failed_create_log_dir": "Failed to create log directory: %s",
+  "log.wildernessodysseyapi.failed_write_conflict_log": "Failed to write to conflict log file: %s",
+  "log.wildernessodysseyapi.failed_write": "Failed to write to %s",
+  "log.wildernessodysseyapi.uncaught_exception": "Uncaught exception in thread '%s': %s"
+}
 


### PR DESCRIPTION
## Summary
- Localize Cryo Tube and Terrain Replacer names
- Replace hard-coded logger strings with translatable messages

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68913dd53c3c83289f2d6ef898382e10