### PR TITLE
Fix WorldEdit readiness timeout check

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
@@ -79,15 +79,13 @@ public class WorldEditStructurePlacer {
      */
     public AABB placeStructure(ServerLevel world, BlockPos position) {
         try {
-            if (world.getGameTime() > MAX_WORLD_AGE_TICKS) {
-                if (!placementWindowLogged) {
-                    LOGGER.warn("Skipping placement of {} because the 5 minute placement window has expired", id);
-                    placementWindowLogged = true;
-                }
-                return null;
-            }
             if (!isWorldEditReady()) {
-                if (!missingLogged) {
+                if (world.getGameTime() > MAX_WORLD_AGE_TICKS) {
+                    if (!placementWindowLogged) {
+                        LOGGER.warn("Skipping placement of {} because the 5 minute placement window has expired", id);
+                        placementWindowLogged = true;
+                    }
+                } else if (!missingLogged) {
                     LOGGER.warn("WorldEdit not initialized (block registry not ready); skipping placement of {}", id);
                     missingLogged = true;
                 }


### PR DESCRIPTION
## Summary
- ensure the WorldEdit placement timeout only applies while waiting for the plugin to finish initializing

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f2e46e366c8328ab75b1ad3b117dc8