### PR TITLE
Expand cryo tube bounding box

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlock.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlock.java
@@ -86,8 +86,8 @@ public class CryoTubeBlock {
      * Simple implementation that allows players to sleep inside the tube.
      */
     public static class BlockImpl extends Block implements EntityBlock {
-        // Narrow voxel shape matching the tube's slender footprint.
-        private static final VoxelShape SHAPE = Block.box(2.0D, 0.0D, 2.0D, 14.0D, 16.0D, 14.0D);
+        // Bounding shape covering the entire cryo tube (1x1 block footprint, 2.5 blocks tall).
+        private static final VoxelShape SHAPE = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 40.0D, 16.0D);
 
         public BlockImpl(Properties properties) {
             super(properties);


### PR DESCRIPTION
## Summary
- expand cryo tube block shape to cover entire 1x1 footprint and 2.5 block height

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6895f16696f48328983901aab31fa94b