### PR TITLE
Relocate hardware summary Done button to avoid overlapping text

### DIFF
--- a/src/main/java/com/wildernessodyssey/client/gui/HardwareRequirementScreen.java
+++ b/src/main/java/com/wildernessodyssey/client/gui/HardwareRequirementScreen.java
@@ -34,6 +34,8 @@ public class HardwareRequirementScreen extends Screen {
     private int contentLeft;
     private int contentRight;
 
+    private Button doneButton;
+
     public HardwareRequirementScreen(HardwareRequirementChecker checker) {
         super(Component.translatable("screen.wildernessodyssey.hardware.title"));
         this.checker = Objects.requireNonNull(checker);
@@ -44,8 +46,8 @@ public class HardwareRequirementScreen extends Screen {
         snapshot = checker.refresh();
         evaluations = checker.evaluateAll(snapshot);
 
-        addRenderableWidget(Button.builder(Component.translatable("gui.done"), button -> onClose())
-            .bounds((this.width - 200) / 2, this.height - 40, 200, 20)
+        this.doneButton = addRenderableWidget(Button.builder(Component.translatable("gui.done"), button -> onClose())
+            .bounds(0, 0, 120, 20)
             .build());
     }
 
@@ -58,6 +60,12 @@ public class HardwareRequirementScreen extends Screen {
         this.contentRight = this.width - 20;
         this.contentTop = 48;
         this.contentBottom = this.height - 60;
+
+        if (this.doneButton != null) {
+            int buttonX = this.contentRight - this.doneButton.getWidth();
+            int buttonY = this.contentTop - this.doneButton.getHeight() - 4;
+            this.doneButton.setPosition(buttonX, buttonY);
+        }
 
         if (this.contentBottom <= this.contentTop) {
             this.contentBottom = this.contentTop + 1;


### PR DESCRIPTION
## Summary
- store the hardware screen Done button so it can be repositioned dynamically
- move the button to the top-right corner above the scrollable summary content to keep text unobstructed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f57504edb08328a7f48eee2a6f3d21