### PR TITLE
Handle WorldEdit mod id variants for structure spawning

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -31,6 +31,7 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerStructureGenerator;
+import com.thunder.wildernessodysseyapi.WorldGen.util.WorldEditCompat;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorStructureSpawner;
 import com.thunder.wildernessodysseyapi.WorldGen.util.DeferredTaskScheduler;
 import net.minecraft.world.phys.AABB;
@@ -118,7 +119,7 @@ public class WildernessOdysseyAPIMainModClass {
             // ready, causing a NoClassDefFoundError and preventing WorldEdit from
             // loading later on. Simply log a message and allow WorldEdit to finish
             // bootstrapping naturally.
-            if (ModList.get().isLoaded("worldedit")) {
+            if (WorldEditCompat.isInstalled()) {
                 LOGGER.debug("WorldEdit detected; deferring BlockTypes usage until after startup");
             }
         });

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerStructureGenerator.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/BunkerStructureGenerator.java
@@ -4,6 +4,7 @@ import com.thunder.ticktoklib.TickTokHelper;
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Worldedit.WorldEditStructurePlacer;
 import com.thunder.wildernessodysseyapi.WorldGen.util.DeferredTaskScheduler;
+import com.thunder.wildernessodysseyapi.WorldGen.util.WorldEditCompat;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.configurable.StructureConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -13,8 +14,6 @@ import net.minecraft.world.phys.AABB;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.level.ChunkEvent;
-import net.neoforged.fml.ModList;
-
 import java.util.HashSet;
 import java.util.Set;
 
