### PR TITLE
Ensure doors close when locked and timer sticks glow

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/command/DoorLockCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/DoorLockCommand.java
@@ -35,6 +35,7 @@ public class DoorLockCommand {
         tag.putInt("door_lock_duration", duration);
         stick.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
         stick.set(DataComponents.CUSTOM_NAME, Component.literal("Door Timer (" + seconds + "s)"));
+        stick.set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true);
         player.addItem(stick);
         return 1;
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/doorlock/DoorLockEvents.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/doorlock/DoorLockEvents.java
@@ -44,6 +44,10 @@ public class DoorLockEvents {
                         }
                     } else {
                         int duration = tag.getInt("door_lock_duration");
+                        DoorBlock door = (DoorBlock) state.getBlock();
+                        if (state.getValue(DoorBlock.OPEN)) {
+                            door.setOpen(player, level, state, pos, false);
+                        }
                         data.setLock(pos, duration, now);
                         if (!player.isCreative()) {
                             stack.shrink(1);


### PR DESCRIPTION
## Summary
- Close doors before locking to prevent locking them open
- Give the `/doorlock` timer stick a glowing glint

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68941786a7988328a88e1ece43d7cd45