### PR TITLE
Prevent hardware requirements screen from pausing the game

### DIFF
--- a/src/main/java/com/wildernessodyssey/client/gui/HardwareRequirementScreen.java
+++ b/src/main/java/com/wildernessodyssey/client/gui/HardwareRequirementScreen.java
@@ -46,6 +46,11 @@ public class HardwareRequirementScreen extends Screen {
     }
 
     @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+
+    @Override
     public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
         this.renderBackground(graphics, mouseX, mouseY, partialTick);
         graphics.drawCenteredString(this.font, this.title, this.width / 2, 20, 0xFFFFFF);


### PR DESCRIPTION
## Summary
- mark the hardware requirements screen as non-pausing so the world stays sharp in the background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f579f3fa0c83288110be2d6fcd4811