### PR TITLE
Fix cryo tube block placement alignment

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlockItem.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/blocks/CryoTubeBlockItem.java
@@ -1,16 +1,14 @@
 package com.thunder.wildernessodysseyapi.WorldGen.blocks;
 
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.core.Direction;
 
 /**
- * Block item for the cryo tube that places the tube one block higher
- * than the targeted position to account for the model's vertical offset.
+ * Custom block item that normalises the cryo tube placement so it behaves like
+ * a regular block despite the model using an offset origin.
  */
 public class CryoTubeBlockItem extends BlockItem {
     public CryoTubeBlockItem(Block block, Properties properties) {
@@ -19,9 +17,19 @@ public class CryoTubeBlockItem extends BlockItem {
 
     @Override
     public InteractionResult place(BlockPlaceContext context) {
-        BlockPos pos = context.getClickedPos().relative(context.getClickedFace()).above();
-        BlockHitResult hit = new BlockHitResult(context.getClickLocation(), Direction.UP, pos, false);
-        BlockPlaceContext offset = new BlockPlaceContext(context.getLevel(), context.getPlayer(), context.getHand(), context.getItemInHand(), hit);
-        return super.place(offset);
+        BlockHitResult hit = new BlockHitResult(
+                context.getClickLocation(),
+                context.getClickedFace(),
+                context.getClickedPos().relative(context.getClickedFace()),
+                false
+        );
+        BlockPlaceContext adjustedContext = new BlockPlaceContext(
+                context.getLevel(),
+                context.getPlayer(),
+                context.getHand(),
+                context.getItemInHand(),
+                hit
+        );
+        return super.place(adjustedContext);
     }
 }


### PR DESCRIPTION
## Summary
- update the cryo tube block item so it uses the clicked face instead of forcing an extra block offset
- keep placement logic behaving like a normal block despite the model's offset origin

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d2c1215f508328a428cac8d9cf97ed