### PR TITLE
Fix cryo tube placement and bounding box

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlock.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlock.java
@@ -10,7 +10,6 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -76,7 +75,7 @@ public class CryoTubeBlock {
     }
 
     private static <T extends Block> void registerBlockItem(DeferredBlock<T> block) {
-        ModItems.ITEMS.register("cryo_tube", () -> new BlockItem(block.get(), new Item.Properties()));
+        ModItems.ITEMS.register("cryo_tube", () -> new CryoTubeBlockItem(block.get(), new Item.Properties()));
     }
 
     /**
@@ -92,7 +91,7 @@ public class CryoTubeBlock {
      */
     public static class BlockImpl extends Block implements EntityBlock {
         // Narrow voxel shape matching the tube's slender footprint.
-        private static final VoxelShape SHAPE = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 40.0D, 16.0D);
+        private static final VoxelShape SHAPE = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 48.0D, 16.0D);
         /**
          * After this many ticks (10 Minecraft days) tubes no longer function.
          */

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlockItem.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlockItem.java
@@ -1,0 +1,27 @@
+package com.thunder.wildernessodysseyapi.WorldGen.blocks;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.core.Direction;
+
+/**
+ * Block item for the cryo tube that places the tube one block higher
+ * than the targeted position to account for the model's vertical offset.
+ */
+public class CryoTubeBlockItem extends BlockItem {
+    public CryoTubeBlockItem(Block block, Properties properties) {
+        super(block, properties);
+    }
+
+    @Override
+    public InteractionResult place(BlockPlaceContext context) {
+        BlockPos pos = context.getClickedPos().relative(context.getClickedFace()).above();
+        BlockHitResult hit = new BlockHitResult(context.getClickLocation(), Direction.UP, pos, false);
+        BlockPlaceContext offset = new BlockPlaceContext(context.getLevel(), context.getPlayer(), context.getHand(), context.getItemInHand(), hit);
+        return super.place(offset);
+    }
+}


### PR DESCRIPTION
## Summary
- expand Cryo Tube voxel shape to cover all three blocks
- offset Cryo Tube block placement one block higher to avoid spawning underground

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6896b58c95308328ad4eb0d48527adee