### PR TITLE
Optimize campfire effects and reduce log spam

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryUtils.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryUtils.java
@@ -36,23 +36,34 @@ public class MemoryUtils {
     }
 
     /**
-     * Returns the amount of used memory in MB.
+     * Returns the amount of used memory in MB. Logs only when the value changes
+     * to avoid spamming the console on frequent calls.
      */
+    private static long lastLoggedUsedMB = -1;
     public static long getUsedMemoryMB() {
         long free  = Runtime.getRuntime().freeMemory();
         long total = Runtime.getRuntime().totalMemory();
         long used = (total - free) / (1024 * 1024);
-        LOGGER.debug("Calculated used memory: {} MB (total={} MB, free={} MB)", used, total / (1024 * 1024), free / (1024 * 1024));
+        if (used != lastLoggedUsedMB) {
+            lastLoggedUsedMB = used;
+            LOGGER.debug("Calculated used memory: {} MB (total={} MB, free={} MB)",
+                    used, total / (1024 * 1024), free / (1024 * 1024));
+        }
         return used;
     }
 
     /**
-     * Returns the total allocated memory (heap) in MB.
+     * Returns the total allocated memory (heap) in MB. Logs only when the value
+     * changes to reduce noise.
      */
+    private static long lastLoggedTotalMB = -1;
     public static long getTotalMemoryMB() {
         long total = Runtime.getRuntime().totalMemory();
         long totalMB = total / (1024 * 1024);
-        LOGGER.debug("Total memory allocated: {} MB", totalMB);
+        if (totalMB != lastLoggedTotalMB) {
+            lastLoggedTotalMB = totalMB;
+            LOGGER.debug("Total memory allocated: {} MB", totalMB);
+        }
         return totalMB;
     }
 
