### PR TITLE
Add client command to auto-configure Iris shaders

### DIFF
--- a/src/main/java/com/wildernessodyssey/client/WildernessOdysseyClient.java
+++ b/src/main/java/com/wildernessodyssey/client/WildernessOdysseyClient.java
@@ -1,6 +1,7 @@
 package com.wildernessodyssey.client;
 
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.wildernessodyssey.client.command.AutoShaderCommand;
 import com.wildernessodyssey.client.gui.HardwareRequirementScreen;
 import com.wildernessodyssey.client.hardware.HardwareRequirementChecker;
 import com.wildernessodyssey.client.hardware.HardwareRequirementConfig;
@@ -50,12 +51,18 @@ public final class WildernessOdysseyClient {
         public static void registerClientCommands(RegisterClientCommandsEvent event) {
             event.getDispatcher().register(Commands.literal("hardwarecheck")
                 .executes(context -> executeOpenScreen(context.getSource())));
+            event.getDispatcher().register(Commands.literal("autoshader")
+                .executes(context -> executeAutoShader(context.getSource())));
         }
 
         private static int executeOpenScreen(CommandSourceStack source) {
             openHardwareScreen();
             source.sendSuccess(() -> Component.translatable("command.wildernessodyssey.hardware.open"), true);
             return 1;
+        }
+
+        private static int executeAutoShader(CommandSourceStack source) {
+            return AutoShaderCommand.execute(source, getOrCreateChecker());
         }
     }
 }

