### PR TITLE
fix: defer worldedit block type access

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -48,8 +48,6 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 
-import com.sk89q.worldedit.WorldEdit;
-import com.sk89q.worldedit.world.block.BlockTypes;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -106,17 +104,13 @@ public class WildernessOdysseyAPIMainModClass {
     private void commonSetup(final FMLCommonSetupEvent event) {
         event.enqueueWork(() -> {
             System.out.println("Wilderness Odyssey setup complete!");
+            // WorldEdit performs internal initialization asynchronously. Referencing
+            // BlockTypes here can trigger its static initialiser before WorldEdit is
+            // ready, causing a NoClassDefFoundError and preventing WorldEdit from
+            // loading later on. Simply log a message and allow WorldEdit to finish
+            // bootstrapping naturally.
             if (ModList.get().isLoaded("worldedit")) {
-                try {
-                    // BlockTypes are populated after WorldEdit finishes booting. Wait briefly
-                    // so BlockTypes.AIR becomes available before other code uses it.
-                    for (int i = 0; i < 50 && BlockTypes.AIR == null; i++) {
-                        BlockTypes.get("minecraft:air");
-                        Thread.sleep(100);
-                    }
-                } catch (Exception | ExceptionInInitializerError e) {
-                    LOGGER.warn("WorldEdit not initialized yet during setup: {}", e.toString());
-                }
+                LOGGER.debug("WorldEdit detected; deferring BlockTypes usage until after startup");
             }
         });
         LOGGER.warn("Mod Pack Version: {}", VERSION); // Logs as a warning


### PR DESCRIPTION
## Summary
- avoid triggering WorldEdit's BlockTypes during common setup
- log detection of WorldEdit and defer its use until after startup

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6892768a3f28832881d5e720d3e1deab