@@ -37,7 +36,7 @@ public class BunkerStructureGenerator {
 
     @SubscribeEvent
     public static void onChunkLoad(ChunkEvent.Load event) {
-        if (!ModList.get().isLoaded("worldedit")) return;
+        if (!WorldEditCompat.isInstalled()) return;
         if (!(event.getLevel() instanceof ServerLevel level)) return;
         if (!(event.getChunk() instanceof LevelChunk chunk)) return;
         if (isCountdownExpired(level)) return;

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/BunkerFeature.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/BunkerFeature.java
@@ -4,6 +4,7 @@ import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.StructureSpawnTracker;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Worldedit.WorldEditStructurePlacer;
+import com.thunder.wildernessodysseyapi.WorldGen.util.WorldEditCompat;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.configurable.StructureConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
@@ -13,8 +14,6 @@ import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
 import net.minecraft.world.phys.AABB;
-import net.neoforged.fml.ModList;
-
 /**
  * Feature that places the bunker structure during world generation.
  */
@@ -26,7 +25,7 @@ public class BunkerFeature extends Feature<NoneFeatureConfiguration> {
     @Override
     public boolean place(FeaturePlaceContext<NoneFeatureConfiguration> context) {
         LevelAccessor levelAccessor = context.level();
-        if (!ModList.get().isLoaded("worldedit")) return false;
+        if (!WorldEditCompat.isInstalled()) return false;
         if (!(levelAccessor instanceof ServerLevel level)) return false;
 
         BlockPos origin = context.origin();

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/SpawnBlock/WorldSpawnHandler.java
@@ -9,6 +9,7 @@ import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.StructureSpawnTracker;
 import com.thunder.wildernessodysseyapi.WorldGen.schematic.SchematicManager;
+import com.thunder.wildernessodysseyapi.WorldGen.util.WorldEditCompat;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.configurable.StructureConfig;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.structures.MeteorImpactData;
 import net.minecraft.core.BlockPos;
@@ -16,7 +17,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.level.LevelEvent;
 
@@ -143,7 +143,7 @@ public class WorldSpawnHandler {
     }
 
     private static List<BlockPos> rebuildSpawnCache(ServerLevel world) {
-        if (!ModList.get().isLoaded("worldedit")) {
+        if (!WorldEditCompat.isInstalled()) {
             return Collections.emptyList();
         }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Worldedit/WorldEditStructurePlacer.java
@@ -16,7 +16,7 @@ import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock.Play
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock.WorldSpawnHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.TerrainBlockReplacer;
 import com.thunder.wildernessodysseyapi.WorldGen.schematic.SchematicManager;
-import net.neoforged.fml.ModList;
+import com.thunder.wildernessodysseyapi.WorldGen.util.WorldEditCompat;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -197,7 +197,7 @@ public class WorldEditStructurePlacer {
         if (worldEditReady) {
             return true;
         }
-        if (!ModList.get().isLoaded("worldedit")) {
+        if (!WorldEditCompat.isInstalled()) {
             return false;
         }
         if (isBlockRegistryReady()) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/SecretOrderVillage/SecretOrderVillageGenerator.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/SecretOrderVillage/SecretOrderVillageGenerator.java
@@ -5,7 +5,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.level.ChunkEvent;
-import net.neoforged.fml.ModList;
+import com.thunder.wildernessodysseyapi.WorldGen.util.WorldEditCompat;
 
 import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
 
@@ -19,7 +19,7 @@ public class SecretOrderVillageGenerator {
      */
     @SubscribeEvent
     public static void onChunkLoad(ChunkEvent.Load event) {
-        if (!ModList.get().isLoaded("worldedit")) return;
+        if (!WorldEditCompat.isInstalled()) return;
         if (!(event.getLevel() instanceof ServerLevel level)) return;
         if (!(event.getChunk() instanceof LevelChunk chunk)) return;
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/util/WorldEditCompat.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/util/WorldEditCompat.java
@@ -1,0 +1,39 @@
+package com.thunder.wildernessodysseyapi.WorldGen.util;
+
+import net.neoforged.fml.ModList;
+
+import java.util.Set;
+
+/**
+ * Small helper to detect the presence of WorldEdit across the different
+ * variants that exist for NeoForge. Older builds ship the classic
+ * {@code worldedit} mod id while some nightlies briefly used
+ * {@code worldedit_neoforge}. Rather than hard coding a single string in
+ * every call site we centralise the logic here so future aliases can be added
+ * in one place.
+ */
+public final class WorldEditCompat {
+
+    private static final Set<String> KNOWN_MOD_IDS = Set.of(
+            "worldedit",
+            "worldedit_neoforge",
+            "enginehub_worldedit"
+    );
+
+    private WorldEditCompat() {
+    }
+
+    /**
+     * @return {@code true} if any known WorldEdit mod id is loaded.
+     */
+    public static boolean isInstalled() {
+        ModList modList = ModList.get();
+        for (String modId : KNOWN_MOD_IDS) {
+            if (modList.isLoaded(modId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
@@ -6,6 +6,7 @@ import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.StructureSpawnT
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock.WorldSpawnHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Worldedit.WorldEditStructurePlacer;
 import com.thunder.wildernessodysseyapi.WorldGen.util.DeferredTaskScheduler;
+import com.thunder.wildernessodysseyapi.WorldGen.util.WorldEditCompat;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.resources.ResourceKey;
@@ -24,8 +25,6 @@ import net.minecraft.core.Holder;
 import net.minecraft.tags.BiomeTags;
 
 import java.util.Set;
-import net.neoforged.fml.ModList;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -109,7 +108,7 @@ public class MeteorStructureSpawner {
             return;
         }
 
-        boolean worldEditLoaded = ModList.get().isLoaded("worldedit");
+        boolean worldEditLoaded = WorldEditCompat.isInstalled();
         boolean worldEditReady = !worldEditLoaded || WorldEditStructurePlacer.isWorldEditReady();
 
         if (worldEditLoaded && !worldEditReady) {
@@ -221,7 +220,7 @@ public class MeteorStructureSpawner {
     }
 
     private static PlacementState placeBunker(ServerLevel level, BlockPos impactPos, MeteorImpactData impactData) {
-        if (!ModList.get().isLoaded("worldedit")) {
+        if (!WorldEditCompat.isInstalled()) {
             if (!missingWorldEditLogged) {
                 ModConstants.LOGGER.warn("WorldEdit is required to place the bunker structure; skipping placement");
                 missingWorldEditLogged = true;


### PR DESCRIPTION
## Summary
- add a WorldEditCompat utility that recognises the different NeoForge WorldEdit mod ids
- update structure placement and spawn handlers to rely on the shared detection helper so meteor sites, bunkers, and the secret village still run when WorldEdit is present

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ff97785ef48328b8b1f2355db1fb4d