### PR TITLE
Improve structure block overlay visibility

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockRendererMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockRendererMixin.java
@@ -1,0 +1,57 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.thunder.wildernessodysseyapi.util.StructureBlockSettings;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.StructureBlockRenderer;
+import net.minecraft.world.level.block.entity.StructureBlockEntity;
+import net.minecraft.world.level.block.state.properties.StructureMode;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(StructureBlockRenderer.class)
+public abstract class StructureBlockRendererMixin {
+
+    @Unique
+    private boolean wildernessodysseyapi$depthForced;
+
+    @Inject(method = "render(Lnet/minecraft/world/level/block/entity/StructureBlockEntity;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;II)V", at = @At("HEAD"))
+    private void wildernessodysseyapi$startOverlayRender(StructureBlockEntity blockEntity, float partialTick,
+            PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay, CallbackInfo ci) {
+        if (!wildernessodysseyapi$shouldForceOverlay(blockEntity)) {
+            return;
+        }
+        RenderSystem.disableDepthTest();
+        RenderSystem.depthMask(false);
+        wildernessodysseyapi$depthForced = true;
+    }
+
+    @Inject(method = "render(Lnet/minecraft/world/level/block/entity/StructureBlockEntity;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;II)V", at = @At("TAIL"))
+    private void wildernessodysseyapi$finishOverlayRender(StructureBlockEntity blockEntity, float partialTick,
+            PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay, CallbackInfo ci) {
+        if (!wildernessodysseyapi$depthForced) {
+            return;
+        }
+        RenderSystem.depthMask(true);
+        RenderSystem.enableDepthTest();
+        wildernessodysseyapi$depthForced = false;
+    }
+
+    @Inject(method = "getViewDistance", at = @At("HEAD"), cancellable = true)
+    private void wildernessodysseyapi$extendViewDistance(CallbackInfoReturnable<Integer> cir) {
+        int radius = StructureBlockSettings.MAX_STRUCTURE_OFFSET + StructureBlockSettings.MAX_STRUCTURE_SIZE;
+        int extended = Math.max(512, radius);
+        cir.setReturnValue(extended);
+    }
+
+    @Unique
+    private static boolean wildernessodysseyapi$shouldForceOverlay(StructureBlockEntity blockEntity) {
+        StructureMode mode = blockEntity.getMode();
+        return mode == StructureMode.SAVE || mode == StructureMode.LOAD;
+    }
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -4,18 +4,19 @@
   "package": "com.thunder.wildernessodysseyapi.mixin",
   "compatibilityLevel": "JAVA_17",
   "refmap": "mixins.wildernessodysseyapi.refmap.json",
-    "mixins": [
-      "CampfireBlockMixin",
-      "DayNightCycleMixin",
-      "EntityAccessor",
-      "StructureBlockEntityMixin"
+  "mixins": [
+    "CampfireBlockMixin",
+    "DayNightCycleMixin",
+    "EntityAccessor",
+    "StructureBlockEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1
   },
-    "client": [
-        "DebugMixin",
-        "MixinWorldCreationUiState",
-        "ParticleEngineMixin"
-    ]
+  "client": [
+    "DebugMixin",
+    "MixinWorldCreationUiState",
+    "ParticleEngineMixin",
+    "StructureBlockRendererMixin"
+  ]
 }


### PR DESCRIPTION
## Summary
- keep structure block selection overlays visible at the expanded capture radius by increasing the renderer view distance
- ensure the bounding box lines render above the structure block by temporarily disabling depth testing during rendering
- register the new client-side renderer mixin

## Testing
- ./gradlew :compileJava *(aborted during the long decompile step)*

------
https://chatgpt.com/codex/tasks/task_e_690176f69c9083288cb8d5d60333b7cb