### PR TITLE
Fix StructureBlockEntity mixin for 1.21.1

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -37,10 +37,9 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
 
     @Shadow public abstract void setStructurePos(BlockPos pos);
     @Shadow public abstract void setStructureSize(Vec3i size);
-    @Shadow @org.jetbrains.annotations.Nullable private String structureName;
 
     @Shadow public abstract StructureMode getMode();
-    @Shadow @org.jetbrains.annotations.Nullable public abstract String getStructureName();
+    @Shadow @org.jetbrains.annotations.Nullable public abstract ResourceLocation getStructureName();
     @Shadow public abstract void setMode(StructureMode mode);
     @Shadow public abstract void setStructureName(ResourceLocation name);
 
@@ -260,12 +259,7 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
 
     @Unique
     private void wildernessodysseyapi$placeCornerBlocks(ServerLevel serverLevel, BlockPos structureBlockPos, BlockPos minCorner, Vec3i size) {
-        String structureNameRaw = this.getStructureName();
-        if (structureNameRaw == null || structureNameRaw.isEmpty()) {
-            return;
-        }
-
-        ResourceLocation structureName = ResourceLocation.tryParse(structureNameRaw);
+        ResourceLocation structureName = this.getStructureName();
         if (structureName == null) {
             return;
         }


### PR DESCRIPTION
## Summary
- align the StructureBlockEntity mixin shadows with Minecraft 1.21.1 by removing the obsolete String field and shadowing the ResourceLocation getter instead
- update corner placement helper to use the ResourceLocation returned by the structure block entity directly

## Testing
- ⚠️ `./gradlew --console=plain build` *(stalled during the Vineflower decompile step in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69011fc930e08328a262c53e6a7832da