### PR TITLE
Integrate WorldEdit meteor site schematic

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ loaded from the data pack when structures generate. If a matching data pack file
 is not found, the bundled schematic under
 `assets/<namespace>/schematics/` is used instead.
 
+The meteor impact site looks for the `wildernessodysseyapi:meteor_site`
+schematic. Drop your finished WorldEdit build at
+`data/wildernessodysseyapi/structures/meteor_site.schem` (or bundle it under
+`assets/wildernessodysseyapi/schematics/`) so the crash crater is pasted before
+the bunker generates.
+
 Loot tables defined inside schematics work the same way as with vanilla
 `nbt` structures. The scanner now detects loot table references in both
 `.nbt` and `.schem` files so datapacks can supply their own chest contents.

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
@@ -1,61 +1,88 @@
 package com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures;
 
-import net.minecraft.core.BlockPos;
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.StructureSpawnTracker;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Worldedit.WorldEditStructurePlacer;
-import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorImpactData;
+import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
+import net.minecraft.world.phys.AABB;
+import net.neoforged.fml.ModList;
 
 import java.util.Optional;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
-import net.neoforged.fml.ModList;
 
 /****
  * MeteorStructureSpawner for the Wilderness Odyssey API mod.
  */
 public class MeteorStructureSpawner {
+    private static final ResourceLocation METEOR_TEMPLATE_ID = ResourceLocation.tryBuild(MOD_ID, "meteor_bunker");
+    private static final WorldEditStructurePlacer METEOR_SITE_PLACER =
+            new WorldEditStructurePlacer(ModConstants.MOD_ID, "meteor_site.schem");
+    private static final WorldEditStructurePlacer BUNKER_PLACER =
+            new WorldEditStructurePlacer(ModConstants.MOD_ID, "bunker.schem");
+
     private static boolean placed = false;
 
     public static void tryPlace(ServerLevel level) {
-        if (!ModList.get().isLoaded("worldedit")) return;
         // Only place once in the entire world
-        if (placed) return;
+        if (placed) {
+            return;
+        }
+
+        BlockPos impactOrigin = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, BlockPos.ZERO);
+        BlockPos impactPos = placeMeteorSite(level, impactOrigin);
+        MeteorImpactData.get(level).setImpactPos(impactPos);
+
+        placeBunker(level, impactPos);
+
         placed = true;
+    }
 
-        // Decide where to place the meteor
-        BlockPos spawnPos = new BlockPos(0, level.getHeight(), 0);
-        MeteorImpactData.get(level).setImpactPos(spawnPos);
+    private static BlockPos placeMeteorSite(ServerLevel level, BlockPos origin) {
+        if (ModList.get().isLoaded("worldedit")) {
+            AABB bounds = METEOR_SITE_PLACER.placeStructure(level, origin);
+            if (bounds != null) {
+                return BlockPos.containing(bounds.getCenter());
+            }
+        }
 
-        ResourceLocation structureID = ResourceLocation.tryBuild(MOD_ID, "meteor_bunker");
-        StructureTemplateManager manager = level.getStructureManager();
-        Optional<StructureTemplate> templateOpt = manager.get(structureID);
-
-        if (templateOpt.isPresent()) {
+        if (METEOR_TEMPLATE_ID != null) {
+            StructureTemplateManager manager = level.getStructureManager();
+            Optional<StructureTemplate> templateOpt = manager.get(METEOR_TEMPLATE_ID);
+            if (templateOpt.isPresent()) {
             StructureTemplate template = templateOpt.get();
             StructurePlaceSettings settings = new StructurePlaceSettings();
-            template.placeInWorld(level, spawnPos, spawnPos, settings, level.random, 2);
-
-            // place bunker two chunks east of the meteor
-            BlockPos bunkerPos = spawnPos.offset(32, 0, 0);
-            bunkerPos = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, bunkerPos);
-            // Prefer schematics from data packs but fall back to bundled resource
-            WorldEditStructurePlacer placer = new WorldEditStructurePlacer(ModConstants.MOD_ID, "bunker.schem");
-            StructureSpawnTracker tracker = StructureSpawnTracker.get(level);
-            if (!tracker.hasSpawnedAt(bunkerPos)) {
-                var bounds = placer.placeStructure(level, bunkerPos);
-                if (bounds != null) {
-                    BunkerProtectionHandler.addBunkerBounds(bounds);
-                    tracker.addSpawnPos(bunkerPos);
-                }
+            template.placeInWorld(level, origin, origin, settings, level.random, 2);
             }
+        }
+
+        return origin;
+    }
+
+    private static void placeBunker(ServerLevel level, BlockPos impactPos) {
+        if (!ModList.get().isLoaded("worldedit")) {
+            return;
+        }
+
+        BlockPos bunkerPos = impactPos.offset(32, 0, 0);
+        bunkerPos = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, bunkerPos);
+
+        StructureSpawnTracker tracker = StructureSpawnTracker.get(level);
+        if (tracker.hasSpawnedAt(bunkerPos)) {
+            return;
+        }
+
+        AABB bounds = BUNKER_PLACER.placeStructure(level, bunkerPos);
+        if (bounds != null) {
+            BunkerProtectionHandler.addBunkerBounds(bounds);
+            tracker.addSpawnPos(bunkerPos);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add support for pasting the meteor impact crater from a WorldEdit `meteor_site` schematic while keeping the old template fallback
- reuse the crater center when spawning the companion bunker so the protection bounds follow the pasted build
- document where to place the new schematic so custom meteor sites load in game

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d2c03ee15083289b955fe73a1c6276