### PR TITLE
feat: add dev-mode and door lock removal

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/doorlock/DoorLockEvents.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/doorlock/DoorLockEvents.java
@@ -38,13 +38,23 @@ public class DoorLockEvents {
             if (stack.is(Items.STICK) && custom != null) {
                 CompoundTag tag = custom.copyTag();
                 if (tag.contains("door_lock_duration")) {
-                    int duration = tag.getInt("door_lock_duration");
-                    data.setLock(pos, duration, now);
-                    if (!player.isCreative()) {
-                        stack.shrink(1);
+                    if (player.isShiftKeyDown()) {
+                        if (data.removeLock(pos)) {
+                            player.displayClientMessage(Component.literal("Door lock removed"), true);
+                        }
+                    } else {
+                        int duration = tag.getInt("door_lock_duration");
+                        data.setLock(pos, duration, now);
+                        if (!player.isCreative()) {
+                            stack.shrink(1);
+                        }
+                        float seconds = TickTokHelper.toSeconds(duration);
+                        String msg = "Door locked for " + seconds + "s";
+                        if (DoorLockSavedData.DEV_MODE) {
+                            msg += " (pending)";
+                        }
+                        player.displayClientMessage(Component.literal(msg), true);
                     }
-                    float seconds = TickTokHelper.toSeconds(duration);
-                    player.displayClientMessage(Component.literal("Door locked for " + seconds + "s"), true);
                     event.setCanceled(true);
                     return;
                 }


### PR DESCRIPTION
## Summary
- add `WO_DOORLOCK_DEV` env flag so devs can stage locks without them starting
- support removing door locks by shift-right-clicking with the lock stick

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6893a69112ec832889874ee42e638898