### PR TITLE
Include structure block in bounding calculations

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -261,6 +261,30 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
             }
         }
 
+        if (hasBounds) {
+            int structureX = blockPos.getX();
+            int structureY = blockPos.getY();
+            int structureZ = blockPos.getZ();
+            if (structureX < minX) {
+                minX = structureX;
+            }
+            if (structureY < minY) {
+                minY = structureY;
+            }
+            if (structureZ < minZ) {
+                minZ = structureZ;
+            }
+            if (structureX > maxX) {
+                maxX = structureX;
+            }
+            if (structureY > maxY) {
+                maxY = structureY;
+            }
+            if (structureZ > maxZ) {
+                maxZ = structureZ;
+            }
+        }
+
         if (!hasBounds) {
             return;
         }


### PR DESCRIPTION
## Summary
- ensure the structure block position is included when updating detected structure bounds

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6901851a32dc8328b92482a7c455125d