### PR TITLE
Add pack metadata for resources

### DIFF
--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "description": "Wilderness Odyssey API resources",
+    "pack_format": 34
+  }
+}


### PR DESCRIPTION
## Summary
- add `pack.mcmeta` so Minecraft loads mod textures correctly

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6894195adf348328820ac6b4df08c1be