### PR TITLE
Reduce tick overhead

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -67,6 +67,9 @@ public class WildernessOdysseyAPIMainModClass {
 
     private static AABB structureBoundingBox;
 
+    private int serverTickCounter = 0;
+    private static final int LOG_INTERVAL = 600;
+
     private static final Map<CustomPacketPayload.Type<?>, NetworkMessage<?>> MESSAGES = new HashMap<>();
 
     private record NetworkMessage<T extends CustomPacketPayload>(StreamCodec<? extends FriendlyByteBuf, T> reader,
@@ -205,16 +208,17 @@ public class WildernessOdysseyAPIMainModClass {
         MinecraftServer server = event.getServer();
         if (!event.hasTime()) return;
 
-        if (server.getTickCount() % 600 == 0) {
-                long usedMB = MemoryUtils.getUsedMemoryMB();
-                long totalMB = MemoryUtils.getTotalMemoryMB();
+        if (++serverTickCounter >= LOG_INTERVAL) {
+            serverTickCounter = 0;
+            long usedMB = MemoryUtils.getUsedMemoryMB();
+            long totalMB = MemoryUtils.getTotalMemoryMB();
 
-                // Use the dynamic mod count
-                int recommendedMB = MemoryUtils.calculateRecommendedRAM(usedMB, dynamicModCount);
+            // Use the dynamic mod count
+            int recommendedMB = MemoryUtils.calculateRecommendedRAM(usedMB, dynamicModCount);
 
             LOGGER.info("[ResourceManager] Memory usage: {}MB / {}MB. Recommended ~{}MB for {} loaded mods.", usedMB, totalMB, recommendedMB, dynamicModCount);
-            }
         }
+    }
     @SubscribeEvent
     public void onReload(AddReloadListenerEvent event) {
         event.addListener(new FaqReloadListener());

--- a/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryTracker.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryTracker.java
@@ -13,11 +13,17 @@ import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
 @EventBusSubscriber(modid = MOD_ID)
 public class MemoryTracker {
 
+    private static final int SAMPLE_INTERVAL = 20;
+    private static int tickCounter = 0;
+
     /**
-     * Invoked each server tick; updates peak memory usage statistics.
+     * Invoked on server ticks; periodically updates peak memory statistics.
      */
     @SubscribeEvent
     public static void onServerTick(ServerTickEvent.Post event) {
-        MemoryUtils.recordPeakUsage();
+        if (++tickCounter >= SAMPLE_INTERVAL) {
+            tickCounter = 0;
+            MemoryUtils.recordPeakUsage();
+        }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryTrackerClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryTrackerClient.java
@@ -14,11 +14,17 @@ import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
 @EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT)
 public class MemoryTrackerClient {
 
+    private static final int SAMPLE_INTERVAL = 20;
+    private static int tickCounter = 0;
+
     /**
-     * Invoked each client tick; updates peak memory usage statistics.
+     * Invoked on client ticks; periodically updates peak memory statistics.
      */
     @SubscribeEvent
     public static void onClientTick(ClientTickEvent.Post event) {
-        MemoryUtils.recordPeakUsage();
+        if (++tickCounter >= SAMPLE_INTERVAL) {
+            tickCounter = 0;
+            MemoryUtils.recordPeakUsage();
+        }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryUtils.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryUtils.java
@@ -9,6 +9,8 @@ public class MemoryUtils {
 
     // Base recommended MB; adjust as needed
     private static final int BASE_RECOMMENDED_MB = 4096; // 4GB
+    private static final Runtime RUNTIME = Runtime.getRuntime();
+    private static final long MB = 1024L * 1024L;
 
     /**
      * Tracks the peak memory usage observed during this session in MB.
@@ -39,21 +41,17 @@ public class MemoryUtils {
      * Returns the amount of used memory in MB.
      */
     public static long getUsedMemoryMB() {
-        long free  = Runtime.getRuntime().freeMemory();
-        long total = Runtime.getRuntime().totalMemory();
-        long used = (total - free) / (1024 * 1024);
-        LOGGER.debug("Calculated used memory: {} MB (total={} MB, free={} MB)", used, total / (1024 * 1024), free / (1024 * 1024));
-        return used;
+        long free  = RUNTIME.freeMemory();
+        long total = RUNTIME.totalMemory();
+        return (total - free) / MB;
     }
 
     /**
      * Returns the total allocated memory (heap) in MB.
      */
     public static long getTotalMemoryMB() {
-        long total = Runtime.getRuntime().totalMemory();
-        long totalMB = total / (1024 * 1024);
-        LOGGER.debug("Total memory allocated: {} MB", totalMB);
-        return totalMB;
+        long total = RUNTIME.totalMemory();
+        return total / MB;
     }
 
     /**

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ClientSaveHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ClientSaveHandler.java
@@ -12,6 +12,9 @@ import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
 @EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT)
 public class ClientSaveHandler {
 
+    private static final int FLUSH_INTERVAL = 10000;
+    private static int tickCounter = 0;
+
     /**
      * If you want to optimize the final "Saving World" step on a singleplayer game,
      * you can ensure chunks are saved incrementally or flush them just before
@@ -46,19 +49,16 @@ public class ClientSaveHandler {
      * you could do so every X ticks on the client side, when in singleplayer.
      */
     @SubscribeEvent
-    public static void onClientTick(ClientTickEvent.Post event) {{
-            Minecraft mc = Minecraft.getInstance();
-            if (mc.player == null) return;
-            if (mc.hasSingleplayerServer()) {
-                // Example: flush once every 10,000 ticks on the client side
-                assert mc.level != null;
-                long time = mc.level.getGameTime();
-                if (time % 10000 == 0) {
-                    assert mc.getSingleplayerServer() != null;
-                    mc.getSingleplayerServer().execute(() -> {
-                        mc.getSingleplayerServer().overworld().save(null, false, true);
-                    });
-                }
+    public static void onClientTick(ClientTickEvent.Post event) {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.player == null) return;
+        if (mc.hasSingleplayerServer()) {
+            if (++tickCounter >= FLUSH_INTERVAL) {
+                tickCounter = 0;
+                assert mc.getSingleplayerServer() != null;
+                mc.getSingleplayerServer().execute(() -> {
+                    mc.getSingleplayerServer().overworld().save(null, false, true);
+                });
             }
         }
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/PlayerSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/PlayerSpawnHandler.java
@@ -2,7 +2,6 @@ package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
@@ -12,13 +11,12 @@ import net.minecraft.network.protocol.game.ClientboundSetTitlesAnimationPacket;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorImpactData;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
 
@@ -30,7 +28,7 @@ import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
 public class PlayerSpawnHandler {
 
     private static final AtomicInteger spawnIndex = new AtomicInteger(0);
-    private static List<BlockPos> spawnBlocks = null;
+    private static List<BlockPos> spawnBlocks = Collections.emptyList();
     private static final String CRYO_TAG = "wo_in_cryo";
     private static final String CRYO_USED_TAG = "wo_cryo_used";
     private static final String CRYO_POS_TAG = "wo_cryo_pos";
@@ -44,14 +42,15 @@ public class PlayerSpawnHandler {
     @SubscribeEvent
     public static void onPlayerJoin(PlayerEvent.PlayerLoggedInEvent event) {
         ServerPlayer player = (ServerPlayer) event.getEntity();
-        ServerLevel world = player.serverLevel();
 
         CompoundTag tag = player.getPersistentData();
         if (tag.getBoolean(CRYO_USED_TAG)) {
             return;
         }
 
-        ensureSpawnBlocks(world);
+        if (spawnBlocks.isEmpty()) {
+            return;
+        }
 
         tag.putInt(CRYO_DELAY_TAG, 200); // 10 second delay (20 ticks * 10)
         playIntroCinematic(player);
@@ -65,7 +64,6 @@ public class PlayerSpawnHandler {
         if (!(event.getEntity() instanceof ServerPlayer player)) return;
 
         CompoundTag tag = player.getPersistentData();
-        ServerLevel world = player.serverLevel();
 
         if (tag.contains(CRYO_DELAY_TAG)) {
             int delay = tag.getInt(CRYO_DELAY_TAG) - 1;
@@ -75,17 +73,18 @@ public class PlayerSpawnHandler {
             }
             tag.remove(CRYO_DELAY_TAG);
 
-            ensureSpawnBlocks(world);
             if (!spawnBlocks.isEmpty()) {
                 BlockPos spawnPos = getNextSpawnBlock();
-                player.teleportTo(world, spawnPos.getX() + 0.5, spawnPos.getY(), spawnPos.getZ() + 0.5, player.getYRot(), player.getXRot());
+                player.teleportTo(player.serverLevel(),
+                        spawnPos.getX() + 0.5,
+                        spawnPos.getY(),
+                        spawnPos.getZ() + 0.5,
+                        player.getYRot(),
+                        player.getXRot());
                 tag.putBoolean(CRYO_TAG, true);
                 tag.putBoolean(CRYO_USED_TAG, true);
                 tag.putLong(CRYO_POS_TAG, spawnPos.asLong());
                 player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, 60, 255, false, false));
-            } else {
-                // No cryo tube yet, try again in a second
-                tag.putInt(CRYO_DELAY_TAG, 20);
             }
             return;
         }
@@ -117,23 +116,13 @@ public class PlayerSpawnHandler {
     }
 
     private static BlockPos getNextSpawnBlock() {
-        int index = spawnIndex.getAndUpdate(i -> (i + 1) % spawnBlocks.size());
+        int size = spawnBlocks.size();
+        int index = spawnIndex.getAndUpdate(i -> i + 1 >= size ? 0 : i + 1);
         return spawnBlocks.get(index);
     }
 
-    private static void ensureSpawnBlocks(ServerLevel world) {
-        if (spawnBlocks == null || spawnBlocks.isEmpty()) {
-            spawnBlocks = WorldSpawnHandler.findAllWorldSpawnBlocks(world);
-            BlockPos meteorPos = MeteorImpactData.get(world).getImpactPos();
-            if (meteorPos != null && !spawnBlocks.isEmpty()) {
-                BlockPos closest = spawnBlocks.stream()
-                        .min((a, b) -> Double.compare(a.distSqr(meteorPos), b.distSqr(meteorPos)))
-                        .orElse(spawnBlocks.get(0));
-                final double maxDist = 400.0; // radius squared (20 blocks)
-                spawnBlocks = spawnBlocks.stream()
-                        .filter(p -> p.distSqr(closest) <= maxDist)
-                        .collect(Collectors.toList());
-            }
-        }
+    public static void setSpawnBlocks(List<BlockPos> blocks) {
+        spawnBlocks = blocks == null ? Collections.emptyList() : blocks;
+        spawnIndex.set(0);
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
@@ -3,15 +3,18 @@ package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ChunkMap;
 import net.minecraft.world.level.chunk.LevelChunk;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorImpactData;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.level.LevelEvent;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
 
@@ -21,6 +24,19 @@ import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
  */
 @EventBusSubscriber(modid = MOD_ID)
 public class WorldSpawnHandler {
+
+    private static final Method GET_CHUNKS_METHOD;
+
+    static {
+        Method method;
+        try {
+            method = ChunkMap.class.getDeclaredMethod("getChunks");
+            method.setAccessible(true);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        GET_CHUNKS_METHOD = method;
+    }
 
     /**
      * On world load.
@@ -37,17 +53,25 @@ public class WorldSpawnHandler {
                 BlockPos meteorPos = MeteorImpactData.get(world).getImpactPos();
                 BlockPos spawnBlockPos;
                 if (meteorPos != null) {
-                    spawnBlockPos = spawnBlockPositions.stream()
+                    BlockPos closest = spawnBlockPositions.stream()
                             .min((a, b) -> Double.compare(a.distSqr(meteorPos), b.distSqr(meteorPos)))
                             .orElse(spawnBlockPositions.get(0));
+                    final double maxDist = 400.0; // radius squared (20 blocks)
+                    spawnBlockPositions = spawnBlockPositions.stream()
+                            .filter(p -> p.distSqr(closest) <= maxDist)
+                            .collect(Collectors.toList());
+                    spawnBlockPos = closest;
                 } else {
                     Random random = new Random();
                     spawnBlockPos = spawnBlockPositions.get(random.nextInt(spawnBlockPositions.size()));
                 }
 
+                PlayerSpawnHandler.setSpawnBlocks(spawnBlockPositions);
+
                 // Set the world's default spawn position
                 world.setDefaultSpawnPos(spawnBlockPos.above(), 0.0F);
             } else {
+                PlayerSpawnHandler.setSpawnBlocks(spawnBlockPositions);
                 // Log a warning or handle cases where no spawn blocks are found
                 System.err.println("No Cryo Tube Blocks found in the world!");
             }
@@ -65,9 +89,7 @@ public class WorldSpawnHandler {
 
         try {
             // ChunkMap#getChunks became protected; use reflection to access it
-            var method = world.getChunkSource().chunkMap.getClass().getDeclaredMethod("getChunks");
-            method.setAccessible(true);
-            Iterable<?> holders = (Iterable<?>) method.invoke(world.getChunkSource().chunkMap);
+            Iterable<?> holders = (Iterable<?>) GET_CHUNKS_METHOD.invoke(world.getChunkSource().chunkMap);
             for (Object holderObj : holders) {
                 // Each holder represents a chunk; attempt to extract a loaded LevelChunk
                 var holderClass = holderObj.getClass();


### PR DESCRIPTION
## Summary
- replace per-tick modulo checks with simple counters in memory tracking, client saves, server logging, and spawn rotation
- cache the `Runtime` instance and MB constant for leaner memory calculations
- resolve spawn block lookup only during world initialization and reuse cached positions for player spawns

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689e95e7a528832899735ee0634e90d2