### PR TITLE
Fix compile errors in spawn handler and memory utils

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryUtils.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryUtils.java
@@ -45,19 +45,16 @@ public class MemoryUtils {
      */
     private static long lastLoggedUsedMB = -1;
     public static long getUsedMemoryMB() {
-        long free  = RUNTIME.freeMemory();
+        long free = RUNTIME.freeMemory();
         long total = RUNTIME.totalMemory();
-        return (total - free) / MB;
-        long free = Runtime.getRuntime().freeMemory();
-        long total = Runtime.getRuntime().totalMemory();
-        long used = (total - free) / (1024 * 1024);
+        long used = (total - free) / MB;
         if (used != lastLoggedUsedMB) {
             lastLoggedUsedMB = used;
             LOGGER.debug(
                     "Calculated used memory: {} MB (total={} MB, free={} MB)",
                     used,
-                    total / (1024 * 1024),
-                    free / (1024 * 1024));
+                    total / MB,
+                    free / MB);
         }
         return used;
     }
@@ -69,9 +66,7 @@ public class MemoryUtils {
     private static long lastLoggedTotalMB = -1;
     public static long getTotalMemoryMB() {
         long total = RUNTIME.totalMemory();
-        return total / MB;
-        long total = Runtime.getRuntime().totalMemory();
-        long totalMB = total / (1024 * 1024);
+        long totalMB = total / MB;
         if (totalMB != lastLoggedTotalMB) {
             lastLoggedTotalMB = totalMB;
             LOGGER.debug("Total memory allocated: {} MB", totalMB);

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/PlayerSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/PlayerSpawnHandler.java
@@ -3,6 +3,7 @@ package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorImpactData;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
@@ -31,7 +32,6 @@ public class PlayerSpawnHandler {
 
     private static final AtomicInteger spawnIndex = new AtomicInteger(0);
     private static List<BlockPos> spawnBlocks = Collections.emptyList();
-    private static List<BlockPos> spawnBlocks = null;
     private static long lastScanTime = Long.MIN_VALUE;
     private static final int SCAN_INTERVAL = 200;
     private static final String CRYO_TAG = "wo_in_cryo";
@@ -129,6 +129,8 @@ public class PlayerSpawnHandler {
     public static void setSpawnBlocks(List<BlockPos> blocks) {
         spawnBlocks = blocks == null ? Collections.emptyList() : blocks;
         spawnIndex.set(0);
+    }
+
     private static void ensureSpawnBlocks(ServerLevel world) {
         if ((spawnBlocks == null || spawnBlocks.isEmpty()) &&
                 world.getGameTime() - lastScanTime >= SCAN_INTERVAL) {


### PR DESCRIPTION
## Summary
- resolve unclosed method and duplicate field in PlayerSpawnHandler
- streamline MemoryUtils to avoid duplicate variables and log memory usage correctly

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689f801d15d8832883657dfe2d80f598