@@ -63,15 +74,18 @@ public class MemoryUtils {
      * - If current usage is already higher than that naive guess,
      *   bump recommended to current usage + 512MB.
      */
+    private static int lastRecommendedMB = -1;
     public static int calculateRecommendedRAM(long currentUsedMB, int modCount) {
-        LOGGER.debug("Calculating recommended RAM with currentUsedMB={} and modCount={}", currentUsedMB, modCount);
         int extraPer10Mods = (modCount / 10) * 128;
         int recommendedMB = BASE_RECOMMENDED_MB + extraPer10Mods;
 
         if (currentUsedMB > recommendedMB) {
             recommendedMB = (int) currentUsedMB + 512;
         }
-        LOGGER.debug("Recommended RAM determined to be {} MB", recommendedMB);
+        if (recommendedMB != lastRecommendedMB) {
+            lastRecommendedMB = recommendedMB;
+            LOGGER.debug("Recommended RAM determined to be {} MB", recommendedMB);
+        }
         return recommendedMB;
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Random;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
 
 
 /**
@@ -49,7 +50,7 @@ public class WorldSpawnHandler {
                 world.setDefaultSpawnPos(spawnBlockPos.above(), 0.0F);
             } else {
                 // Log a warning or handle cases where no spawn blocks are found
-                System.err.println("No Cryo Tube Blocks found in the world!");
+                LOGGER.warn("No Cryo Tube Blocks found in the world!");
             }
         }
     }
@@ -84,7 +85,7 @@ public class WorldSpawnHandler {
             }
         } catch (ReflectiveOperationException e) {
             // If reflection fails, fall back to empty result
-            e.printStackTrace();
+            LOGGER.error("Failed to locate Cryo Tube Blocks", e);
         }
         return spawnBlocks;
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/TerrainBlockReplacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/TerrainBlockReplacer.java
@@ -11,10 +11,17 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.level.ServerLevel;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
+
 /****
  * TerrainBlockReplacer for the Wilderness Odyssey API mod.
  */
 public class TerrainBlockReplacer {
+
+    private static final Set<String> loggedBlockErrors = new HashSet<>();
 
     /**
      * Replaces a block in a schematic with the terrain block sampled from the given world position.
@@ -73,8 +80,9 @@ public class TerrainBlockReplacer {
         try {
             return BlockTypes.get(blockId);
         } catch (Exception e) {
-            System.out.println("Error converting block: " + blockId);
-            e.printStackTrace();
+            if (loggedBlockErrors.add(blockId)) {
+                LOGGER.warn("Error converting block {}", blockId, e);
+            }
             return null;
         }
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
@@ -15,7 +15,6 @@ import com.sk89q.worldedit.world.block.BlockTypes;
 import net.neoforged.fml.ModList;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.TerrainBlockReplacer;
 import com.thunder.wildernessodysseyapi.WorldGen.schematic.SchematicManager;
-import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -23,6 +22,10 @@ import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.phys.AABB;
 
 import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
 
 /**
  * The type World edit structure placer.
@@ -33,6 +36,8 @@ public class WorldEditStructurePlacer {
     // Cache WorldEdit availability to avoid repeated startup checks and log spam
     private static Boolean worldEditReady = null;
     private static boolean missingLogged = false;
+    private static final Set<ResourceLocation> missingSchematicsLogged = new HashSet<>();
+    private static final Set<ResourceLocation> missingCryoTubeLogged = new HashSet<>();
 
     /**
      * Instantiates a new World edit structure placer.
@@ -64,7 +69,7 @@ public class WorldEditStructurePlacer {
             // Wait for WorldEdit to finish booting so BlockTypes are populated.
             if (!waitForWorldEdit()) {
                 if (!missingLogged) {
-                    System.out.println("WorldEdit not initialized (BlockTypes.AIR is null); skipping placement of " + id);
+                    LOGGER.warn("WorldEdit not initialized (BlockTypes.AIR is null); skipping placement of {}", id);
                     missingLogged = true;
                 }
                 return null;
@@ -86,7 +91,9 @@ public class WorldEditStructurePlacer {
 
 
             if (clipboard == null) {
-                System.out.println("Schematic file not found: " + id);
+                if (missingSchematicsLogged.add(id)) {
+                    LOGGER.warn("Schematic file not found: {}", id);
+                }
                 return null;
             }
 
@@ -118,7 +125,9 @@ public class WorldEditStructurePlacer {
                 }
 
                 if (!hasCryoTube) {
-                    System.out.println("Skipping bunker placement: schematic missing cryo tube.");
+                    if (missingCryoTubeLogged.add(id)) {
+                        LOGGER.warn("Skipping bunker placement: schematic missing cryo tube in {}", id);
+                    }
                     return null;
                 }
             }
@@ -157,8 +166,7 @@ public class WorldEditStructurePlacer {
             }
             return bounds;
         } catch (Throwable e) {
-            System.out.println("Error placing BunkerStructure:");
-            e.printStackTrace();
+            LOGGER.error("Error placing BunkerStructure {}", id, e);
             return null;
         }
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/CampfireBlockMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/CampfireBlockMixin.java
@@ -11,8 +11,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Map;
-import java.util.WeakHashMap;
+import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongIterator;
 
 /**
  * The type Campfire block mixin.
@@ -20,9 +20,9 @@ import java.util.WeakHashMap;
 @Mixin(CampfireBlock.class)
 public class CampfireBlockMixin {
 
-    // Weak map so chunk unloads don’t cause memory leaks
+    // Track last particle emission times keyed by block position to throttle
     @Unique
-    private static final Map<BlockPos, Long> LAST_PARTICLE_TIME = new WeakHashMap<>();
+    private static final Long2LongOpenHashMap LAST_PARTICLE_TIME = new Long2LongOpenHashMap();
 
     @Inject(method = "makeParticles", at = @At("HEAD"), cancellable = true)
     private static void modifyMakeParticles(Level level, BlockPos pos, boolean isSignalFire, boolean spawnExtraSmoke, CallbackInfo ci) {
@@ -33,11 +33,24 @@ public class CampfireBlockMixin {
         }
 
         long gameTime = level.getGameTime();
-        long lastTime = LAST_PARTICLE_TIME.getOrDefault(pos.immutable(), 0L);
+        long key = pos.asLong();
+        long lastTime = LAST_PARTICLE_TIME.getOrDefault(key, 0L);
 
         // Throttle particle spawn per campfire every 5 ticks (1/4 second)
         if (gameTime - lastTime < 5) return;
-        LAST_PARTICLE_TIME.put(pos.immutable(), gameTime);
+        LAST_PARTICLE_TIME.put(key, gameTime);
+
+        // Periodically clean up stale entries to avoid unbounded growth
+        if (gameTime % 200 == 0) {
+            LongIterator iter = LAST_PARTICLE_TIME.keySet().iterator();
+            while (iter.hasNext()) {
+                long k = iter.nextLong();
+                long value = LAST_PARTICLE_TIME.get(k);
+                if (gameTime - value > 200) {
+                    iter.remove();
+                }
+            }
+        }
 
         RandomSource random = level.getRandom();
         int maxHeight = level.getMaxBuildHeight();


### PR DESCRIPTION
## Summary
- Improve campfire particle throttling and cleanup to reduce overhead
- Guard WorldEdit structure placement with cached log messages
- Cache memory usage metrics and convert noisy prints to mod logger

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689e893c17b8832880f46810420a7ceb