### PR TITLE
Ensure bunker cryo tubes exist and add debug spawn override

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Spawn Behavior:
 ----------
 Players spawn inside a cryo tube when joining the world for the first time. Leaving the tube prevents re-entry.
 An introductory title sequence plays as they wake, which can be replaced with a custom cinematic in the future.
+Set `bunker.debugIgnoreCryoTubeSpawns` to `true` in the common config when testing to bypass the cryo tubes and drop
+players at a random safe location inside the bunker instead.
 
 Custom Assets
 -------------
@@ -50,9 +52,10 @@ World Generation
 The bunker now spawns via the normal world generation pipeline. Two config options
 control its frequency:
 `bunker.spawnDistanceChunks` sets the minimum chunk distance between bunkers and
-`bunker.maxSpawnCount` limits how many bunkers can generate per world.
+`bunker.maxSpawnCount` limits how many bunkers can generate per world. Bunker schematics are
+validated to ensure at least one cryo tube is present, and any missing tubes are restored after placement.
 
-The meteor impact zone structure is generated when a new world loads, creating a crater and a bunker nearby.
+Multiple meteor impact zones are generated the first time a new world loads, each roughly 1,000 chunks (16,000 blocks) apart to encourage long-range exploration. A single bunker is placed adjacent to one of these craters to serve as the player's first destination.
 Secret Order villages may rarely appear in jungle biomes, using the bundled schematic.
 
 Using Data Pack Schematics
@@ -65,11 +68,11 @@ loaded from the data pack when structures generate. If a matching data pack file
 is not found, the bundled schematic under
 `assets/<namespace>/schematics/` is used instead.
 
-The meteor impact site looks for the `wildernessodysseyapi:meteor_site`
+The meteor impact site looks for the `wildernessodysseyapi:impact_zone`
 schematic. Drop your finished WorldEdit build at
