### PR TITLE
Handle headless environments for mod diff viewer

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModListTracker/commands/ModListDiffCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModListTracker/commands/ModListDiffCommand.java
@@ -7,7 +7,11 @@ import com.thunder.wildernessodysseyapi.ModListTracker.gui.ModDiffViewer;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
+
+import java.awt.GraphicsEnvironment;
 import java.util.List;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
 
 /**
  * Command to display mod list differences since last launch.
@@ -49,6 +53,14 @@ public class ModListDiffCommand {
             if (!versionChange.isEmpty()) {
                 source.sendSuccess(() -> Component.literal("\u00A7b" + versionChange), false);
             }
+        }
+
+        if (GraphicsEnvironment.isHeadless()) {
+            LOGGER.info("Headless environment detected; skipping mod diff viewer GUI."
+                    + " Players can review logs/mod-changes.log for the full diff.");
+            source.sendSuccess(() -> Component.literal(
+                    "GUI not available on this server. Check logs/mod-changes.log for details."), false);
+            return;
         }
 
         new Thread(() -> javax.swing.SwingUtilities.invokeLater(ModDiffViewer::createAndShowGUI)).start();

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModListTracker/gui/ModDiffViewer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModListTracker/gui/ModDiffViewer.java
@@ -7,6 +7,8 @@ import java.io.*;
 import java.nio.file.*;
 import java.util.List;
 
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
+
 /**
  * Utility window for viewing logged mod list changes.
  */
@@ -17,6 +19,11 @@ public class ModDiffViewer {
      * Creates and shows the swing window displaying the diff log.
      */
     public static void createAndShowGUI() {
+        if (GraphicsEnvironment.isHeadless()) {
+            LOGGER.warn("Skipping mod diff viewer GUI because the environment is headless. See logs/mod-changes.log for details.");
+            return;
+        }
+
         JFrame frame = new JFrame("Mod List Differences");
         frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE); // Keep game running after closing GUI
         frame.setSize(600, 400);


### PR DESCRIPTION
## Summary
- guard the mod diff viewer against headless environments and log a warning instead of throwing an exception
- notify command callers on headless servers that the GUI is unavailable and point them to the log file

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f247b9f4608328a233218270ef9dc8