### PR TITLE
Render translucent hint for cloaked entities

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Client/CloakRenderHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Client/CloakRenderHandler.java
@@ -1,0 +1,29 @@
+package com.thunder.wildernessodysseyapi.Client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.LightTexture;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.block.Blocks;
+
+/**
+ * Renders cloaked entities as a translucent pixelated box.
+ */
+public class CloakRenderHandler {
+
+    /**
+     * Render the cloak effect for a single entity.
+     */
+    public static void renderCloak(LivingEntity entity, PoseStack poseStack, MultiBufferSource buffer) {
+        poseStack.pushPose();
+        float width = entity.getBbWidth();
+        float height = entity.getBbHeight();
+
+        poseStack.translate(-width / 2.0f, 0.0f, -width / 2.0f);
+        poseStack.scale(width, height, width);
+        Minecraft.getInstance().getBlockRenderer().renderSingleBlock(Blocks.GLASS.defaultBlockState(), poseStack, buffer, LightTexture.FULL_BRIGHT, OverlayTexture.NO_OVERLAY);
+        poseStack.popPose();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/CloakItem.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/CloakItem.java
@@ -1,0 +1,38 @@
+package com.thunder.wildernessodysseyapi.item;
+
+import java.util.Set;
+
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Item used to toggle an entity's cloaked state via scoreboard tags.
+ */
+public class CloakItem extends Item {
+    public static final String CLOAK_TAG = "wildernessodysseyapi.cloaked";
+    private static final Set<EntityType<?>> ALLOWED_TYPES = Set.of(EntityType.PLAYER);
+
+    public CloakItem(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public InteractionResult interactLivingEntity(ItemStack stack, Player player, LivingEntity target, InteractionHand hand) {
+        if (!ALLOWED_TYPES.contains(target.getType())) {
+            return InteractionResult.PASS;
+        }
+        if (!player.level().isClientSide) {
+            if (target.getTags().contains(CLOAK_TAG)) {
+                target.removeTag(CLOAK_TAG);
+            } else {
+                target.addTag(CLOAK_TAG);
+            }
+        }
+        return InteractionResult.sidedSuccess(player.level().isClientSide);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/ModItems.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/ModItems.java
@@ -2,6 +2,8 @@ package com.thunder.wildernessodysseyapi.item;
 
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.DeferredItem;
+import net.minecraft.world.item.Item;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
 
@@ -13,6 +15,12 @@ public class ModItems {
      * The constant ITEMS.
      */
     public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
+
+    /**
+     * Handheld cloak item used to toggle cloaking on allowed entities.
+     */
+    public static final DeferredItem<CloakItem> CLOAK_ITEM =
+            ITEMS.register("cloak_item", () -> new CloakItem(new Item.Properties().stacksTo(1)));
 
     // No standalone items needed, as the unbreakable block's BlockItem is automatically registered.
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/CloakRenderMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/CloakRenderMixin.java
@@ -1,0 +1,26 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.thunder.wildernessodysseyapi.Client.CloakRenderHandler;
+import com.thunder.wildernessodysseyapi.item.CloakItem;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.LivingEntityRenderer;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Prevents rendering of entities marked with the cloak tag.
+ */
+@Mixin(LivingEntityRenderer.class)
+public abstract class CloakRenderMixin {
+    @Inject(method = "render(Lnet/minecraft/world/entity/LivingEntity;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", at = @At("HEAD"), cancellable = true)
+    private void wildernessodysseyapi$hideCloaked(LivingEntity entity, float entityYaw, float partialTicks, PoseStack poseStack, MultiBufferSource buffer, int packedLight, CallbackInfo ci) {
+        if (entity.getTags().contains(CloakItem.CLOAK_TAG)) {
+            CloakRenderHandler.renderCloak(entity, poseStack, buffer);
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
+++ b/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
@@ -4,6 +4,6 @@
   "item.examplemod.example_item": "Example Item",
   "message.wildernessodysseyapi.wake_up": "Waking from cryostasis...",
   "message.wildernessodysseyapi.cryo_tube_locked": "The cryo tube can no longer be used.",
-  "block.wildernessodysseyapi.cryo_tube": "Cryo Tube"
+  "block.wildernessodysseyapi.cryo_tube": "Cryo Tube",
+  "item.wildernessodysseyapi.cloak_item": "Handheld Cloak"
 }
-

--- a/src/main/resources/assets/wildernessodysseyapi/models/item/cloak_item.json
+++ b/src/main/resources/assets/wildernessodysseyapi/models/item/cloak_item.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "minecraft:item/green_dye"
+  }
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -13,9 +13,10 @@
   "injectors": {
     "defaultRequire": 1
   },
-  "client": [
-    "DebugMixin",
-    "MixinWorldCreationUiState",
-    "ParticleEngineMixin"
-  ]
-} 
+    "client": [
+        "DebugMixin",
+        "MixinWorldCreationUiState",
+        "ParticleEngineMixin",
+        "CloakRenderMixin"
+    ]
+}


### PR DESCRIPTION
## Summary
- Cancel normal rendering for cloaked entities and draw a custom effect instead
- Show cloaked targets as a scaled translucent glass box so observers can faintly see them

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6897d35b627c8328a06a774614022de0