### PR TITLE
Improve structure block detection

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockSettings.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockSettings.java
@@ -19,6 +19,13 @@ public final class StructureBlockSettings {
      */
     public static final int MAX_STRUCTURE_OFFSET = 512;
 
+    /**
+     * Default radius used when the detect button runs without an existing bounding box. Scanning a generous
+     * 64-block radius keeps the operation responsive while still covering most medium-sized builds. Players can
+     * expand the configured size manually before detecting if their structure exceeds this area.
+     */
+    public static final int DEFAULT_DETECTION_RADIUS = 64;
+
     private StructureBlockSettings() {
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockSettings.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockSettings.java
@@ -20,11 +20,11 @@ public final class StructureBlockSettings {
     public static final int MAX_STRUCTURE_OFFSET = 512;
 
     /**
-     * Default radius used when the detect button runs without an existing bounding box. Scanning a generous
-     * 64-block radius keeps the operation responsive while still covering most medium-sized builds. Players can
-     * expand the configured size manually before detecting if their structure exceeds this area.
+     * Maximum diagonal search distance when looking for a corner block that defines the opposite corner of the
+     * structure. The requirement keeps the detection step deterministic without forcing players to place more than one
+     * helper block.
      */
-    public static final int DEFAULT_DETECTION_RADIUS = 64;
+    public static final int CORNER_SEARCH_RADIUS = 64;
 
     private StructureBlockSettings() {
     }


### PR DESCRIPTION
## Summary
- reuse the automatic bounding-box fitting for the detect button so corners are optional
- add a fallback search radius for detection when no manual bounding box is defined
- centralize the fitting logic to ensure both save and detect actions stay in sync

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_6900feaf059883289a5f0e54ffdc8b3b