### PR TITLE
Hardcode structure block limit expansion

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -54,28 +54,27 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
     }
 
     @Unique
-    private static boolean wildernessodysseyapi$limitsExpanded;
-
-    @Unique
     private final java.util.Set<BlockPos> wildernessodysseyapi$cornerMarkers = new java.util.HashSet<>();
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void wildernessodysseyapi$expandLimits(BlockPos pos, BlockState state, CallbackInfo ci) {
-        if (wildernessodysseyapi$limitsExpanded) {
-            return;
+        int configuredSize = StructureBlockSettings.getMaxStructureSize();
+        int configuredOffset = StructureBlockSettings.getMaxStructureOffset();
+        if (MAX_SIZE_PER_AXIS != configuredSize) {
+            MAX_SIZE_PER_AXIS = configuredSize;
         }
-        wildernessodysseyapi$limitsExpanded = true;
-        MAX_SIZE_PER_AXIS = StructureBlockSettings.MAX_STRUCTURE_SIZE;
-        MAX_OFFSET_PER_AXIS = StructureBlockSettings.MAX_STRUCTURE_OFFSET;
+        if (MAX_OFFSET_PER_AXIS != configuredOffset) {
+            MAX_OFFSET_PER_AXIS = configuredOffset;
+        }
     }
 
     @Redirect(method = "loadAdditional", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Mth;clamp(III)I"))
     private int wildernessodysseyapi$expandClampRange(int value, int min, int max) {
         if (min < 0) {
-            int limit = StructureBlockSettings.MAX_STRUCTURE_OFFSET;
+            int limit = StructureBlockSettings.getMaxStructureOffset();
             return Mth.clamp(value, -limit, limit);
         }
-        int limit = StructureBlockSettings.MAX_STRUCTURE_SIZE;
+        int limit = StructureBlockSettings.getMaxStructureSize();
         return Mth.clamp(value, 0, limit);
     }
 
@@ -97,11 +96,11 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
         BlockPos currentOffset = this.structurePos == null ? BlockPos.ZERO : this.structurePos;
         Vec3i currentSize = this.structureSize == null ? Vec3i.ZERO : this.structureSize;
 
-        int detectionRadius = StructureBlockSettings.DEFAULT_DETECTION_RADIUS;
+        int detectionRadius = StructureBlockSettings.getDefaultDetectionRadius();
         detectionRadius = Math.max(detectionRadius, wildernessodysseyapi$computeRadiusForAxis(currentOffset.getX(), currentSize.getX()));
         detectionRadius = Math.max(detectionRadius, wildernessodysseyapi$computeRadiusForAxis(currentOffset.getY(), currentSize.getY()));
         detectionRadius = Math.max(detectionRadius, wildernessodysseyapi$computeRadiusForAxis(currentOffset.getZ(), currentSize.getZ()));
-        detectionRadius = Math.min(detectionRadius, StructureBlockSettings.MAX_STRUCTURE_OFFSET);
+        detectionRadius = Math.min(detectionRadius, StructureBlockSettings.getMaxStructureOffset());
         if (detectionRadius <= 0) {
             return;
         }
@@ -545,8 +544,7 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
             return;
         }
 
-        int searchRadius = StructureBlockSettings.CORNER_SEARCH_RADIUS;
-        searchRadius = Math.min(searchRadius, StructureBlockSettings.MAX_STRUCTURE_OFFSET);
+        int searchRadius = StructureBlockSettings.getCornerSearchRadius();
         if (searchRadius <= scannedRadius) {
             return;
         }

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockRendererMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockRendererMixin.java
@@ -50,7 +50,7 @@ public abstract class StructureBlockRendererMixin {
 
     @Inject(method = "getViewDistance", at = @At("HEAD"), cancellable = true)
     private void wildernessodysseyapi$extendViewDistance(CallbackInfoReturnable<Integer> cir) {
-        int axisRange = StructureBlockSettings.MAX_STRUCTURE_OFFSET + StructureBlockSettings.MAX_STRUCTURE_SIZE;
+        int axisRange = StructureBlockSettings.getMaxStructureOffset() + StructureBlockSettings.getMaxStructureSize();
         int extended = Math.max(512, (int) Math.ceil(Math.sqrt(3.0D) * axisRange));
         cir.setReturnValue(extended);
         cir.cancel();
@@ -85,7 +85,7 @@ public abstract class StructureBlockRendererMixin {
 
     @Unique
     private static double wildernessodysseyapi$getMaxOverlayDistance() {
-        return StructureBlockSettings.MAX_STRUCTURE_OFFSET + StructureBlockSettings.MAX_STRUCTURE_SIZE;
+        return StructureBlockSettings.getMaxStructureOffset() + StructureBlockSettings.getMaxStructureSize();
     }
 
     @Unique

--- a/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockSettings.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockSettings.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.util;
 
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -7,33 +8,46 @@ import net.minecraft.world.level.block.state.BlockState;
  * Shared configuration for structure block enhancements.
  */
 public final class StructureBlockSettings {
-    /**
-     * Expanded limit for structure block dimensions. Vanilla uses 48 blocks per axis which is too restrictive for
-     * the large set pieces shipped with the modpack, so we greatly increase the limit.
-     */
-    public static final int MAX_STRUCTURE_SIZE = 512;
 
-    /**
-     * Expanded limit for the offset from the structure block when capturing structures. Matching the size limit keeps
-     * the UI experience consistent and allows placing the controller block outside of large builds.
-     */
-    public static final int MAX_STRUCTURE_OFFSET = 512;
-
-    /**
-     * Default radius used when the detect button runs without an existing bounding box. Scanning a generous
-     * 64-block radius keeps the operation responsive while still covering most medium-sized builds. Players can
-     * expand the configured size manually before detecting if their structure exceeds this area.
-     */
-    public static final int DEFAULT_DETECTION_RADIUS = 64;
-
-    /**
-     * Maximum diagonal search distance when looking for a corner block that defines the opposite corner of the
-     * structure. Matching the expanded offset limit allows lone corner markers to seed the bounding box anywhere inside
-     * the 512-block cube around the save block.
-     */
-    public static final int CORNER_SEARCH_RADIUS = 512;
-
+    /** Maximum allowed capture size per axis when working with structure blocks. */
+    private static final int MAX_STRUCTURE_SIZE = 512;
+    /** Maximum offset permitted between the structure block and its captured area. */
+    private static final int MAX_STRUCTURE_OFFSET = 512;
+    /** Default radius scanned when pressing the Detect button without existing bounds. */
+    private static final int DEFAULT_DETECTION_RADIUS = 64;
+    /** Maximum range used when searching for matching corner structure blocks. */
+    private static final int CORNER_SEARCH_RADIUS = 512;
     private StructureBlockSettings() {
+    }
+
+    /**
+     * @return Maximum allowed structure size per axis, sanitized from the configuration file.
+     */
+    public static int getMaxStructureSize() {
+        return MAX_STRUCTURE_SIZE;
+    }
+
+    /**
+     * @return Maximum offset allowed between the structure block and the captured structure.
+     */
+    public static int getMaxStructureOffset() {
+        return MAX_STRUCTURE_OFFSET;
+    }
+
+    /**
+     * @return Default detection radius, clamped so it never exceeds the offset limit.
+     */
+    public static int getDefaultDetectionRadius() {
+        int radius = Math.max(0, DEFAULT_DETECTION_RADIUS);
+        return Mth.clamp(radius, 0, getMaxStructureOffset());
+    }
+
+    /**
+     * @return Maximum search range for corner structure blocks, limited to the offset limit to avoid chunk thrashing.
+     */
+    public static int getCornerSearchRadius() {
+        int radius = Math.max(0, CORNER_SEARCH_RADIUS);
+        return Math.min(radius, getMaxStructureOffset());
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove the structure block limit settings from the config file so existing installs keep the new behaviour without extra tuning
- replace the getters with static defaults so the mixins still raise the vanilla save limits and detection radius

## Testing
- `./gradlew --console=plain build` *(fails: java.io.FileNotFoundException: https://piston-data.mojang.com/.../client.jar)*

------
https://chatgpt.com/codex/tasks/task_e_69024f7e65048328adc6ca8330dd9fc5