### PR TITLE
Fix debugIgnoreCryoTubeSpawns bypass logic

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/PlayerSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/PlayerSpawnHandler.java
@@ -56,7 +56,7 @@ public class PlayerSpawnHandler {
 
         if (StructureConfig.DEBUG_IGNORE_CRYO_TUBE.get()) {
             if (!tag.getBoolean(CRYO_USED_TAG)) {
-                BlockPos debugSpawn = findRandomBunkerSpawn(player);
+                BlockPos debugSpawn = findRandomBunkerSpawn(player.serverLevel());
                 if (debugSpawn != null) {
                     playIntroCinematic(player);
                     teleportPlayer(player, debugSpawn);
@@ -164,8 +164,7 @@ public class PlayerSpawnHandler {
                 player.getXRot());
     }
 
-    private static BlockPos findRandomBunkerSpawn(ServerPlayer player) {
-        ServerLevel level = player.serverLevel();
+    public static BlockPos findRandomBunkerSpawn(ServerLevel level) {
         List<AABB> bounds = BunkerProtectionHandler.getBunkerBounds();
         if (bounds.isEmpty()) {
             return null;

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
@@ -90,8 +90,13 @@ public class WorldSpawnHandler {
                 world.setDefaultSpawnPos(spawnBlockPos.above(), 0.0F);
             } else {
                 PlayerSpawnHandler.setSpawnBlocks(spawnBlockPositions);
-                BlockPos debugSpawnAnchor = meteorPos != null ? meteorPos : spawnBlockPos;
-                world.setDefaultSpawnPos(debugSpawnAnchor.above(), 0.0F);
+                BlockPos debugSpawn = PlayerSpawnHandler.findRandomBunkerSpawn(world);
+                if (debugSpawn != null) {
+                    world.setDefaultSpawnPos(debugSpawn, 0.0F);
+                } else {
+                    BlockPos debugSpawnAnchor = meteorPos != null ? meteorPos : spawnBlockPos;
+                    world.setDefaultSpawnPos(debugSpawnAnchor.above(), 0.0F);
+                }
             }
         } else {
             PlayerSpawnHandler.setSpawnBlocks(Collections.emptyList());


### PR DESCRIPTION
## Summary
- reuse the bunker spawn search when ignoring cryo tubes so world spawn moves away from cryo pods
- expose the bunker spawn helper so both the world and player spawn handlers can use the same logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2dcd884f08328af0b7a213de0c2c4