### PR TITLE
Fix structure block corner placement shadow

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -9,6 +9,8 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.StructureBlock;
 import net.minecraft.world.level.block.state.properties.StructureMode;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -34,7 +36,11 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
 
     @Shadow public abstract void setStructurePos(BlockPos pos);
     @Shadow public abstract void setStructureSize(Vec3i size);
+    @Shadow @org.jetbrains.annotations.Nullable private String structureName;
+
     @Shadow public abstract StructureMode getMode();
+    @Shadow public abstract void setMode(StructureMode mode);
+    @Shadow public abstract void setStructureName(String name);
 
     protected StructureBlockEntityMixin(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -42,6 +48,9 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
 
     @Unique
     private static boolean wildernessodysseyapi$limitsExpanded;
+
+    @Unique
+    private final java.util.Set<BlockPos> wildernessodysseyapi$cornerMarkers = new java.util.HashSet<>();
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void wildernessodysseyapi$expandLimits(BlockPos pos, BlockState state, CallbackInfo ci) {
@@ -51,6 +60,114 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
         wildernessodysseyapi$limitsExpanded = true;
         MAX_SIZE_PER_AXIS = StructureBlockSettings.MAX_STRUCTURE_SIZE;
         MAX_OFFSET_PER_AXIS = StructureBlockSettings.MAX_STRUCTURE_OFFSET;
+    }
+
+    @Inject(method = "detectSize", at = @At("HEAD"), cancellable = true)
+    private void wildernessodysseyapi$scanSurroundingBlocks(CallbackInfoReturnable<Boolean> cir) {
+        Level level = this.level;
+        if (!(level instanceof ServerLevel serverLevel)) {
+            return;
+        }
+        if (this.getMode() != StructureMode.SAVE) {
+            return;
+        }
+
+        BlockPos blockPos = this.getBlockPos();
+        BlockPos currentOffset = this.structurePos == null ? BlockPos.ZERO : this.structurePos;
+        Vec3i currentSize = this.structureSize == null ? Vec3i.ZERO : this.structureSize;
+
+        int detectionRadius = StructureBlockSettings.DEFAULT_DETECTION_RADIUS;
+        detectionRadius = Math.max(detectionRadius, wildernessodysseyapi$computeRadiusForAxis(currentOffset.getX(), currentSize.getX()));
+        detectionRadius = Math.max(detectionRadius, wildernessodysseyapi$computeRadiusForAxis(currentOffset.getY(), currentSize.getY()));
+        detectionRadius = Math.max(detectionRadius, wildernessodysseyapi$computeRadiusForAxis(currentOffset.getZ(), currentSize.getZ()));
+        detectionRadius = Math.min(detectionRadius, StructureBlockSettings.MAX_STRUCTURE_OFFSET);
+        if (detectionRadius <= 0) {
+            return;
+        }
+
+        int minXBound = blockPos.getX() - detectionRadius;
+        int maxXBound = blockPos.getX() + detectionRadius;
+        int minZBound = blockPos.getZ() - detectionRadius;
+        int maxZBound = blockPos.getZ() + detectionRadius;
+        int minYBound = Math.max(serverLevel.getMinBuildHeight(), blockPos.getY() - detectionRadius);
+        int maxYBound = Math.min(serverLevel.getMaxBuildHeight() - 1, blockPos.getY() + detectionRadius);
+
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        boolean found = false;
+        int minX = Integer.MAX_VALUE;
+        int minY = Integer.MAX_VALUE;
+        int minZ = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        int maxY = Integer.MIN_VALUE;
+        int maxZ = Integer.MIN_VALUE;
+
+        for (int x = minXBound; x <= maxXBound; x++) {
+            for (int y = minYBound; y <= maxYBound; y++) {
+                for (int z = minZBound; z <= maxZBound; z++) {
+                    cursor.set(x, y, z);
+                    if (!StructureBlockSettings.isStructureContent(serverLevel.getBlockState(cursor))) {
+                        continue;
+                    }
+                    if (cursor.equals(blockPos)) {
+                        continue;
+                    }
+                    found = true;
+                    if (x < minX) {
+                        minX = x;
+                    }
+                    if (y < minY) {
+                        minY = y;
+                    }
+                    if (z < minZ) {
+                        minZ = z;
+                    }
+                    if (x > maxX) {
+                        maxX = x;
+                    }
+                    if (y > maxY) {
+                        maxY = y;
+                    }
+                    if (z > maxZ) {
+                        maxZ = z;
+                    }
+                }
+            }
+        }
+
+        if (!found) {
+            return;
+        }
+
+        BlockPos newStart = new BlockPos(minX, minY, minZ);
+        BlockPos newSize = new BlockPos(maxX - minX + 1, maxY - minY + 1, maxZ - minZ + 1);
+        BlockPos relativePos = newStart.subtract(blockPos);
+
+        boolean changed = false;
+        if (!relativePos.equals(this.structurePos)) {
+            this.setStructurePos(relativePos);
+            changed = true;
+        }
+        if (!newSize.equals(this.structureSize)) {
+            this.setStructureSize(newSize);
+            changed = true;
+        }
+
+        if (changed) {
+            this.setChanged();
+            BlockState state = this.getBlockState();
+            serverLevel.sendBlockUpdated(blockPos, state, state, 3);
+        }
+
+        wildernessodysseyapi$placeCornerBlocks(serverLevel, blockPos, newStart, newSize);
+
+        if (!changed) {
+            cir.setReturnValue(true);
+            cir.cancel();
+            return;
+        }
+
+        cir.setReturnValue(true);
+        cir.cancel();
     }
 
     @Inject(method = "saveStructure", at = @At("HEAD"))
@@ -126,6 +243,99 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
         }
         if (!newSize.equals(this.structureSize)) {
             this.setStructureSize(newSize);
+        }
+    }
+
+    @Unique
+    private static int wildernessodysseyapi$computeRadiusForAxis(int offset, int size) {
+        if (size <= 0) {
+            return Math.abs(offset);
+        }
+        int start = offset;
+        int end = offset + size - 1;
+        return Math.max(Math.abs(start), Math.abs(end));
+    }
+
+    @Unique
+    private void wildernessodysseyapi$placeCornerBlocks(ServerLevel serverLevel, BlockPos structureBlockPos, BlockPos minCorner, Vec3i size) {
+        String structureName = this.structureName;
+        if (structureName == null || structureName.isEmpty()) {
+            return;
+        }
+
+        BlockPos maxCorner = minCorner.offset(size.getX() - 1, size.getY() - 1, size.getZ() - 1);
+        java.util.List<BlockPos> bottomCorners = new java.util.ArrayList<>(4);
+        bottomCorners.add(new BlockPos(minCorner.getX(), minCorner.getY(), minCorner.getZ()));
+        bottomCorners.add(new BlockPos(maxCorner.getX(), minCorner.getY(), minCorner.getZ()));
+        bottomCorners.add(new BlockPos(minCorner.getX(), minCorner.getY(), maxCorner.getZ()));
+        bottomCorners.add(new BlockPos(maxCorner.getX(), minCorner.getY(), maxCorner.getZ()));
+
+        bottomCorners.sort(java.util.Comparator.comparingInt(pos -> pos.distManhattan(structureBlockPos)));
+
+        java.util.LinkedHashSet<BlockPos> desiredCorners = new java.util.LinkedHashSet<>();
+
+        for (int i = 1; i < bottomCorners.size() && desiredCorners.size() < 2; i++) {
+            BlockPos candidate = bottomCorners.get(i);
+            if (!candidate.equals(structureBlockPos)) {
+                desiredCorners.add(candidate);
+            }
+        }
+
+        if (size.getY() > 1) {
+            BlockPos topCorner = new BlockPos(maxCorner.getX(), maxCorner.getY(), maxCorner.getZ());
+            if (!topCorner.equals(structureBlockPos)) {
+                desiredCorners.add(topCorner);
+            }
+        }
+
+        if (desiredCorners.isEmpty()) {
+            return;
+        }
+
+        java.util.Set<BlockPos> retainedMarkers = new java.util.HashSet<>();
+
+        for (BlockPos target : desiredCorners) {
+            retainedMarkers.add(target.immutable());
+        }
+
+        java.util.Iterator<BlockPos> existing = this.wildernessodysseyapi$cornerMarkers.iterator();
+        while (existing.hasNext()) {
+            BlockPos tracked = existing.next();
+            if (retainedMarkers.contains(tracked)) {
+                continue;
+            }
+            BlockState state = serverLevel.getBlockState(tracked);
+            if (state.is(Blocks.STRUCTURE_BLOCK)) {
+                BlockEntity entity = serverLevel.getBlockEntity(tracked);
+                if (entity instanceof StructureBlockEntity structureBlockEntity && structureBlockEntity.getMode() == StructureMode.CORNER) {
+                    serverLevel.setBlock(tracked, Blocks.AIR.defaultBlockState(), 3);
+                }
+            }
+            existing.remove();
+        }
+
+        BlockState cornerState = Blocks.STRUCTURE_BLOCK.defaultBlockState().setValue(StructureBlock.MODE, StructureMode.CORNER);
+
+        for (BlockPos target : desiredCorners) {
+            if (!serverLevel.hasChunkAt(target)) {
+                continue;
+            }
+            BlockState state = serverLevel.getBlockState(target);
+            if (!state.isAir() && !state.is(Blocks.STRUCTURE_BLOCK) && !state.is(Blocks.STRUCTURE_VOID)) {
+                continue;
+            }
+            if (!state.is(cornerState.getBlock())) {
+                serverLevel.setBlock(target, cornerState, 3);
+            }
+            BlockEntity entity = serverLevel.getBlockEntity(target);
+            if (entity instanceof StructureBlockEntity structureBlockEntity) {
+                structureBlockEntity.setStructureName(structureName);
+                structureBlockEntity.setMode(StructureMode.CORNER);
+                structureBlockEntity.setStructurePos(BlockPos.ZERO);
+                structureBlockEntity.setStructureSize(Vec3i.ZERO);
+                structureBlockEntity.setChanged();
+            }
+            this.wildernessodysseyapi$cornerMarkers.add(target.immutable());
         }
     }
 }


### PR DESCRIPTION
## Summary
- shadow the structure name field so the mixin no longer targets a missing getter
- skip corner placement when the structure name is empty and set markers with the string setter

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_690106c92aa8832892f3893a1db3ad28