### PR TITLE
Expand structure block load clamp

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -16,6 +16,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.StructureBlock;
 import net.minecraft.world.level.block.state.properties.StructureMode;
 import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.util.Mth;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -23,6 +24,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
@@ -65,6 +67,16 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
         wildernessodysseyapi$limitsExpanded = true;
         MAX_SIZE_PER_AXIS = StructureBlockSettings.MAX_STRUCTURE_SIZE;
         MAX_OFFSET_PER_AXIS = StructureBlockSettings.MAX_STRUCTURE_OFFSET;
+    }
+
+    @Redirect(method = "loadAdditional", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Mth;clamp(III)I"))
+    private int wildernessodysseyapi$expandClampRange(int value, int min, int max) {
+        if (min < 0) {
+            int limit = StructureBlockSettings.MAX_STRUCTURE_OFFSET;
+            return Mth.clamp(value, -limit, limit);
+        }
+        int limit = StructureBlockSettings.MAX_STRUCTURE_SIZE;
+        return Mth.clamp(value, 0, limit);
     }
 
     @Inject(method = "detectSize", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
## Summary
- expand the structure block load clamping logic to honor the expanded 512-block limits

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_69017283c6d48328a75f142fa00d8aba