### PR TITLE
Restore StructureBlockEntity mixin structureName shadow

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -34,13 +34,12 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
 
     @Shadow private BlockPos structurePos;
     @Shadow private Vec3i structureSize;
+    @Shadow @org.jetbrains.annotations.Nullable private ResourceLocation structureName;
 
     @Shadow public abstract void setStructurePos(BlockPos pos);
     @Shadow public abstract void setStructureSize(Vec3i size);
-    @Shadow @org.jetbrains.annotations.Nullable private String structureName;
 
     @Shadow public abstract StructureMode getMode();
-    @Shadow @org.jetbrains.annotations.Nullable public abstract String getStructureName();
     @Shadow public abstract void setMode(StructureMode mode);
     @Shadow public abstract void setStructureName(ResourceLocation name);
 
@@ -260,12 +259,7 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
 
     @Unique
     private void wildernessodysseyapi$placeCornerBlocks(ServerLevel serverLevel, BlockPos structureBlockPos, BlockPos minCorner, Vec3i size) {
-        String structureNameRaw = this.getStructureName();
-        if (structureNameRaw == null || structureNameRaw.isEmpty()) {
-            return;
-        }
-
-        ResourceLocation structureName = ResourceLocation.tryParse(structureNameRaw);
+        ResourceLocation structureName = this.structureName;
         if (structureName == null) {
             return;
         }


### PR DESCRIPTION
## Summary
- shadow the `StructureBlockEntity` ResourceLocation field for the structure name to match the 1.21.1 class layout
- read the shadowed field when propagating corner block state instead of invoking a non-existent ResourceLocation getter

## Testing
- ⚠️ `./gradlew --console=plain build` *(stalled during the Vineflower decompile step in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69011fc930e08328a262c53e6a7832da