### PR TITLE
feat: separate conflict logging

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -17,6 +17,7 @@ import com.thunder.wildernessodysseyapi.donations.command.DonateCommand;
 import com.thunder.wildernessodysseyapi.item.ModItems;
 import com.thunder.wildernessodysseyapi.AntiCheat.BlacklistChecker;
 import com.thunder.wildernessodysseyapi.donations.config.DonationReminderConfig;
+import com.thunder.wildernessodysseyapi.ModConflictChecker.Util.LoggerUtil;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -76,7 +77,8 @@ public class WildernessOdysseyAPIMainModClass {
      * @param container   the container
      */
     public WildernessOdysseyAPIMainModClass(IEventBus modEventBus, ModContainer container) {
-        LOGGER.info("WildernessOdysseyAPI initialized. I will also start to track mod conflicts");
+        LoggerUtil.log(LoggerUtil.ConflictSeverity.INFO,
+                "WildernessOdysseyAPI initialized. I will also start to track mod conflicts", false);
         // Register mod setup and creative tabs
         modEventBus.addListener(this::commonSetup);
         modEventBus.addListener(this::addCreative);

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/RegistryConflictHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/RegistryConflictHandler.java
@@ -27,7 +27,7 @@ public class RegistryConflictHandler {
 
     @SubscribeEvent
     public static void onServerStart(ServerStartingEvent event) {
-        LoggerUtil.log(ConflictSeverity.INFO, "Server starting. Checking for registry conflicts...");
+        LoggerUtil.log(ConflictSeverity.INFO, "Server starting. Checking for registry conflicts...", false);
 
         MinecraftServer server = event.getServer();
 
@@ -64,13 +64,13 @@ public class RegistryConflictHandler {
                 if (!originalMod.equals(modSource)) {
                     LoggerUtil.log(ConflictSeverity.ERROR, String.format(
                             "Conflict detected: %s '%s' was originally registered by '%s' but has been overwritten by '%s'.",
-                            type, key, originalMod, modSource));
+                            type, key, originalMod, modSource), false);
                 }
             } else {
                 // Log successful registration
                 trackedRegistry.put(key, modSource);
                 LoggerUtil.log(ConflictSeverity.INFO, String.format(
-                        "%s '%s' registered by '%s'.", type, key, modSource));
+                        "%s '%s' registered by '%s'.", type, key, modSource), false);
             }
         });
     }
@@ -81,7 +81,7 @@ public class RegistryConflictHandler {
      * @param server The Minecraft server instance.
      */
     private static void checkRecipeConflicts(MinecraftServer server) {
-        LoggerUtil.log(ConflictSeverity.INFO, "Checking for crafting recipe conflicts...");
+        LoggerUtil.log(ConflictSeverity.INFO, "Checking for crafting recipe conflicts...", false);
 
         server.getRecipeManager().getRecipes().forEach(recipeHolder -> {
             ResourceLocation recipeKey = recipeHolder.id(); // Use 'id()' instead of 'getId()'
@@ -92,15 +92,15 @@ public class RegistryConflictHandler {
 
                 // Log conflict if detected
                 if (!originalMod.equals(modSource)) {
-                    LoggerUtil.log(ConflictSeverity.ERROR, String.format(
-                            "Conflict detected: Recipe '%s' was originally registered by '%s' but has been overwritten by '%s'.",
-                            recipeKey, originalMod, modSource));
+                        LoggerUtil.log(ConflictSeverity.ERROR, String.format(
+                                "Conflict detected: Recipe '%s' was originally registered by '%s' but has been overwritten by '%s'.",
+                                recipeKey, originalMod, modSource), false);
                 }
             } else {
                 // Log successful registration
                 recipeRegistry.put(recipeKey, modSource);
                 LoggerUtil.log(ConflictSeverity.INFO, String.format(
-                        "Recipe '%s' registered by '%s'.", recipeKey, modSource));
+                        "Recipe '%s' registered by '%s'.", recipeKey, modSource), false);
             }
         });
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/ShaderConflictChecker.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/ShaderConflictChecker.java
@@ -17,7 +17,7 @@ public class ShaderConflictChecker {
     private static final Map<String, List<String>> shaderUsageMap = new HashMap<>();
 
     public static void scanForConflicts() {
-        LoggerUtil.log(LoggerUtil.ConflictSeverity.INFO, "Scanning mods for potential shader conflicts...");
+        LoggerUtil.log(LoggerUtil.ConflictSeverity.INFO, "Scanning mods for potential shader conflicts...", false);
 
         for (var mod : ModList.get().getMods()) {
             ModFile file = (ModFile) mod.getOwningFile().getFile();
@@ -35,7 +35,7 @@ public class ShaderConflictChecker {
                     }
                 }
             } catch (IOException e) {
-                LoggerUtil.log(LoggerUtil.ConflictSeverity.WARN, "Failed to inspect mod: " + mod.getModId() + " for shader conflicts. " + e.getMessage());
+                LoggerUtil.log(LoggerUtil.ConflictSeverity.WARN, "Failed to inspect mod: " + mod.getModId() + " for shader conflicts. " + e.getMessage(), false);
             }
         }
 
