### PR TITLE
Run CodeQL for Java and GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,13 @@
+---
 name: CodeQL Security Analysis
 
-on:
+'on':
   push:
-    branches: [ "main", "1.21", "release/**" ]
+    branches: ["main", "1.21", "release/**"]
   pull_request:
-    branches: [ "**" ]
+    branches: ["**"]
   schedule:
-    - cron: '0 3 * * 1' # Every Monday at 3 AM UTC
+    - cron: '0 3 * * 1'  # Every Monday at 3 AM UTC
   workflow_dispatch:
     inputs:
       package_path:
@@ -29,13 +30,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ java ]
+        language: [java, actions]
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Prepare CodeQL config
+        if: matrix.language == 'java'
         env:
           PACKAGE_PATH: ${{ github.event.inputs.package_path }}
         run: |
@@ -43,13 +45,21 @@ jobs:
           PACKAGE_PATH="${PACKAGE_PATH:-src/main/java/com/thunder/wildernessodysseyapi}"
           sed -i "s|PACKAGE_PATH|$PACKAGE_PATH|g" codeql-package-config.yml
 
-      - name: Initialize CodeQL
+      - name: Initialize CodeQL (Java)
+        if: matrix.language == 'java'
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           config-file: codeql-package-config.yml
 
+      - name: Initialize CodeQL (Actions)
+        if: matrix.language == 'actions'
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
       - name: Set up JDK 21
+        if: matrix.language == 'java'
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -57,11 +67,25 @@ jobs:
           cache: 'gradle'
 
       - name: Grant execute permission to gradlew
+        if: matrix.language == 'java'
         run: chmod +x ./gradlew
 
       - name: Build project (no tests)
+        if: matrix.language == 'java'
         run: ./gradlew clean assemble --no-daemon --stacktrace
-
+      - name: Inspect Code with Qodana
+        if: matrix.language == 'java'
+        uses: JetBrains/qodana-action@v2023.3
+        with:
+          linter: jetbrains/qodana-jvm-community
+          use-caches: false
+      - name: Upload Qodana results to code scanning
+        if: matrix.language == 'java'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
+      - name: Note Actions analysis requires no build
+        if: matrix.language == 'actions'
+        run: echo "Scanning GitHub Actions workflows"
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
-

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,3 @@
+---
+version: "1.0"
+linter: jetbrains/qodana-jvm-community


### PR DESCRIPTION
## Summary
- extend CodeQL matrix to scan both Java and GitHub Actions
- run Java build and Qodana only when analyzing Java
- log GitHub Actions analysis to clarify missing build output

## Testing
- `./gradlew clean assemble --no-daemon --stacktrace`
- `./gradlew test --no-daemon --stacktrace`
- `yamllint .github/workflows/codeql.yml qodana.yaml && echo "yamllint: OK"`


------
https://chatgpt.com/codex/tasks/task_e_68927d97f6188328bc71b6ba692b52aa