--- a/src/main/java/com/wildernessodyssey/client/command/AutoShaderCommand.java
+++ b/src/main/java/com/wildernessodyssey/client/command/AutoShaderCommand.java
@@ -1,0 +1,154 @@
+package com.wildernessodyssey.client.command;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.wildernessodyssey.client.hardware.HardwareRequirementChecker;
+import com.wildernessodyssey.client.hardware.HardwareRequirementConfig;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+import net.neoforged.fml.loading.FMLPaths;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumMap;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+/**
+ * Client-side command that chooses the appropriate shader pack for the
+ * current hardware tier and updates Iris' configuration to use it.
+ */
+public final class AutoShaderCommand {
+    private AutoShaderCommand() {
+    }
+
+    public static int execute(CommandSourceStack source, HardwareRequirementChecker checker) {
+        EnumMap<HardwareRequirementConfig.Tier, HardwareRequirementChecker.TierEvaluation> evaluations =
+            checker.evaluateAll(checker.getSnapshot());
+
+        Optional<HardwareRequirementConfig.Tier> maybeTier = selectTier(evaluations);
+        if (maybeTier.isEmpty()) {
+            source.sendFailure(Component.translatable("command.wildernessodyssey.autoshader.no_match"));
+            return 0;
+        }
+
+        HardwareRequirementConfig.Tier tier = maybeTier.get();
+        Optional<HardwareRequirementConfig.HardwareRequirementTier> tierConfig = checker.config().getTier(tier);
+        if (tierConfig.isEmpty() || tierConfig.get().shaderPack().isEmpty()) {
+            source.sendFailure(Component.translatable("command.wildernessodyssey.autoshader.no_shader", tierComponent(tier)));
+            return 0;
+        }
+
+        String desiredShaderPack = tierConfig.get().shaderPack().orElseThrow();
+        ResolvedShaderPack resolved = resolveShaderPack(desiredShaderPack);
+
+        try {
+            updateIrisConfiguration(resolved.fileName());
+        } catch (IOException ex) {
+            ModConstants.LOGGER.error("Failed to update Iris configuration", ex);
+            source.sendFailure(Component.translatable("command.wildernessodyssey.autoshader.write_error", ex.getMessage()));
+            return 0;
+        }
+
+        ModConstants.LOGGER.info("Auto shader command selected '{}' for tier {}", resolved.fileName(), tier.name());
+        source.sendSuccess(() -> Component.translatable("command.wildernessodyssey.autoshader.success",
+            resolved.fileName(), tierComponent(tier)), false);
+
+        if (!resolved.exists()) {
+            source.sendSuccess(() -> Component.translatable("command.wildernessodyssey.autoshader.pack_missing", desiredShaderPack), false);
+        }
+
+        return 1;
+    }
+
+    private static Optional<HardwareRequirementConfig.Tier> selectTier(
+        EnumMap<HardwareRequirementConfig.Tier, HardwareRequirementChecker.TierEvaluation> evaluations) {
+        HardwareRequirementConfig.Tier[] tiers = HardwareRequirementConfig.Tier.values();
+        for (int i = tiers.length - 1; i >= 0; i--) {
+            HardwareRequirementConfig.Tier tier = tiers[i];
+            HardwareRequirementChecker.TierEvaluation evaluation = evaluations.get(tier);
+            if (evaluation != null && evaluation.meets()) {
+                return Optional.of(tier);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static ResolvedShaderPack resolveShaderPack(String desiredShaderPack) {
+        Path shaderpacksDir = FMLPaths.GAMEDIR.get().resolve("shaderpacks");
+        if (!Files.isDirectory(shaderpacksDir)) {
+            return new ResolvedShaderPack(desiredShaderPack, false);
+        }
+
+        String desiredNormalized = normalizeShaderName(desiredShaderPack);
+
+        try (Stream<Path> stream = Files.list(shaderpacksDir)) {
+            Path exact = stream
+                .filter(path -> Files.isRegularFile(path) || Files.isDirectory(path))
+                .filter(path -> path.getFileName().toString().equalsIgnoreCase(desiredShaderPack))
+                .findFirst()
+                .orElse(null);
+            if (exact != null) {
+                return new ResolvedShaderPack(exact.getFileName().toString(), true);
+            }
+        } catch (IOException ex) {
+            ModConstants.LOGGER.warn("Unable to scan shaderpacks directory for '{}'", desiredShaderPack, ex);
+            return new ResolvedShaderPack(desiredShaderPack, false);
+        }
+
+        try (Stream<Path> stream = Files.list(shaderpacksDir)) {
+            return stream
+                .filter(path -> Files.isRegularFile(path) || Files.isDirectory(path))
+                .map(path -> path.getFileName().toString())
+                .filter(name -> normalizeShaderName(name).equals(desiredNormalized))
+                .findFirst()
+                .map(name -> new ResolvedShaderPack(name, true))
+                .orElseGet(() -> new ResolvedShaderPack(desiredShaderPack, false));
+        } catch (IOException ex) {
+            ModConstants.LOGGER.warn("Unable to scan shaderpacks directory for '{}'", desiredShaderPack, ex);
+            return new ResolvedShaderPack(desiredShaderPack, false);
+        }
+    }
+
+    private static void updateIrisConfiguration(String shaderPack) throws IOException {
+        Path configDir = FMLPaths.CONFIGDIR.get();
+        Path irisConfig = configDir.resolve("iris.properties");
+
+        Properties properties = new Properties();
+        if (Files.exists(irisConfig)) {
+            try (Reader reader = Files.newBufferedReader(irisConfig, StandardCharsets.UTF_8)) {
+                properties.load(reader);
+            }
+        }
+
+        properties.setProperty("shaderPack", shaderPack);
+        properties.setProperty("enableShaders", "true");
+
+        Files.createDirectories(configDir);
+        try (Writer writer = Files.newBufferedWriter(irisConfig, StandardCharsets.UTF_8)) {
+            properties.store(writer, "Updated by Wilderness Odyssey auto shader command");
+        }
+    }
+
+    private static Component tierComponent(HardwareRequirementConfig.Tier tier) {
+        return Component.translatable("hardware.wildernessodyssey.tier." + tier.name().toLowerCase(Locale.ROOT));
+    }
+
+    private static String normalizeShaderName(String name) {
+        String trimmed = stripExtension(name).trim().toLowerCase(Locale.ROOT);
+        return trimmed.replaceAll("[\\s_-]+", " ");
+    }
+
+    private static String stripExtension(String name) {
+        int dotIndex = name.lastIndexOf('.');
+        return dotIndex > 0 ? name.substring(0, dotIndex) : name;
+    }
+
+    private record ResolvedShaderPack(String fileName, boolean exists) {
+    }
+}

--- a/src/main/resources/assets/wildernessodyssey/lang/en_us.json
+++ b/src/main/resources/assets/wildernessodyssey/lang/en_us.json
@@ -23,5 +23,10 @@
   "hardware.wildernessodyssey.status.partial": "Unable to fully verify the %s requirements (%s).",
   "hardware.wildernessodyssey.status.warning": "Your system does not meet the %s requirements (%s).",
   "screen.wildernessodyssey.hardware.requirement.shaderpack": "\u2022 Recommended Iris shader pack: %s",
-  "command.wildernessodyssey.hardware.open": "Opened the hardware requirement summary"
+  "command.wildernessodyssey.hardware.open": "Opened the hardware requirement summary",
+  "command.wildernessodyssey.autoshader.success": "Enabled Iris shaders using %s for the %s tier.",
+  "command.wildernessodyssey.autoshader.no_match": "Unable to determine a compatible hardware tier; Iris shaders were not changed.",
+  "command.wildernessodyssey.autoshader.no_shader": "No shader recommendation is configured for the %s tier.",
+  "command.wildernessodyssey.autoshader.write_error": "Failed to update Iris configuration: %s",
+  "command.wildernessodyssey.autoshader.pack_missing": "Recommended shader pack '%s' is not installed; saved preference anyway."
 }


### PR DESCRIPTION
## Summary
- add an `AutoShaderCommand` that evaluates the detected hardware tier and writes the recommended shader pack into `iris.properties`
- register a new `/autoshader` client command and extend the localization strings used for status messaging

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68f5643215f083288d8cbaa34512086d