@@ -44,7 +44,7 @@ public class ShaderConflictChecker {
             if (modIds.size() > 1) {
                 LoggerUtil.log(LoggerUtil.ConflictSeverity.ERROR,
                         String.format("Shader conflict detected: '%s' is used by multiple mods: %s",
-                                shaderPath, String.join(", ", modIds)));
+                                shaderPath, String.join(", ", modIds)), false);
             }
         });
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/Util/LoggerUtil.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/Util/LoggerUtil.java
@@ -15,24 +15,37 @@ public class LoggerUtil {
     private static final String LOG_FILE_PATH = "config/WildernessOdysseyAPI/conflict_log.txt";
 
     /**
-     * Log.
+     * Log to console and file by default.
      *
      * @param severity the severity
      * @param message  the message
      */
     public static void log(ConflictSeverity severity, String message) {
+        log(severity, message, true);
+    }
+
+    /**
+     * Logs a message with the given severity. Optionally writes to the console in addition to the
+     * dedicated conflict log file.
+     *
+     * @param severity     the severity of the message
+     * @param message      the message to log
+     * @param logToConsole whether the message should also be logged to the standard console logger
+     */
+    public static void log(ConflictSeverity severity, String message, boolean logToConsole) {
         // Add a timestamp to the message
         String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         String formattedMessage = formatLogMessage(severity, timestamp, message);
 
-        // Log to the console
-        switch (severity) {
-            case INFO -> LOGGER.info(formattedMessage);
-            case WARN -> LOGGER.warn(formattedMessage);
-            case ERROR -> LOGGER.error(formattedMessage);
+        if (logToConsole) {
+            switch (severity) {
+                case INFO -> LOGGER.info(formattedMessage);
+                case WARN -> LOGGER.warn(formattedMessage);
+                case ERROR -> LOGGER.error(formattedMessage);
+            }
         }
 
-        // Log to the file
+        // Always log to the file
         logToFile(formattedMessage);
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/Util/Utils.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModConflictChecker/Util/Utils.java
@@ -2,8 +2,6 @@ package com.thunder.wildernessodysseyapi.ModConflictChecker.Util;
 
 import net.minecraft.resources.ResourceLocation;
 
-import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
-
 /**
  * The type Utils.
  */
@@ -18,7 +16,8 @@ public class Utils {
     public static boolean isValidResourceLocation(String name) {
         ResourceLocation key = ResourceLocation.tryParse(name);
         if (key == null) {
-            LOGGER.error("Invalid ResourceLocation: '{}'", name);
+            LoggerUtil.log(LoggerUtil.ConflictSeverity.ERROR,
+                    String.format("Invalid ResourceLocation: '%s'", name), false);
             return false;
         }
         return true;


### PR DESCRIPTION
## Summary
- add option in `LoggerUtil` to log only to dedicated conflict log
- update conflict checkers and utilities to write solely to conflict log
- ensure mod init uses conflict log instead of latest.log

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68925d7edc7883289725a9aa26d27fb8