-`data/wildernessodysseyapi/structures/meteor_site.schem` (or bundle it under
-`assets/wildernessodysseyapi/schematics/`) so the crash crater is pasted before
-the bunker generates.
+`data/wildernessodysseyapi/structures/impact_zone.schem` (or bundle it under
+`assets/wildernessodysseyapi/schematics/`) so the crash craters are pasted
+before the bunker generates.
 
 Loot tables defined inside schematics work the same way as with vanilla
 `nbt` structures. The scanner now detects loot table references in both

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerProtectionHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerProtectionHandler.java
@@ -12,6 +12,8 @@ import net.neoforged.neoforge.event.level.BlockEvent;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
@@ -36,6 +38,13 @@ public class BunkerProtectionHandler {
      */
     public static void addBunkerBounds(AABB bounds) {
         bunkerBounds.add(bounds);
+    }
+
+    /**
+     * @return immutable view of all known bunker bounds.
+     */
+    public static List<AABB> getBunkerBounds() {
+        return Collections.unmodifiableList(bunkerBounds);
     }
 
     /** Checks if the given position is inside any bunker bounds. */

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
@@ -20,8 +20,10 @@ import com.thunder.wildernessodysseyapi.WorldGen.schematic.SchematicManager;
 import net.neoforged.fml.ModList;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.phys.AABB;
 
 import java.io.InputStream;
@@ -31,6 +33,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
 
 /**
  * The type World edit structure placer.
@@ -43,6 +46,7 @@ public class WorldEditStructurePlacer {
     private static boolean missingLogged = false;
     private static final Set<ResourceLocation> missingSchematicsLogged = new HashSet<>();
     private static final Set<ResourceLocation> missingCryoTubeLogged = new HashSet<>();
+    private static final ResourceLocation CRYO_TUBE_ID = ResourceLocation.tryBuild(MOD_ID, "cryo_tube");
 
     /**
      * Instantiates a new World edit structure placer.
@@ -175,6 +179,16 @@ public class WorldEditStructurePlacer {
                 editSession.flushSession();
             }
             if (cryoTubes != null && !cryoTubes.isEmpty()) {
+                if (CRYO_TUBE_ID != null) {
+                    Block cryoBlock = BuiltInRegistries.BLOCK.getOptional(CRYO_TUBE_ID).orElse(null);
+                    if (cryoBlock != null) {
+                        for (BlockPos cryoPos : cryoTubes) {
+                            if (!world.getBlockState(cryoPos).is(cryoBlock)) {
+                                world.setBlockAndUpdate(cryoPos, cryoBlock.defaultBlockState());
+                            }
+                        }
+                    }
+                }
                 CryoSpawnData data = CryoSpawnData.get(world);
                 data.addAll(cryoTubes);
                 PlayerSpawnHandler.setSpawnBlocks(data.getPositions());

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/configurable/StructureConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/configurable/StructureConfig.java
@@ -17,6 +17,8 @@ public class StructureConfig {
     public static final ModConfigSpec.IntValue BUNKER_MIN_DISTANCE;
     /** Maximum bunkers allowed in a world */
     public static final ModConfigSpec.IntValue BUNKER_MAX_COUNT;
+    /** Debug toggle to bypass cryo tube spawning */
+    public static final ModConfigSpec.BooleanValue DEBUG_IGNORE_CRYO_TUBE;
 
     private static final HashMap<String, BooleanValue> STRUCTURES = new HashMap<>();
     private static final HashMap<String, BooleanValue> POIS = new HashMap<>();
@@ -28,6 +30,10 @@ public class StructureConfig {
                 .defineInRange("spawnDistanceChunks", 12000, 1, Integer.MAX_VALUE);
         BUNKER_MAX_COUNT = BUILDER.comment("Maximum number of bunkers generated per world")
                 .defineInRange("maxSpawnCount", 1, 0, Integer.MAX_VALUE);
+        DEBUG_IGNORE_CRYO_TUBE = BUILDER.comment(
+                        "If true, players spawn at a random position inside the bunker instead of inside cryo tubes."
+                )
+                .define("debugIgnoreCryoTubeSpawns", false);
         BUILDER.pop();
 
         registerAll();

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorImpactData.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorImpactData.java
@@ -3,9 +3,14 @@ package com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.saveddata.SavedData;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Stores the location of the meteor impact zone so other systems
@@ -13,33 +18,73 @@ import org.jetbrains.annotations.NotNull;
  */
 public class MeteorImpactData extends SavedData {
     private static final String DATA_NAME = "wo_meteor_location";
-    private long impactPos = Long.MIN_VALUE;
+    private final List<Long> impactPositions = new ArrayList<>();
+    private long bunkerPos = Long.MIN_VALUE;
 
     public MeteorImpactData() {}
 
     public MeteorImpactData(CompoundTag tag, HolderLookup.Provider registries) {
-        if (tag.contains("pos")) {
-            impactPos = tag.getLong("pos");
+        if (tag.contains("positions", Tag.TAG_LONG_ARRAY)) {
+            long[] arr = tag.getLongArray("positions");
+            for (long entry : arr) {
+                impactPositions.add(entry);
+            }
+        } else if (tag.contains("pos")) {
+            impactPositions.add(tag.getLong("pos"));
+        }
+
+        if (tag.contains("bunker")) {
+            bunkerPos = tag.getLong("bunker");
         }
     }
 
     @Override
     public @NotNull CompoundTag save(@NotNull CompoundTag tag, HolderLookup.@NotNull Provider registries) {
-        tag.putLong("pos", impactPos);
+        tag.putLongArray("positions", impactPositions.stream().mapToLong(Long::longValue).toArray());
+        if (bunkerPos != Long.MIN_VALUE) {
+            tag.putLong("bunker", bunkerPos);
+        }
         return tag;
     }
 
-    /** Set the impact position and mark the data dirty. */
-    public void setImpactPos(BlockPos pos) {
-        impactPos = pos.asLong();
+    /** Set all known impact positions and mark the data dirty. */
+    public void setImpactPositions(List<BlockPos> positions) {
+        impactPositions.clear();
+        for (BlockPos pos : positions) {
+            impactPositions.add(pos.asLong());
+        }
         setDirty();
     }
 
     /**
-     * @return the stored impact position or null if not yet set.
+     * @return immutable list of stored impact positions.
      */
-    public BlockPos getImpactPos() {
-        return impactPos == Long.MIN_VALUE ? null : BlockPos.of(impactPos);
+    public List<BlockPos> getImpactPositions() {
+        List<BlockPos> positions = new ArrayList<>(impactPositions.size());
+        for (long entry : impactPositions) {
+            positions.add(BlockPos.of(entry));
+        }
+        return Collections.unmodifiableList(positions);
+    }
+
+    /**
+     * @return {@code true} if at least one impact position has been recorded.
+     */
+    public boolean hasImpactPositions() {
+        return !impactPositions.isEmpty();
+    }
+
+    /** Store the bunker location and mark the data dirty. */
+    public void setBunkerPos(BlockPos pos) {
+        bunkerPos = pos.asLong();
+        setDirty();
+    }
+
+    /**
+     * @return the stored bunker position or {@code null} if not yet set.
+     */
+    public BlockPos getBunkerPos() {
+        return bunkerPos == Long.MIN_VALUE ? null : BlockPos.of(bunkerPos);
     }
 
     /** Retrieve the data instance for the given world. */


### PR DESCRIPTION
## Summary
- add a debug config option to bypass cryo-tube spawning and drop players at a safe random location inside the bunker
- verify bunker schematics provide cryo tubes, restoring missing tubes during placement and caching the resulting spawn points
- expose bunker bounds for spawn logic, update world spawn selection, and document the new configuration behavior

## Testing
- ./gradlew --console=plain compileJava

------
https://chatgpt.com/codex/tasks/task_e_68f1a458402c83288c722b172f4a9181