### PR TITLE
fix: guard WorldEdit structure placement before init

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -47,6 +47,9 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.world.block.BlockTypes;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -99,7 +102,21 @@ public class WildernessOdysseyAPIMainModClass {
 
 
     private void commonSetup(final FMLCommonSetupEvent event) {
-        event.enqueueWork(() -> System.out.println("Wilderness Odyssey setup complete!"));
+        event.enqueueWork(() -> {
+            System.out.println("Wilderness Odyssey setup complete!");
+            if (ModList.get().isLoaded("worldedit")) {
+                WorldEdit.getInstance();
+                // BlockTypes are populated after WorldEdit finishes booting. Wait briefly
+                // so BlockTypes.AIR becomes available before other code uses it.
+                for (int i = 0; i < 50 && BlockTypes.AIR == null; i++) {
+                    BlockTypes.get("minecraft:air");
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException ignored) {
+                    }
+                }
+            }
+        });
         LOGGER.warn("Mod Pack Version: {}", VERSION); // Logs as a warning
         LOGGER.warn("This message is for development purposes only."); // Logs as info
         UncaughtExceptionLogger.init();

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
@@ -12,6 +12,7 @@ import com.sk89q.worldedit.session.ClipboardHolder;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
+import net.neoforged.fml.ModList;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.TerrainBlockReplacer;
 import com.thunder.wildernessodysseyapi.WorldGen.schematic.SchematicManager;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
@@ -56,6 +57,11 @@ public class WorldEditStructurePlacer {
      */
     public AABB placeStructure(ServerLevel world, BlockPos position) {
         try {
+            // Wait for WorldEdit to finish booting so BlockTypes are populated.
+            if (!waitForWorldEdit()) {
+                System.out.println("WorldEdit not initialized (BlockTypes.AIR is null); skipping placement of " + id);
+                return null;
+            }
             Clipboard clipboard = SchematicManager.INSTANCE.get(id);
             if (clipboard == null) {
                 InputStream schemStream = getClass().getResourceAsStream(
@@ -145,5 +151,28 @@ public class WorldEditStructurePlacer {
             e.printStackTrace();
             return null;
         }
+    }
+
+    /**
+     * Wait briefly for WorldEdit to populate its block registry. Returns {@code true} when
+     * {@code BlockTypes.AIR} is available or {@code false} if WorldEdit is missing or still
+     * uninitialized after waiting.
+     */
+    private static boolean waitForWorldEdit() {
+        if (BlockTypes.AIR != null) {
+            return true;
+        }
+        if (!ModList.get().isLoaded("worldedit")) {
+            return false;
+        }
+        for (int i = 0; i < 50 && BlockTypes.AIR == null; i++) {
+            WorldEdit.getInstance();
+            BlockTypes.get("minecraft:air");
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ignored) {
+            }
+        }
+        return BlockTypes.AIR != null;
     }
 }


### PR DESCRIPTION
## Summary
- ensure WorldEdit initializes during common setup to populate BlockTypes
- skip schematic placement when WorldEdit's block registry hasn't initialized to avoid NPEs
- block until WorldEdit's block registry loads before using WorldEdit APIs

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6891768f5e1c8328b4746ac87ef2bce7