### PR TITLE
Run IntelliJ inspections in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,13 @@
+---
 name: CodeQL Security Analysis
 
-on:
+'on':
   push:
-    branches: [ "main", "1.21", "release/**" ]
+    branches: ["main", "1.21", "release/**"]
   pull_request:
-    branches: [ "**" ]
+    branches: ["**"]
   schedule:
-    - cron: '0 3 * * 1' # Every Monday at 3 AM UTC
+    - cron: '0 3 * * 1'  # Every Monday at 3 AM UTC
   workflow_dispatch:
     inputs:
       package_path:
@@ -29,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ java ]
+        language: [java]
 
     steps:
       - name: Checkout Repository
@@ -61,7 +62,14 @@ jobs:
 
       - name: Build project (no tests)
         run: ./gradlew clean assemble --no-daemon --stacktrace
-
+      - name: Inspect Code with Qodana
+        uses: JetBrains/qodana-action@v2023.3
+        with:
+          linter: jetbrains/qodana-jvm-community
+          use-caches: false
+      - name: Upload Qodana results to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
-

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,3 @@
+---
+version: "1.0"
+linter: jetbrains/qodana-jvm-community


### PR DESCRIPTION
## Summary
- add JetBrains Qodana inspection to CodeQL analysis
- provide Qodana config for JVM projects
- upload Qodana SARIF so IntelliJ inspection results appear as code scanning alerts

## Testing
- `./gradlew clean assemble --no-daemon --stacktrace`
- `./gradlew test --no-daemon --stacktrace`
- `yamllint .github/workflows/codeql.yml qodana.yaml && echo "yamllint: OK"`


------
https://chatgpt.com/codex/tasks/task_e_68927d97f6188328bc71b6ba692b52aa