### PR TITLE
Add memory allocation advisor and peak usage tracker

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemCheckCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemCheckCommand.java
@@ -25,15 +25,21 @@ public class MemCheckCommand {
                             LOGGER.info("/memcheck command executed");
 
                             long usedMB  = MemoryUtils.getUsedMemoryMB();
+                            long peakMB  = MemoryUtils.getPeakUsedMemoryMB();
                             long totalMB = MemoryUtils.getTotalMemoryMB();
                             int recommended = MemoryUtils.calculateRecommendedRAM(
-                                    usedMB,
+                                    peakMB,
                                     WildernessOdysseyAPIMainModClass.dynamicModCount
                             );
 
                             source.sendSuccess(
                                     () -> Component.nullToEmpty(ChatFormatting.GREEN + "Current memory usage: "
                                             + usedMB + "MB / " + totalMB + "MB"),
+                                    false
+                            );
+                            source.sendSuccess(
+                                    () -> Component.nullToEmpty(ChatFormatting.AQUA + "Peak usage observed: "
+                                            + peakMB + "MB"),
                                     false
                             );
                             source.sendSuccess(

--- a/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryTracker.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryTracker.java
@@ -1,0 +1,23 @@
+package com.thunder.wildernessodysseyapi.MemUtils;
+
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
+
+/**
+ * Records memory usage on the server thread every tick so modpack authors can
+ * gauge peak memory requirements during play.
+ */
+@EventBusSubscriber(modid = MOD_ID)
+public class MemoryTracker {
+
+    /**
+     * Invoked each server tick; updates peak memory usage statistics.
+     */
+    @SubscribeEvent
+    public static void onServerTick(ServerTickEvent.Post event) {
+        MemoryUtils.recordPeakUsage();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryTrackerClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryTrackerClient.java
@@ -1,0 +1,24 @@
+package com.thunder.wildernessodysseyapi.MemUtils;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
+
+/**
+ * Client-side hook for tracking peak memory usage while the game is running in
+ * singleplayer or with an integrated server.
+ */
+@EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT)
+public class MemoryTrackerClient {
+
+    /**
+     * Invoked each client tick; updates peak memory usage statistics.
+     */
+    @SubscribeEvent
+    public static void onClientTick(ClientTickEvent.Post event) {
+        MemoryUtils.recordPeakUsage();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryUtils.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryUtils.java
@@ -11,6 +11,31 @@ public class MemoryUtils {
     private static final int BASE_RECOMMENDED_MB = 4096; // 4GB
 
     /**
+     * Tracks the peak memory usage observed during this session in MB.
+     */
+    private static long peakUsedMB = 0;
+
+    /**
+     * Samples the current memory usage and updates the {@code peakUsedMB} if a
+     * new high watermark is observed. This method is lightweight and intended to
+     * be called frequently (e.g., every tick).
+     */
+    public static void recordPeakUsage() {
+        long used = getUsedMemoryMB();
+        if (used > peakUsedMB) {
+            peakUsedMB = used;
+            LOGGER.debug("New peak memory usage recorded: {} MB", peakUsedMB);
+        }
+    }
+
+    /**
+     * Returns the highest memory usage recorded so far in MB.
+     */
+    public static long getPeakUsedMemoryMB() {
+        return peakUsedMB;
+    }
+
+    /**
      * Returns the amount of used memory in MB.
      */
     public static long getUsedMemoryMB() {


### PR DESCRIPTION
## Summary
- track memory usage each tick on server and client
- expose peak usage through `/memcheck` for better RAM recommendations

## Testing
- `./gradlew test` *(fails: reached end of file while parsing src/main/java/com/thunder/wildernessodysseyapi/skytorch/SkyTorchStaffItem.java)*

------
https://chatgpt.com/codex/tasks/task_e_689e0da15bac8328b0da7c0e55089031