### PR TITLE
Add world generation scan command for diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ is not found, the bundled schematic under
 Loot tables defined inside schematics work the same way as with vanilla
 `nbt` structures. The scanner now detects loot table references in both
 `.nbt` and `.schem` files so datapacks can supply their own chest contents.
+
+World Generation Diagnostics
+--------------------------
+Use `/worldgenscan <radius>` to count nearby structures, features, and biomes and identify which mods add them.

--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -16,6 +16,7 @@ import com.thunder.wildernessodysseyapi.command.StructureInfoCommand;
 import com.thunder.wildernessodysseyapi.donations.command.DonateCommand;
 import com.thunder.wildernessodysseyapi.doorlock.DoorLockEvents;
 import com.thunder.wildernessodysseyapi.command.DoorLockCommand;
+import com.thunder.wildernessodysseyapi.command.WorldGenScanCommand;
 import com.thunder.wildernessodysseyapi.item.ModCreativeTabs;
 import com.thunder.wildernessodysseyapi.item.ModItems;
 import com.thunder.wildernessodysseyapi.AntiCheat.BlacklistChecker;
@@ -154,6 +155,7 @@ public class WildernessOdysseyAPIMainModClass {
         FaqCommand.register(event.getDispatcher());
         DonateCommand.register(event.getDispatcher());
         DoorLockCommand.register(event.getDispatcher());
+        WorldGenScanCommand.register(event.getDispatcher());
     }
 
     /**

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/WorldGenScanCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/WorldGenScanCommand.java
@@ -1,0 +1,142 @@
+package com.thunder.wildernessodysseyapi.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeGenerationSettings;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.structure.Structure;
+import net.neoforged.fml.ModList;
+
+import java.util.*;
+
+/**
+ * Scans nearby chunks and reports the structures that were generated.
+ * Useful for identifying mods that may be over-generating structures
+ * and causing messy world generation.
+ */
+public class WorldGenScanCommand {
+
+    /**
+     * Register the command with the dispatcher.
+     */
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(
+                Commands.literal("worldgenscan")
+                        .executes(ctx -> execute(ctx, 1))
+                        .then(Commands.argument("radius", IntegerArgumentType.integer(1, 8))
+                                .executes(ctx -> execute(ctx, IntegerArgumentType.getInteger(ctx, "radius"))))
+        );
+    }
+
+    private static int execute(CommandContext<CommandSourceStack> ctx, int radius) throws CommandSyntaxException {
+        ServerPlayer player = ctx.getSource().getPlayerOrException();
+        ServerLevel level = player.serverLevel();
+        ChunkPos center = player.chunkPosition();
+
+        Registry<Structure> structReg = level.registryAccess()
+                .registryOrThrow(Registries.STRUCTURE);
+
+        Map<ResourceLocation, Integer> structureCounts = new HashMap<>();
+        Map<ResourceLocation, Integer> featureCounts = new HashMap<>();
+        Map<ResourceLocation, Integer> biomeCounts = new HashMap<>();
+
+        for (int dx = -radius; dx <= radius; dx++) {
+            for (int dz = -radius; dz <= radius; dz++) {
+                ChunkPos pos = new ChunkPos(center.x + dx, center.z + dz);
+                BlockPos worldPos = pos.getWorldPosition();
+
+                // Structures
+                structReg.entrySet().forEach(entry -> {
+                    if (level.structureManager().getStructureWithPieceAt(worldPos, entry.getValue()).isValid()) {
+                        structureCounts.merge(entry.getKey().location(), 1, Integer::sum);
+                    }
+                });
+
+                // Biome and features at chunk center
+                BlockPos samplePos = worldPos.offset(8, player.getBlockY(), 8);
+                Holder<Biome> biomeHolder = level.getBiome(samplePos);
+                biomeHolder.unwrapKey().ifPresent(key ->
+                        biomeCounts.merge(key.location(), 1, Integer::sum));
+
+                BiomeGenerationSettings gen = biomeHolder.value().getGenerationSettings();
+                for (HolderSet<PlacedFeature> step : gen.features()) {
+                    for (Holder<PlacedFeature> holder : step) {
+                        holder.unwrapKey().ifPresent(key ->
+                                featureCounts.merge(key.location(), 1, Integer::sum));
+                    }
+                }
+            }
+        }
+
+        if (structureCounts.isEmpty() && featureCounts.isEmpty() && biomeCounts.isEmpty()) {
+            ctx.getSource().sendSuccess(() -> Component.literal("No structures, features, or biomes found in radius " + radius), false);
+        } else {
+            StringBuilder out = new StringBuilder("Worldgen in radius " + radius + ":");
+
+            if (!structureCounts.isEmpty()) {
+                out.append("\nStructures:");
+                structureCounts.entrySet().stream()
+                        .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+                        .forEach(entry -> {
+                            String modName = ModList.get().getModContainerById(entry.getKey().getNamespace())
+                                    .map(c -> c.getModInfo().getDisplayName())
+                                    .orElse("Unknown Mod");
+                            out.append("\n - ")
+                                    .append(entry.getKey().getPath())
+                                    .append(" [").append(modName).append("]: ")
+                                    .append(entry.getValue());
+                        });
+            }
+
+            if (!featureCounts.isEmpty()) {
+                out.append("\nFeatures:");
+                featureCounts.entrySet().stream()
+                        .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+                        .forEach(entry -> {
+                            String modName = ModList.get().getModContainerById(entry.getKey().getNamespace())
+                                    .map(c -> c.getModInfo().getDisplayName())
+                                    .orElse("Unknown Mod");
+                            out.append("\n - ")
+                                    .append(entry.getKey().getPath())
+                                    .append(" [").append(modName).append("]: ")
+                                    .append(entry.getValue());
+                        });
+            }
+
+            if (!biomeCounts.isEmpty()) {
+                out.append("\nBiomes:");
+                biomeCounts.entrySet().stream()
+                        .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+                        .forEach(entry -> {
+                            String modName = ModList.get().getModContainerById(entry.getKey().getNamespace())
+                                    .map(c -> c.getModInfo().getDisplayName())
+                                    .orElse("Unknown Mod");
+                            out.append("\n - ")
+                                    .append(entry.getKey().getPath())
+                                    .append(" [").append(modName).append("]: ")
+                                    .append(entry.getValue());
+                        });
+            }
+
+            ctx.getSource().sendSuccess(() -> Component.literal(out.toString()), false);
+        }
+
+        return 1;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `/worldgenscan` command to tally nearby structures, configured features, and biomes with mod attribution
- register the scan command alongside existing diagnostics
- document the new `/worldgenscan` command in the README

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689fa60aa4cc8328ada8ee40366390f3