### PR TITLE
Constrain structure detection to corner-defined bounds

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -149,6 +149,7 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
         int cornerBoundMaxY = structureY;
         int cornerBoundMinZ = structureZ;
         int cornerBoundMaxZ = structureZ;
+        boolean cornerHasVerticalExtent = false;
 
         for (BlockPos corner : cornerMarkers) {
             if (corner.equals(blockPos)) {
@@ -170,12 +171,20 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
             if (cornerY > cornerBoundMaxY) {
                 cornerBoundMaxY = cornerY;
             }
+            if (cornerY != structureY) {
+                cornerHasVerticalExtent = true;
+            }
             if (cornerZ < cornerBoundMinZ) {
                 cornerBoundMinZ = cornerZ;
             }
             if (cornerZ > cornerBoundMaxZ) {
                 cornerBoundMaxZ = cornerZ;
             }
+        }
+
+        if (restrictToCornerBounds && !cornerHasVerticalExtent) {
+            cornerBoundMinY = minYBound;
+            cornerBoundMaxY = maxYBound;
         }
 
         java.util.Set<BlockPos> visited = new java.util.HashSet<>();


### PR DESCRIPTION
## Summary
- gather corner markers (including distant ones) before scanning structure content and derive axis-aligned bounds from them
- restrict the breadth-first search and neighbor seeding to positions within those corner bounds so detection stops when a corner is reached
- preserve the existing orientation adjustments so the SAVE box extends outward from the structure block when only forward corners are present

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_690215e60edc8328903e20aac7420887