### PR TITLE
Fix schem loading with WorldEdit

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
@@ -61,7 +61,7 @@ public class WorldEditStructurePlacer {
                         "/assets/" + id.getNamespace() + "/schematics/" + id.getPath() + ".schem"
                 );
                 if (schemStream != null) {
-                    ClipboardFormat format = ClipboardFormats.findByAlias("schematic");
+                    ClipboardFormat format = ClipboardFormats.findByAlias("schem");
                     if (format != null) {
                         try (ClipboardReader reader = format.getReader(schemStream)) {
                             clipboard = reader.read();
@@ -74,12 +74,6 @@ public class WorldEditStructurePlacer {
             if (clipboard == null) {
                 System.out.println("Schematic file not found: " + id);
                 return null;
-            }
-
-            // Detect the Sponge schematic format used by our bundled file
-            ClipboardFormat format = ClipboardFormats.findByAlias("schem");
-            if (format == null) {
-                throw new IllegalArgumentException("Unsupported schematic format!");
             }
 
             final BlockPos surfacePos = world.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, position);

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/schematic/SchematicManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/schematic/SchematicManager.java
@@ -33,7 +33,7 @@ public class SchematicManager extends SimplePreparableReloadListener<Map<Resourc
             String path = file.getPath().substring("structures/".length(), file.getPath().length() - ".schem".length());
             ResourceLocation id = ResourceLocation.tryBuild(file.getNamespace(), path);
             try (InputStream in = entry.getValue().open()) {
-                ClipboardFormat fmt = ClipboardFormats.findByAlias("schematic");
+                ClipboardFormat fmt = ClipboardFormats.findByAlias("schem");
                 if (fmt != null) {
                     try (ClipboardReader reader = fmt.getReader(in)) {
                         loaded.put(id, reader.read());


### PR DESCRIPTION
## Summary
- load bundled schematics using WorldEdit's `schem` format instead of legacy `schematic`
- update schematic manager to use same format for datapack structures

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68915e34ceb88328b44dd60576ec8340