### PR TITLE
fix: guard WorldEdit structure placement before init

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -47,6 +47,9 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.world.block.BlockTypes;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -99,7 +102,15 @@ public class WildernessOdysseyAPIMainModClass {
 
 
     private void commonSetup(final FMLCommonSetupEvent event) {
-        event.enqueueWork(() -> System.out.println("Wilderness Odyssey setup complete!"));
+        event.enqueueWork(() -> {
+            System.out.println("Wilderness Odyssey setup complete!");
+            if (ModList.get().isLoaded("worldedit")) {
+                WorldEdit.getInstance();
+                if (BlockTypes.AIR == null) {
+                    BlockTypes.get("minecraft:air");
+                }
+            }
+        });
         LOGGER.warn("Mod Pack Version: {}", VERSION); // Logs as a warning
         LOGGER.warn("This message is for development purposes only."); // Logs as info
         UncaughtExceptionLogger.init();

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
@@ -56,6 +56,13 @@ public class WorldEditStructurePlacer {
      */
     public AABB placeStructure(ServerLevel world, BlockPos position) {
         try {
+            // WorldEdit's block registry is not initialized until the mod fully loads.
+            // If another mod calls into WorldEdit too early, static entries like
+            // BlockTypes.AIR remain null and cause NPEs when reading schematics.
+            if (BlockTypes.AIR == null) {
+                System.out.println("WorldEdit not initialized (BlockTypes.AIR is null); skipping placement of " + id);
+                return null;
+            }
             Clipboard clipboard = SchematicManager.INSTANCE.get(id);
             if (clipboard == null) {
                 InputStream schemStream = getClass().getResourceAsStream(


### PR DESCRIPTION
## Summary
- ensure WorldEdit initializes during common setup to populate BlockTypes
- skip schematic placement when WorldEdit's block registry hasn't initialized to avoid NPEs

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6891768f5e1c8328b4746ac87ef2bce7