### PR TITLE
Fix StructureBlockEntity mixin initialization

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -14,6 +14,7 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -39,8 +40,15 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
         super(type, pos, state);
     }
 
-    @Inject(method = "<clinit>", at = @At("RETURN"))
-    private static void wildernessodysseyapi$expandLimits(CallbackInfo ci) {
+    @Unique
+    private static boolean wildernessodysseyapi$limitsExpanded;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void wildernessodysseyapi$expandLimits(BlockPos pos, BlockState state, CallbackInfo ci) {
+        if (wildernessodysseyapi$limitsExpanded) {
+            return;
+        }
+        wildernessodysseyapi$limitsExpanded = true;
         MAX_SIZE_PER_AXIS = StructureBlockSettings.MAX_STRUCTURE_SIZE;
         MAX_OFFSET_PER_AXIS = StructureBlockSettings.MAX_STRUCTURE_OFFSET;
     }


### PR DESCRIPTION
## Summary
- expand structure block limits from the constructor instead of a missing `<clinit>`
- guard the static reassignment with a unique flag so it only runs once

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_6900d158d6408328bd76ed34306383e3