### PR TITLE
Improve worldgenscan command output

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/command/WorldGenScanCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/WorldGenScanCommand.java
@@ -12,6 +12,7 @@ import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.ChatFormatting;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -21,6 +22,7 @@ import net.minecraft.world.level.biome.BiomeGenerationSettings;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import net.neoforged.fml.ModList;
+import java.awt.GraphicsEnvironment;
 
 import java.util.*;
 
@@ -55,6 +57,11 @@ public class WorldGenScanCommand {
         Map<ResourceLocation, Integer> featureCounts = new HashMap<>();
         Map<ResourceLocation, Integer> biomeCounts = new HashMap<>();
 
+        ctx.getSource().sendSuccess(
+                () -> Component.nullToEmpty(ChatFormatting.GOLD + "Scanning worldgen in radius " + radius + "..."),
+                false
+        );
+
         for (int dx = -radius; dx <= radius; dx++) {
             for (int dz = -radius; dz <= radius; dz++) {
                 ChunkPos pos = new ChunkPos(center.x + dx, center.z + dz);
@@ -84,56 +91,73 @@ public class WorldGenScanCommand {
         }
 
         if (structureCounts.isEmpty() && featureCounts.isEmpty() && biomeCounts.isEmpty()) {
-            ctx.getSource().sendSuccess(() -> Component.literal("No structures, features, or biomes found in radius " + radius), false);
+            ctx.getSource().sendSuccess(
+                    () -> Component.nullToEmpty(ChatFormatting.RED + "No structures, features, or biomes found in radius " + radius),
+                    false
+            );
         } else {
-            StringBuilder out = new StringBuilder("Worldgen in radius " + radius + ":");
+            ctx.getSource().sendSuccess(
+                    () -> Component.nullToEmpty(ChatFormatting.AQUA + "Worldgen results for radius " + radius + ":"),
+                    false
+            );
 
             if (!structureCounts.isEmpty()) {
-                out.append("\nStructures:");
+                ctx.getSource().sendSuccess(
+                        () -> Component.nullToEmpty(ChatFormatting.YELLOW + "Structures:"),
+                        false
+                );
                 structureCounts.entrySet().stream()
                         .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
                         .forEach(entry -> {
                             String modName = ModList.get().getModContainerById(entry.getKey().getNamespace())
                                     .map(c -> c.getModInfo().getDisplayName())
                                     .orElse("Unknown Mod");
-                            out.append("\n - ")
-                                    .append(entry.getKey().getPath())
-                                    .append(" [").append(modName).append("]: ")
-                                    .append(entry.getValue());
+                            ctx.getSource().sendSuccess(
+                                    () -> Component.nullToEmpty(" - " + entry.getKey().getPath() + " [" + modName + "]: " + entry.getValue()),
+                                    false
+                            );
                         });
             }
 
             if (!featureCounts.isEmpty()) {
-                out.append("\nFeatures:");
+                ctx.getSource().sendSuccess(
+                        () -> Component.nullToEmpty(ChatFormatting.YELLOW + "Features:"),
+                        false
+                );
                 featureCounts.entrySet().stream()
                         .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
                         .forEach(entry -> {
                             String modName = ModList.get().getModContainerById(entry.getKey().getNamespace())
                                     .map(c -> c.getModInfo().getDisplayName())
                                     .orElse("Unknown Mod");
-                            out.append("\n - ")
-                                    .append(entry.getKey().getPath())
-                                    .append(" [").append(modName).append("]: ")
-                                    .append(entry.getValue());
+                            ctx.getSource().sendSuccess(
+                                    () -> Component.nullToEmpty(" - " + entry.getKey().getPath() + " [" + modName + "]: " + entry.getValue()),
+                                    false
+                            );
                         });
             }
 
             if (!biomeCounts.isEmpty()) {
-                out.append("\nBiomes:");
+                ctx.getSource().sendSuccess(
+                        () -> Component.nullToEmpty(ChatFormatting.YELLOW + "Biomes:"),
+                        false
+                );
                 biomeCounts.entrySet().stream()
                         .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
                         .forEach(entry -> {
                             String modName = ModList.get().getModContainerById(entry.getKey().getNamespace())
                                     .map(c -> c.getModInfo().getDisplayName())
                                     .orElse("Unknown Mod");
-                            out.append("\n - ")
-                                    .append(entry.getKey().getPath())
-                                    .append(" [").append(modName).append("]: ")
-                                    .append(entry.getValue());
+                            ctx.getSource().sendSuccess(
+                                    () -> Component.nullToEmpty(" - " + entry.getKey().getPath() + " [" + modName + "]: " + entry.getValue()),
+                                    false
+                            );
                         });
             }
 
-            ctx.getSource().sendSuccess(() -> Component.literal(out.toString()), false);
+            if (!GraphicsEnvironment.isHeadless()) {
+                WorldGenScanViewer.show(structureCounts, featureCounts, biomeCounts);
+            }
         }
 
         return 1;

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/WorldGenScanViewer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/WorldGenScanViewer.java
@@ -1,0 +1,48 @@
+package com.thunder.wildernessodysseyapi.command;
+
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.fml.ModList;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.Comparator;
+import java.util.Map;
+
+/**
+ * Simple Swing window displaying worldgen scan results in tabs.
+ */
+public class WorldGenScanViewer {
+
+    public static void show(Map<ResourceLocation, Integer> structures,
+                             Map<ResourceLocation, Integer> features,
+                             Map<ResourceLocation, Integer> biomes) {
+        SwingUtilities.invokeLater(() -> {
+            JFrame frame = new JFrame("WorldGen Scan Results");
+            frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+            frame.setSize(450, 600);
+
+            JTabbedPane tabs = new JTabbedPane();
+            tabs.addTab("Structures", createPanel(structures));
+            tabs.addTab("Features", createPanel(features));
+            tabs.addTab("Biomes", createPanel(biomes));
+
+            frame.add(tabs, BorderLayout.CENTER);
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+        });
+    }
+
+    private static JScrollPane createPanel(Map<ResourceLocation, Integer> map) {
+        DefaultListModel<String> model = new DefaultListModel<>();
+        map.entrySet().stream()
+                .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+                .forEach(entry -> {
+                    String modName = ModList.get().getModContainerById(entry.getKey().getNamespace())
+                            .map(c -> c.getModInfo().getDisplayName())
+                            .orElse("Unknown Mod");
+                    model.addElement(entry.getKey().getPath() + " [" + modName + "]: " + entry.getValue());
+                });
+        JList<String> list = new JList<>(model);
+        return new JScrollPane(list);
+    }
+}


### PR DESCRIPTION
## Summary
- Send a scanning message before analyzing chunks
- Present worldgen results in color-coded sections for structures, features, and biomes
- Open a Swing window with tabbed lists for structures, features, and biomes when graphics are available

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a20eb57088832890c7537f904eb707