### PR TITLE
Align cryo tube placement with player facing

### DIFF
--- a/src/main/resources/assets/wildernessodysseyapi/blockstates/cryo_tube.json
+++ b/src/main/resources/assets/wildernessodysseyapi/blockstates/cryo_tube.json
@@ -1,5 +1,8 @@
 {
   "variants": {
-    "": { "model": "wildernessodysseyapi:block/cryo_tube" }
+    "facing=north": { "model": "wildernessodysseyapi:block/cryo_tube" },
+    "facing=south": { "model": "wildernessodysseyapi:block/cryo_tube", "y": 180 },
+    "facing=west": { "model": "wildernessodysseyapi:block/cryo_tube", "y": 270 },
+    "facing=east": { "model": "wildernessodysseyapi:block/cryo_tube", "y": 90 }
   }
 }


### PR DESCRIPTION
## Summary
- add a horizontal facing property to the cryo tube so it orients itself toward the player on placement
- rotate the sleeping player to match the tube while keeping them standing in the pod
- add facing variants to the cryo tube blockstate so the model rotates correctly

## Testing
- `./gradlew build --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68f158c50c3c83288b8dd1e92addd484