### PR TITLE
Enhance structure block capture behaviour

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -1,0 +1,123 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.thunder.wildernessodysseyapi.util.StructureBlockSettings;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Vec3i;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.entity.StructureBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.StructureMode;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Expands the structure block capture size and automatically snaps the save area to the occupied blocks.
+ */
+@Mixin(StructureBlockEntity.class)
+public abstract class StructureBlockEntityMixin extends BlockEntity {
+
+    @Shadow @Final @Mutable private static int MAX_OFFSET_PER_AXIS;
+    @Shadow @Final @Mutable private static int MAX_SIZE_PER_AXIS;
+
+    @Shadow private BlockPos structurePos;
+    @Shadow private Vec3i structureSize;
+
+    @Shadow public abstract void setStructurePos(BlockPos pos);
+    @Shadow public abstract void setStructureSize(Vec3i size);
+    @Shadow public abstract StructureMode getMode();
+
+    protected StructureBlockEntityMixin(BlockEntityType<?> type, BlockPos pos, BlockState state) {
+        super(type, pos, state);
+    }
+
+    @Inject(method = "<clinit>", at = @At("RETURN"))
+    private static void wildernessodysseyapi$expandLimits(CallbackInfo ci) {
+        MAX_SIZE_PER_AXIS = StructureBlockSettings.MAX_STRUCTURE_SIZE;
+        MAX_OFFSET_PER_AXIS = StructureBlockSettings.MAX_STRUCTURE_OFFSET;
+    }
+
+    @Inject(method = "saveStructure", at = @At("HEAD"))
+    private void wildernessodysseyapi$autoFitStructure(boolean keepAir, CallbackInfoReturnable<Boolean> cir) {
+        Level level = this.level;
+        if (!(level instanceof ServerLevel serverLevel)) {
+            return;
+        }
+        if (this.getMode() != StructureMode.SAVE) {
+            return;
+        }
+
+        if (this.structureSize.getX() <= 0 || this.structureSize.getY() <= 0 || this.structureSize.getZ() <= 0) {
+            return;
+        }
+
+        BlockPos blockPos = this.getBlockPos();
+        BlockPos start = blockPos.offset(this.structurePos);
+        BlockPos end = start.offset(this.structureSize.getX() - 1, this.structureSize.getY() - 1, this.structureSize.getZ() - 1);
+
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        boolean found = false;
+        int minX = Integer.MAX_VALUE;
+        int minY = Integer.MAX_VALUE;
+        int minZ = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        int maxY = Integer.MIN_VALUE;
+        int maxZ = Integer.MIN_VALUE;
+
+        for (int x = start.getX(); x <= end.getX(); x++) {
+            for (int y = start.getY(); y <= end.getY(); y++) {
+                for (int z = start.getZ(); z <= end.getZ(); z++) {
+                    cursor.set(x, y, z);
+                    if (!StructureBlockSettings.isStructureContent(serverLevel.getBlockState(cursor))) {
+                        continue;
+                    }
+                    if (cursor.equals(blockPos)) {
+                        continue;
+                    }
+                    found = true;
+                    if (x < minX) {
+                        minX = x;
+                    }
+                    if (y < minY) {
+                        minY = y;
+                    }
+                    if (z < minZ) {
+                        minZ = z;
+                    }
+                    if (x > maxX) {
+                        maxX = x;
+                    }
+                    if (y > maxY) {
+                        maxY = y;
+                    }
+                    if (z > maxZ) {
+                        maxZ = z;
+                    }
+                }
+            }
+        }
+
+        if (!found) {
+            return;
+        }
+
+        BlockPos newStart = new BlockPos(minX, minY, minZ);
+        BlockPos newSize = new BlockPos(maxX - minX + 1, maxY - minY + 1, maxZ - minZ + 1);
+        BlockPos relativePos = newStart.subtract(blockPos);
+
+        if (!relativePos.equals(this.structurePos)) {
+            this.setStructurePos(relativePos);
+        }
+        if (!newSize.equals(this.structureSize)) {
+            this.setStructureSize(newSize);
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockSettings.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockSettings.java
@@ -1,0 +1,44 @@
+package com.thunder.wildernessodysseyapi.util;
+
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * Shared configuration for structure block enhancements.
+ */
+public final class StructureBlockSettings {
+    /**
+     * Expanded limit for structure block dimensions. Vanilla uses 48 blocks per axis which is too restrictive for
+     * the large set pieces shipped with the modpack, so we greatly increase the limit.
+     */
+    public static final int MAX_STRUCTURE_SIZE = 512;
+
+    /**
+     * Expanded limit for the offset from the structure block when capturing structures. Matching the size limit keeps
+     * the UI experience consistent and allows placing the controller block outside of large builds.
+     */
+    public static final int MAX_STRUCTURE_OFFSET = 512;
+
+    private StructureBlockSettings() {
+    }
+
+    /**
+     * Determines whether the scanned block should count towards the saved bounding box. Air, structure helpers and
+     * void markers are excluded so the automatic fitting logic ignores scaffolding and empty padding.
+     */
+    public static boolean isStructureContent(BlockState state) {
+        if (state.isAir()) {
+            return false;
+        }
+        if (state.is(Blocks.STRUCTURE_BLOCK) || state.is(Blocks.STRUCTURE_VOID)) {
+            return false;
+        }
+        // Ignore the various helper blocks that only exist to control jigsaw assembly.
+        if (state.is(Blocks.JIGSAW) || state.is(Blocks.BARRIER)) {
+            return false;
+        }
+        // Liquids should keep the bounding box even though the block is technically air when flowing, but every other
+        // remaining block should contribute to the capture volume.
+        return true;
+    }
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -8,7 +8,8 @@
       "CampfireBlockMixin",
       "DayNightCycleMixin",
       "EntityAccessor",
-      "WaterFluidMixin"
+      "WaterFluidMixin",
+      "StructureBlockEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary
- expand the structure block size/offset limits so large schematics can be saved without manual patching
- auto-fit structure block saves to the blocks actually present in the capture area to eliminate empty padding
- share configuration for the structure block tweaks and register the new mixin

## Testing
- `./gradlew compileJava`


------
https://chatgpt.com/codex/tasks/task_e_6900bc74dda08328afaa36948847758a