### PR TITLE
Improve FAQ search and listing

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/FAQ/FaqCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/FAQ/FaqCommand.java
@@ -6,6 +6,7 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.network.chat.Component;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -35,6 +36,7 @@ public class FaqCommand {
                                 .executes(ctx -> {
                                     String query = StringArgumentType.getString(ctx, "query");
                                     List<FaqEntry> results = FaqManager.search(query);
+                                    results.sort(Comparator.comparing(FaqEntry::id));
                                     if (results.isEmpty()) {
                                         ctx.getSource().sendFailure(Component.literal("No FAQs found."));
                                     } else {

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/FAQ/FaqManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/FAQ/FaqManager.java
@@ -6,24 +6,24 @@ import net.minecraft.server.packs.resources.ResourceManager;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.util.*;
-import java.util.stream.Collectors;
 /**
  * Loads and stores FAQ entries from resources.
  */
 public class FaqManager {
     private static final Map<String, FaqEntry> FAQ_ENTRIES = new HashMap<>();
+    private static final Map<String, List<FaqEntry>> FAQ_BY_CATEGORY = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     /**
      * Reads all FAQ JSON files from the given resource manager.
      */
     public static void loadFromResources(ResourceManager manager) {
-        FAQ_ENTRIES.clear();
+        clear();
         Gson gson = new Gson();
         Type listType = new TypeToken<List<FaqEntry>>() {}.getType();
         for (ResourceLocation id : manager.listResources("faq", path -> path.getPath().endsWith(".json")).keySet()) {
             try (var reader = new InputStreamReader(manager.getResource(id).get().open())) {
                 List<FaqEntry> entries = gson.fromJson(reader, listType);
                 for (FaqEntry entry : entries) {
-                    FAQ_ENTRIES.put(entry.id(), entry);
+                    add(entry);
                 }
             } catch (Exception e) {
                 System.err.println("Failed to parse FAQ: " + id + ", error: " + e);
@@ -34,36 +34,63 @@ public class FaqManager {
     /** Clears all loaded FAQs. */
     public static void clear() {
         FAQ_ENTRIES.clear();
+        FAQ_BY_CATEGORY.clear();
     }
     /** Adds a single FAQ entry. */
     public static void add(FaqEntry entry) {
         FAQ_ENTRIES.put(entry.id(), entry);
+        FAQ_BY_CATEGORY.computeIfAbsent(entry.category(), c -> new ArrayList<>()).add(entry);
     }
     /** Returns all FAQ ids. */
     public static List<String> getIds() {
-        return new ArrayList<>(FAQ_ENTRIES.keySet());
+        return FAQ_ENTRIES.keySet().stream().sorted().toList();
     }
     /** Gets a FAQ entry by id. */
     public static FaqEntry get(String id) {
         return FAQ_ENTRIES.get(id);
     }
 
-    /** Searches FAQs by keyword in the question text. */
+    /** Searches FAQs by keyword across all fields with basic fuzzy matching. */
     public static List<FaqEntry> search(String keyword) {
         String lower = keyword.toLowerCase();
         return FAQ_ENTRIES.values().stream()
-                .filter(entry -> entry.question().toLowerCase().contains(lower))
+                .filter(entry ->
+                        containsIgnoreCase(entry.id(), lower) ||
+                        containsIgnoreCase(entry.category(), lower) ||
+                        containsIgnoreCase(entry.question(), lower) ||
+                        containsIgnoreCase(entry.answer(), lower) ||
+                        levenshtein(entry.question().toLowerCase(), lower) <= 2)
                 .toList();
+    }
+    private static boolean containsIgnoreCase(String text, String query) {
+        return text.toLowerCase().contains(query);
+    }
+    private static int levenshtein(String a, String b) {
+        int[] costs = new int[b.length() + 1];
+        for (int j = 0; j < costs.length; j++) {
+            costs[j] = j;
+        }
+        for (int i = 1; i <= a.length(); i++) {
+            costs[0] = i;
+            int nw = i - 1;
+            for (int j = 1; j <= b.length(); j++) {
+                int cj = Math.min(1 + Math.min(costs[j], costs[j - 1]),
+                        a.charAt(i - 1) == b.charAt(j - 1) ? nw : nw + 1);
+                nw = costs[j];
+                costs[j] = cj;
+            }
+        }
+        return costs[b.length()];
     }
 
     /** Returns FAQs that belong to the given category. */
     public static List<FaqEntry> getByCategory(String category) {
-        return FAQ_ENTRIES.values().stream()
-                .filter(entry -> entry.category().equalsIgnoreCase(category))
+        return FAQ_BY_CATEGORY.getOrDefault(category, Collections.emptyList())
+                .stream().sorted(Comparator.comparing(FaqEntry::id))
                 .toList();
     }
     /** Lists all available categories. */
     public static Set<String> getCategories() {
-        return FAQ_ENTRIES.values().stream().map(FaqEntry::category).collect(Collectors.toSet());
+        return Collections.unmodifiableSet(FAQ_BY_CATEGORY.keySet());
     }
 }


### PR DESCRIPTION
## Summary
- index FAQ entries by category for sorted listings
- broaden FAQ search across all fields with basic fuzzy matching
- sort `/faq search` results for consistency

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c6d1baa3248328821e4a336d3bc15a