### PR TITLE
refactor: replace deprecated BlockVector3 getters

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/TerrainBlockReplacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/TerrainBlockReplacer.java
@@ -62,8 +62,7 @@ public class TerrainBlockReplacer {
     public static void replaceBlockWithTerrainRelative(EditSession editSession, ServerLevel world,
                                                        BlockVector3 blockVector, BlockPos origin)
             throws MaxChangedBlocksException {
-        BlockPos terrainPos = origin.offset(blockVector.getBlockX(), blockVector.getBlockY(),
-                                            blockVector.getBlockZ());
+        BlockPos terrainPos = origin.offset(blockVector.x(), blockVector.y(), blockVector.z());
         replaceBlockWithTerrain(editSession, world, blockVector, terrainPos);
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
@@ -133,8 +133,8 @@ public class WorldEditStructurePlacer {
             }
 
             AABB bounds = new AABB(
-                    min.getBlockX() + surfacePos.getX(), min.getBlockY() + surfacePos.getY(), min.getBlockZ() + surfacePos.getZ(),
-                    max.getBlockX() + surfacePos.getX(), max.getBlockY() + surfacePos.getY(), max.getBlockZ() + surfacePos.getZ()
+                    min.x() + surfacePos.getX(), min.y() + surfacePos.getY(), min.z() + surfacePos.getZ(),
+                    max.x() + surfacePos.getX(), max.y() + surfacePos.getY(), max.z() + surfacePos.getZ()
             );
 
             try (final EditSession editSession = WorldEdit.getInstance().newEditSession((World) world)) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/SecretOrderVillage/SecretOrderVillagePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/SecretOrderVillage/SecretOrderVillagePlacer.java
@@ -96,13 +96,13 @@ public class SecretOrderVillagePlacer {
                         .ignoreAirBlocks(false)
                         .build();
 
-                for (int x = 0; x < clipboard.getDimensions().getX(); x++) {
-                    for (int z = 0; z < clipboard.getDimensions().getZ(); z++) {
-                        BlockVector3 local = BlockVector3.at(x, clipboard.getDimensions().getY() - 1, z);
+                for (int x = 0; x < clipboard.getDimensions().x(); x++) {
+                    for (int z = 0; z < clipboard.getDimensions().z(); z++) {
+                        BlockVector3 local = BlockVector3.at(x, clipboard.getDimensions().y() - 1, z);
                         BlockVector3 worldVec = local.add(clipboard.getOrigin())
                                 .add(BlockVector3.at(position.getX(), position.getY(), position.getZ()));
                         if (clipboard.getBlock(local).getBlockType().equals(BlockTypes.WHITE_WOOL)) {
-                            BlockPos worldPos = new BlockPos(worldVec.getX(), worldVec.getY(), worldVec.getZ());
+                            BlockPos worldPos = new BlockPos(worldVec.x(), worldVec.y(), worldVec.z());
                             BlockPos below = worldPos.below();
                             net.minecraft.world.level.block.state.BlockState terrainBlock = world.getBlockState(below);
                             BlockFactory weState = WorldEdit.getInstance().getBlockFactory();


### PR DESCRIPTION
## Summary
- replace deprecated `getBlockX/Y/Z` and `getX/Y/Z` calls with record accessors
- update terrain and structure placement logic accordingly

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689f516141fc8328a8a9f561997e9d60