### PR TITLE
Add destructive sky torch beam effect

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -124,6 +124,7 @@ public class WildernessOdysseyAPIMainModClass {
     private void addCreative(BuildCreativeModeTabContentsEvent event) {
         if (event.getTabKey() == CreativeModeTabs.TOOLS_AND_UTILITIES) {
             event.accept(CryoTubeBlock.CRYO_TUBE.get());
+            event.accept(ModItems.SKY_TORCH_STAFF.get());
         }
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/ModItems.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/ModItems.java
@@ -1,7 +1,9 @@
 package com.thunder.wildernessodysseyapi.item;
 
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import net.minecraft.world.item.Item;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
 
@@ -14,7 +16,8 @@ public class ModItems {
      */
     public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
-    // No standalone items needed, as the unbreakable block's BlockItem is automatically registered.
+    public static final DeferredItem<SkyTorchStaffItem> SKY_TORCH_STAFF =
+            ITEMS.register("sky_torch_staff", () -> new SkyTorchStaffItem(new Item.Properties().stacksTo(1)));
 
     /**
      * Register.

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/SkyTorchStaffItem.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/SkyTorchStaffItem.java
@@ -1,0 +1,68 @@
+package com.thunder.wildernessodysseyapi.item;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Explosion;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LightningBolt;
+
+/**
+ * Simple staff item that calls down a beam from the sky and ignites the target.
+ */
+public class SkyTorchStaffItem extends Item {
+    public SkyTorchStaffItem(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
+        ItemStack stack = player.getItemInHand(hand);
+
+        if (!level.isClientSide) {
+            HitResult result = getPlayerPOVHitResult(level, player, ClipContext.Fluid.NONE);
+            if (result.getType() == HitResult.Type.BLOCK) {
+                BlockHitResult blockResult = (BlockHitResult) result;
+                BlockPos hitPos = blockResult.getBlockPos();
+                BlockPos topPos = new BlockPos(hitPos.getX(), level.getMaxBuildHeight(), hitPos.getZ());
+
+                // carve a vertical shaft from the sky down to the impact point
+                for (int y = topPos.getY(); y >= hitPos.getY(); y--) {
+                    BlockPos current = new BlockPos(hitPos.getX(), y, hitPos.getZ());
+                    if (!level.getBlockState(current).isAir()) {
+                        level.destroyBlock(current, false);
+                    }
+                }
+
+                // call lightning from the build height
+                LightningBolt bolt = EntityType.LIGHTNING_BOLT.create(level);
+                if (bolt != null) {
+                    bolt.moveTo(hitPos.getX() + 0.5, level.getMaxBuildHeight(), hitPos.getZ() + 0.5);
+                    level.addFreshEntity(bolt);
+                }
+
+                // explosion at the impact and ignite nearby blocks
+                level.explode(null, hitPos.getX() + 0.5, hitPos.getY(), hitPos.getZ() + 0.5, 2.0F, Level.ExplosionInteraction.TNT);
+                for (BlockPos firePos : BlockPos.betweenClosed(hitPos.offset(-1, 0, -1), hitPos.offset(1, 0, 1))) {
+                    if (level.isEmptyBlock(firePos)) {
+                        level.setBlock(firePos, Blocks.FIRE.defaultBlockState(), 11);
+                    }
+                }
+
+                level.gameEvent(player, GameEvent.ITEM_INTERACT_FINISH, hitPos);
+            }
+        }
+
+        player.getCooldowns().addCooldown(this, 100);
+        return InteractionResultHolder.sidedSuccess(stack, level.isClientSide());
+    }
+}

--- a/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
+++ b/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
@@ -4,6 +4,7 @@
   "item.examplemod.example_item": "Example Item",
   "message.wildernessodysseyapi.wake_up": "Waking from cryostasis...",
   "message.wildernessodysseyapi.cryo_tube_locked": "The cryo tube can no longer be used.",
-  "block.wildernessodysseyapi.cryo_tube": "Cryo Tube"
+  "block.wildernessodysseyapi.cryo_tube": "Cryo Tube",
+  "item.wildernessodysseyapi.sky_torch_staff": "Sky Torch Staff"
 }
 

--- a/src/main/resources/assets/wildernessodysseyapi/models/item/sky_torch_staff.json
+++ b/src/main/resources/assets/wildernessodysseyapi/models/item/sky_torch_staff.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/handheld",
+  "textures": {
+    "layer0": "minecraft:item/blaze_rod"
+  }
+}


### PR DESCRIPTION
## Summary
- enhance Sky Torch Staff so it clears a vertical shaft to the target
- call lightning from build height and ignite surrounding blocks with an explosion

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6897788a52008328b1b9e737349bebfb