### PR TITLE
Handle malformed FAQ data gracefully

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/FAQ/FaqReloadListener.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/FAQ/FaqReloadListener.java
@@ -12,6 +12,8 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
+
 /**
  * Reload listener that populates the FAQ manager when data packs reload.
  */
@@ -32,11 +34,15 @@ public class FaqReloadListener extends SimpleJsonResourceReloadListener {
         for (Map.Entry<ResourceLocation, com.google.gson.JsonElement> entry : map.entrySet()) {
             try {
                 List<FaqEntry> entries = GSON.fromJson(entry.getValue(), LIST_TYPE);
+                if (entries == null || entries.isEmpty()) {
+                    LOGGER.warn("FAQ file '{}' did not contain any entries", entry.getKey());
+                    continue;
+                }
                 for (FaqEntry entryObj : entries) {
                     FaqManager.add(entryObj);
                 }
             } catch (Exception e) {
-                System.err.println("Failed to parse FAQ: " + entry.getKey() + "→ " + e.getMessage());
+                LOGGER.error("Failed to parse FAQ {}", entry.getKey(), e);
             }
         }
     }


### PR DESCRIPTION
## Summary
- guard FAQ reload processing from empty datasets and log issues with the mod logger
- make FAQ manager resilient to malformed entries by normalizing keys and skipping invalid data

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f121af01908328bc132b0c96abe1ea