### PR TITLE
Add door lock timer command and events

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -14,6 +14,8 @@ import com.thunder.wildernessodysseyapi.WorldGen.blocks.TerrainReplacerBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.configurable.StructureConfig;
 import com.thunder.wildernessodysseyapi.command.StructureInfoCommand;
 import com.thunder.wildernessodysseyapi.donations.command.DonateCommand;
+import com.thunder.wildernessodysseyapi.doorlock.DoorLockEvents;
+import com.thunder.wildernessodysseyapi.command.DoorLockCommand;
 import com.thunder.wildernessodysseyapi.item.ModItems;
 import com.thunder.wildernessodysseyapi.AntiCheat.BlacklistChecker;
 import com.thunder.wildernessodysseyapi.donations.config.DonationReminderConfig;
@@ -87,6 +89,7 @@ public class WildernessOdysseyAPIMainModClass {
         NeoForge.EVENT_BUS.register(this);
         NeoForge.EVENT_BUS.register(BlacklistChecker.class);
         NeoForge.EVENT_BUS.register(InfiniteSourceHandler.class);
+        NeoForge.EVENT_BUS.register(DoorLockEvents.class);
 
         CryoTubeBlock.register(modEventBus);
         TerrainReplacerBlock.register(modEventBus);
@@ -148,6 +151,7 @@ public class WildernessOdysseyAPIMainModClass {
         StructureInfoCommand.register(event.getDispatcher());
         FaqCommand.register(event.getDispatcher());
         DonateCommand.register(event.getDispatcher());
+        DoorLockCommand.register(event.getDispatcher());
     }
 
     /**

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/DoorLockCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/DoorLockCommand.java
@@ -1,0 +1,41 @@
+package com.thunder.wildernessodysseyapi.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.thunder.ticktoklib.TickTokHelper;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.component.CustomData;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Gives a timer stick that can lock doors.
+ */
+public class DoorLockCommand {
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("doorlock")
+                .then(Commands.argument("seconds", IntegerArgumentType.integer(1))
+                        .executes(ctx -> giveStick(ctx, IntegerArgumentType.getInteger(ctx, "seconds")))));
+    }
+
+    private static int giveStick(CommandContext<CommandSourceStack> ctx, int seconds) throws CommandSyntaxException {
+        Player player = ctx.getSource().getPlayerOrException();
+        int duration = TickTokHelper.duration(0, 0, seconds, 0);
+        ItemStack stick = new ItemStack(Items.STICK);
+        CustomData custom = stick.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY);
+        CompoundTag tag = custom.copyTag();
+        tag.putInt("door_lock_duration", duration);
+        stick.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
+        stick.set(DataComponents.CUSTOM_NAME, Component.literal("Door Timer (" + seconds + "s)"));
+        player.addItem(stick);
+        return 1;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/doorlock/DoorLockEvents.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/doorlock/DoorLockEvents.java
@@ -1,0 +1,61 @@
+package com.thunder.wildernessodysseyapi.doorlock;
+
+import com.thunder.ticktoklib.TickTokHelper;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.CustomData;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.DoorBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.network.chat.Component;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+
+/**
+ * Handles applying and enforcing door locks.
+ */
+public class DoorLockEvents {
+
+    @SubscribeEvent
+    public static void onRightClick(PlayerInteractEvent.RightClickBlock event) {
+        Level level = event.getLevel();
+        BlockPos pos = event.getPos();
+        BlockState state = level.getBlockState(pos);
+        if (!(state.getBlock() instanceof DoorBlock)) return;
+
+        ItemStack stack = event.getItemStack();
+        if (!level.isClientSide && event.getEntity() instanceof ServerPlayer player) {
+            ServerLevel serverLevel = (ServerLevel) level;
+            DoorLockSavedData data = DoorLockSavedData.get(serverLevel);
+            long now = level.getGameTime();
+
+            CustomData custom = stack.get(DataComponents.CUSTOM_DATA);
+            if (stack.is(Items.STICK) && custom != null) {
+                CompoundTag tag = custom.copyTag();
+                if (tag.contains("door_lock_duration")) {
+                    int duration = tag.getInt("door_lock_duration");
+                    data.setLock(pos, duration, now);
+                    if (!player.isCreative()) {
+                        stack.shrink(1);
+                    }
+                    float seconds = TickTokHelper.toSeconds(duration);
+                    player.displayClientMessage(Component.literal("Door locked for " + seconds + "s"), true);
+                    event.setCanceled(true);
+                    return;
+                }
+            }
+
+            if (data.isLocked(pos, now)) {
+                long remaining = data.remaining(pos, now);
+                float seconds = TickTokHelper.toSeconds((int) remaining);
+                player.displayClientMessage(Component.literal("You can access this in " + seconds + "s"), true);
+                event.setCanceled(true);
+            }
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/doorlock/DoorLockSavedData.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/doorlock/DoorLockSavedData.java
@@ -1,0 +1,78 @@
+package com.thunder.wildernessodysseyapi.doorlock;
+
+import com.thunder.ticktoklib.util.TickTokCountdown;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.saveddata.SavedData;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Stores door lock timers in world save data.
+ */
+public class DoorLockSavedData extends SavedData {
+    private static final String DATA_NAME = "wildernessodyssey_door_locks";
+
+    private final Map<Long, LockInfo> locks = new HashMap<>();
+
+    public record LockInfo(long duration, long start) {}
+
+    public DoorLockSavedData() {}
+
+    public DoorLockSavedData(CompoundTag tag, HolderLookup.Provider registries) {
+        ListTag list = tag.getList("locks", Tag.TAG_COMPOUND);
+        for (int i = 0; i < list.size(); i++) {
+            CompoundTag lockTag = list.getCompound(i);
+            long pos = lockTag.getLong("pos");
+            long duration = lockTag.getLong("duration");
+            long start = lockTag.getLong("start");
+            locks.put(pos, new LockInfo(duration, start));
+        }
+    }
+
+    @Override
+    public @NotNull CompoundTag save(@NotNull CompoundTag tag, HolderLookup.@NotNull Provider registries) {
+        ListTag list = new ListTag();
+        for (Map.Entry<Long, LockInfo> e : locks.entrySet()) {
+            CompoundTag lockTag = new CompoundTag();
+            lockTag.putLong("pos", e.getKey());
+            lockTag.putLong("duration", e.getValue().duration());
+            lockTag.putLong("start", e.getValue().start());
+            list.add(lockTag);
+        }
+        tag.put("locks", list);
+        return tag;
+    }
+
+    public void setLock(BlockPos pos, long duration, long start) {
+        locks.put(pos.asLong(), new LockInfo(duration, start));
+        setDirty();
+    }
+
+    public long remaining(BlockPos pos, long now) {
+        LockInfo info = locks.get(pos.asLong());
+        if (info == null) return 0L;
+        TickTokCountdown countdown = new TickTokCountdown(info.duration(), info.start());
+        return countdown.remaining(now);
+    }
+
+    public boolean isLocked(BlockPos pos, long now) {
+        LockInfo info = locks.get(pos.asLong());
+        if (info == null) return false;
+        TickTokCountdown countdown = new TickTokCountdown(info.duration(), info.start());
+        return !countdown.isFinished(now);
+    }
+
+    public static DoorLockSavedData get(ServerLevel level) {
+        return level.getDataStorage().computeIfAbsent(
+                new SavedData.Factory<>(DoorLockSavedData::new, DoorLockSavedData::new),
+                DATA_NAME
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add `/doorlock` command to grant timer sticks
- store door lock state with TickTok-powered countdowns
- block door interaction until timer expires

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689382a98b708328acf4887ea2a9ba4f