### PR TITLE
Avoid recursive meteor placement scheduling

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -211,6 +211,7 @@ public class WildernessOdysseyAPIMainModClass {
         // Every server tick event
         // This is equivalent to the old "END" phase.
         MinecraftServer server = event.getServer();
+        MeteorStructureSpawner.tick(server);
         if (!event.hasTime()) return;
 
         if (++serverTickCounter >= LOG_INTERVAL) {


### PR DESCRIPTION
## Summary
- queue meteor placement retries and bunker deferrals on a tick-processed task list to avoid immediate recursion
- process queued placement tasks once per server tick and reset scheduling state alongside other placement bookkeeping

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f7e2bef03083289351d984f925ceb4