### PR TITLE
Add placeholder AI client and configuration

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ai/AIClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ai/AIClient.java
@@ -1,0 +1,66 @@
+package com.thunder.wildernessodysseyapi.ai;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simple client that reads lore from {@code ai_config.yaml} and
+ * echoes player messages. This acts as a placeholder for a future
+ * networked AI service.
+ */
+public class AIClient {
+
+    private final List<String> story = new ArrayList<>();
+    private final MemoryStore memoryStore = new MemoryStore();
+
+    public AIClient() {
+        loadStory();
+    }
+
+    private void loadStory() {
+        try (InputStream in = AIClient.class.getClassLoader().getResourceAsStream("ai_config.yaml")) {
+            if (in == null) {
+                return;
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+                boolean inStory = false;
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    line = line.trim();
+                    if (line.startsWith("story:")) {
+                        inStory = true;
+                        continue;
+                    }
+                    if (inStory) {
+                        if (line.startsWith("-")) {
+                            story.add(line.substring(1).trim().replace("\"", ""));
+                        } else if (!line.isEmpty() && !line.startsWith("#")) {
+                            inStory = false;
+                        }
+                    }
+                }
+            }
+        } catch (IOException ignored) {
+            // Config is optional; ignore parsing errors for now
+        }
+    }
+
+    /**
+     * Adds the message to memory and returns a canned reply that includes
+     * the first line of the loaded story as context.
+     *
+     * @param player  player name
+     * @param message player message
+     * @return AI reply
+     */
+    public String sendMessage(String player, String message) {
+        memoryStore.addMessage(player, message);
+        String prefix = story.isEmpty() ? "" : story.get(0) + " ";
+        return prefix + "You said: " + message;
+    }
+}
+

--- a/src/main/java/com/thunder/wildernessodysseyapi/ai/MemoryStore.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ai/MemoryStore.java
@@ -1,0 +1,44 @@
+package com.thunder.wildernessodysseyapi.ai;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Minimal per-player conversation history.
+ */
+public class MemoryStore {
+
+    private static final int MAX_HISTORY = 20;
+    private final Map<String, Deque<String>> messages = new HashMap<>();
+
+    /**
+     * Stores a player message.
+     *
+     * @param player  player name
+     * @param message message text
+     */
+    public void addMessage(String player, String message) {
+        Deque<String> deque = messages.computeIfAbsent(player, p -> new ArrayDeque<>());
+        if (deque.size() >= MAX_HISTORY) {
+            deque.removeFirst();
+        }
+        deque.addLast(message);
+    }
+
+    /**
+     * Returns a newline-separated view of recent messages.
+     *
+     * @param player player name
+     * @return context string or empty if none
+     */
+    public String getRecentContext(String player) {
+        Deque<String> deque = messages.get(player);
+        if (deque == null) {
+            return "";
+        }
+        return String.join("\n", deque);
+    }
+}
+

--- a/src/main/resources/ai_config.yaml
+++ b/src/main/resources/ai_config.yaml
@@ -1,0 +1,8 @@
+story:
+  - "You are the expedition AI in a skyblock survival world."
+  - "The world is fractured; resources are scarce."
+  - "Players must rebuild civilization in floating islands."
+settings:
+  voice_enabled: true
+  speech_recognition: false
+  model: "gpt-4o-mini"


### PR DESCRIPTION
## Summary
- scaffold AIClient that loads lore from `ai_config.yaml` and echoes player messages
- provide MemoryStore for per-player conversation context
- add example `ai_config.yaml` with story and settings placeholders

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c6d228d73883288747284ee7beb322