### PR TITLE
Reset meteor and bunker placement state between worlds

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -29,6 +29,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
+import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorStructureSpawner;
 import net.minecraft.world.phys.AABB;
 import net.neoforged.fml.ModList;
@@ -137,7 +138,8 @@ public class WildernessOdysseyAPIMainModClass {
      */
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event){
-
+        MeteorStructureSpawner.resetState();
+        BunkerProtectionHandler.clear();
     }
 
     /**
@@ -194,7 +196,8 @@ public class WildernessOdysseyAPIMainModClass {
      */
     @SubscribeEvent
     public void onServerStopping(ServerStoppingEvent event) {
-
+        MeteorStructureSpawner.resetState();
+        BunkerProtectionHandler.clear();
     }
 
     private void onLoadComplete(FMLLoadCompleteEvent event) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerProtectionHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerProtectionHandler.java
@@ -41,6 +41,13 @@ public class BunkerProtectionHandler {
     }
 
     /**
+     * Clears all tracked bunker bounds. Intended for lifecycle resets.
+     */
+    public static void clear() {
+        bunkerBounds.clear();
+    }
+
+    /**
      * @return immutable view of all known bunker bounds.
      */
     public static List<AABB> getBunkerBounds() {

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
@@ -54,9 +54,7 @@ public class MeteorStructureSpawner {
 
     public static void tryPlace(ServerLevel level) {
         MeteorImpactData impactData = MeteorImpactData.get(level);
-        if (impactData.getBunkerPos() != null) {
-            placed = true;
-        }
+        placed = impactData.getBunkerPos() != null;
 
         if (placed) {
             return;
@@ -88,6 +86,12 @@ public class MeteorStructureSpawner {
         }
 
         placed = impactData.getBunkerPos() != null;
+    }
+
+    public static void resetState() {
+        placed = false;
+        forcedChunks.clear();
+        worldEditCountdownExpiryTick = -1L;
     }
 
     private static BlockPos placeMeteorSite(ServerLevel level, BlockPos origin) {


### PR DESCRIPTION
## Summary
- reset the meteor spawner's cached placement state so new worlds can generate the impact site and bunker
- clear tracked bunker protection bounds whenever the server starts or stops to avoid leaking coordinates across worlds
- expose a shared reset helper used by lifecycle events

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68f77ff53fa48328a36e609ed8e23236