### PR TITLE
Fix StructureBlock saveStructure injection signature

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -54,7 +54,7 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
     }
 
     @Inject(method = "saveStructure", at = @At("HEAD"))
-    private void wildernessodysseyapi$autoFitStructure(boolean keepAir, CallbackInfoReturnable<Boolean> cir) {
+    private void wildernessodysseyapi$autoFitStructure(CallbackInfoReturnable<Boolean> cir) {
         Level level = this.level;
         if (!(level instanceof ServerLevel serverLevel)) {
             return;


### PR DESCRIPTION
## Summary
- update the StructureBlock mixin's saveStructure injection to match the current method descriptor

## Testing
- ./gradlew build --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_6900d42b65a88328a06b81ce7d53ebc0