### PR TITLE
Fix hardware screen blur

### DIFF
--- a/src/main/java/com/wildernessodyssey/client/gui/HardwareRequirementScreen.java
+++ b/src/main/java/com/wildernessodyssey/client/gui/HardwareRequirementScreen.java
@@ -84,6 +84,11 @@ public class HardwareRequirementScreen extends Screen {
     }
 
     @Override
+    public void renderBackground(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        graphics.fillGradient(0, 0, this.width, this.height, 0xCC101010, 0xCC101010);
+    }
+
+    @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
         if (this.shouldCloseOnEsc() && keyCode == InputConstants.KEY_ESCAPE) {
             this.onClose();


### PR DESCRIPTION
## Summary
- override the hardware requirements screen background rendering to draw a semi-opaque gradient
- prevent the vanilla blur effect so the hardware summary appears crisp and readable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f596f8a5e483289d8ad4cd3ebb0d4a