### PR TITLE
Schedule bunker placement via deferred task queue

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -26,7 +26,7 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
@@ -40,7 +40,7 @@ import net.neoforged.neoforge.event.AddReloadListenerEvent;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
-import net.neoforged.neoforge.event.level.LevelEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
@@ -161,15 +161,15 @@ public class WildernessOdysseyAPIMainModClass {
     }
 
     /**
-     * On world load.
+     * Schedule meteor and bunker placement shortly after the first player joins.
      *
-     * @param event the event
+     * @param event the login event
      */
     @SubscribeEvent
-    public void onWorldLoad(LevelEvent.Load event) {
-        if (!(event.getLevel() instanceof ServerLevel serverLevel)) return;
+    public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) return;
 
-        MeteorStructureSpawner.tryPlace(serverLevel);
+        MeteorStructureSpawner.scheduleInitialPlacement(player.serverLevel());
     }
     /**
      * On mob spawn.

--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -30,7 +30,9 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
+import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerStructureGenerator;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorStructureSpawner;
+import com.thunder.wildernessodysseyapi.WorldGen.util.DeferredTaskScheduler;
 import net.minecraft.world.phys.AABB;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.config.ModConfig;
@@ -140,6 +142,7 @@ public class WildernessOdysseyAPIMainModClass {
     public void onServerStarting(ServerStartingEvent event){
         MeteorStructureSpawner.resetState();
         BunkerProtectionHandler.clear();
+        BunkerStructureGenerator.resetDeferredState();
     }
 
     /**
@@ -198,6 +201,7 @@ public class WildernessOdysseyAPIMainModClass {
     public void onServerStopping(ServerStoppingEvent event) {
         MeteorStructureSpawner.resetState();
         BunkerProtectionHandler.clear();
+        BunkerStructureGenerator.resetDeferredState();
     }
 
     private void onLoadComplete(FMLLoadCompleteEvent event) {
@@ -211,7 +215,7 @@ public class WildernessOdysseyAPIMainModClass {
         // Every server tick event
         // This is equivalent to the old "END" phase.
         MinecraftServer server = event.getServer();
-        MeteorStructureSpawner.tick(server);
+        DeferredTaskScheduler.tick();
         if (!event.hasTime()) return;
 
         if (++serverTickCounter >= LOG_INTERVAL) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/events/WorldEvents.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/events/WorldEvents.java
@@ -12,8 +12,8 @@ public class WorldEvents {
     @SubscribeEvent
     public void onWorldLoad(LevelEvent.Load event) {
         if (event.getLevel() instanceof ServerLevel level) {
-            // Place the meteor impact zone and bunker when the world loads
-            MeteorStructureSpawner.tryPlace(level);
+            // Schedule the meteor impact zone and bunker shortly after the first player joins
+            MeteorStructureSpawner.scheduleInitialPlacement(level);
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/util/DeferredTaskScheduler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/util/DeferredTaskScheduler.java
@@ -1,0 +1,52 @@
+package com.thunder.wildernessodysseyapi.WorldGen.util;
+
+import net.minecraft.server.level.ServerLevel;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+/**
+ * Simple priority-queue-based scheduler for deferring structure placement work to future ticks.
+ */
+public final class DeferredTaskScheduler {
+    private static final PriorityQueue<ScheduledTask> TASKS =
+            new PriorityQueue<>(Comparator.comparingLong(ScheduledTask::runAtTick));
+    private static long currentTick = 0L;
+
+    private DeferredTaskScheduler() {
+    }
+
+    public static void schedule(ServerLevel level, Runnable action) {
+        schedule(level, action, 1);
+    }
+
+    public static void schedule(ServerLevel level, Runnable action, int delayTicks) {
+        Runnable enqueue = () -> {
+            long runAt = currentTick + Math.max(1, delayTicks);
+            TASKS.add(new ScheduledTask(runAt, action));
+        };
+
+        if (level.getServer().isSameThread()) {
+            enqueue.run();
+        } else {
+            level.getServer().execute(enqueue);
+        }
+    }
+
+    public static void tick() {
+        currentTick++;
+        while (!TASKS.isEmpty() && TASKS.peek().runAtTick() <= currentTick) {
+            ScheduledTask task = TASKS.poll();
+            if (task != null) {
+                task.action().run();
+            }
+        }
+    }
+
+    public static void clear() {
+        TASKS.clear();
+        currentTick = 0L;
+    }
+
+    private record ScheduledTask(long runAtTick, Runnable action) { }
+}


### PR DESCRIPTION
## Summary
- ensure bunker placement always runs on the deferred scheduler so it follows the post-login grace period
- add a bunker placement delay matching the initial login delay to prevent immediate world-load execution

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68fae36aca708328850ffc10b792eb89