### PR TITLE
Add persistent modpack data cache infrastructure

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -5,6 +5,9 @@ import com.thunder.wildernessodysseyapi.ModPackPatches.BugFixes.InfiniteSourceHa
 import com.thunder.wildernessodysseyapi.ErrorLog.UncaughtExceptionLogger;
 import com.thunder.wildernessodysseyapi.ModPackPatches.FAQ.FaqCommand;
 import com.thunder.wildernessodysseyapi.ModPackPatches.FAQ.FaqReloadListener;
+import com.thunder.wildernessodysseyapi.ModPackPatches.cache.ModDataCache;
+import com.thunder.wildernessodysseyapi.ModPackPatches.cache.ModDataCacheCommand;
+import com.thunder.wildernessodysseyapi.ModPackPatches.cache.ModDataCacheConfig;
 import com.thunder.wildernessodysseyapi.MemUtils.MemCheckCommand;
 import com.thunder.wildernessodysseyapi.MemUtils.MemoryUtils;
 import com.thunder.wildernessodysseyapi.ModListTracker.commands.ModListDiffCommand;
@@ -43,6 +46,7 @@ import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
@@ -103,6 +107,7 @@ public class WildernessOdysseyAPIMainModClass {
         ModItems.register(modEventBus);
 
         container.registerConfig(ModConfig.Type.COMMON, StructureConfig.CONFIG_SPEC);
+        container.registerConfig(ModConfig.Type.COMMON, ModDataCacheConfig.CONFIG_SPEC);
         // Previously registered client-only events have been removed
         container.registerConfig(ModConfig.Type.CLIENT, DonationReminderConfig.CONFIG_SPEC);
         DonationReminderConfig.validateVersion();
@@ -111,7 +116,10 @@ public class WildernessOdysseyAPIMainModClass {
 
 
     private void commonSetup(final FMLCommonSetupEvent event) {
-        event.enqueueWork(() -> System.out.println("Wilderness Odyssey setup complete!"));
+        event.enqueueWork(() -> {
+            System.out.println("Wilderness Odyssey setup complete!");
+            ModDataCache.initialize();
+        });
         LOGGER.warn("Mod Pack Version: {}", VERSION); // Logs as a warning
         LOGGER.warn("This message is for development purposes only."); // Logs as info
         UncaughtExceptionLogger.init();
@@ -148,6 +156,7 @@ public class WildernessOdysseyAPIMainModClass {
         MemCheckCommand.register(event.getDispatcher());
         StructureInfoCommand.register(event.getDispatcher());
         FaqCommand.register(event.getDispatcher());
+        ModDataCacheCommand.register(dispatcher);
         DonateCommand.register(event.getDispatcher());
         DoorLockCommand.register(event.getDispatcher());
         WorldGenScanCommand.register(event.getDispatcher());
@@ -222,5 +231,19 @@ public class WildernessOdysseyAPIMainModClass {
     @SubscribeEvent
     public void onReload(AddReloadListenerEvent event) {
         event.addListener(new FaqReloadListener());
+    }
+
+    @SubscribeEvent
+    public void onConfigLoaded(ModConfigEvent.Loading event) {
+        if (event.getConfig().getSpec() == ModDataCacheConfig.CONFIG_SPEC) {
+            ModDataCache.applyConfiguration();
+        }
+    }
+
+    @SubscribeEvent
+    public void onConfigReloaded(ModConfigEvent.Reloading event) {
+        if (event.getConfig().getSpec() == ModDataCacheConfig.CONFIG_SPEC) {
+            ModDataCache.applyConfiguration();
+        }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -236,14 +236,14 @@ public class WildernessOdysseyAPIMainModClass {
     @SubscribeEvent
     public void onConfigLoaded(ModConfigEvent.Loading event) {
         if (event.getConfig().getSpec() == ModDataCacheConfig.CONFIG_SPEC) {
-            ModDataCache.applyConfiguration();
+            ModDataCache.initialize();
         }
     }
 
     @SubscribeEvent
     public void onConfigReloaded(ModConfigEvent.Reloading event) {
         if (event.getConfig().getSpec() == ModDataCacheConfig.CONFIG_SPEC) {
-            ModDataCache.applyConfiguration();
+            ModDataCache.initialize();
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/cache/ModDataCache.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/cache/ModDataCache.java
@@ -1,0 +1,412 @@
+package com.thunder.wildernessodysseyapi.ModPackPatches.cache;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import net.neoforged.fml.loading.FMLPaths;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
+
+/**
+ * Thread-safe persistent cache for downloadable mod data.
+ */
+public final class ModDataCache {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final Type INDEX_TYPE = new TypeToken<Map<String, CacheEntry>>() {}.getType();
+    private static final ReentrantReadWriteLock LOCK = new ReentrantReadWriteLock();
+    private static final ConcurrentMap<String, CacheEntry> ENTRIES = new ConcurrentHashMap<>();
+
+    private static volatile boolean initialized = false;
+    private static volatile boolean cacheEnabled = true;
+
+    private static Path cacheDirectory;
+    private static Path indexFile;
+
+    private ModDataCache() {
+    }
+
+    /**
+     * Initializes the cache directories and loads the index. Safe to call multiple times.
+     */
+    public static void initialize() {
+        if (initialized) {
+            applyConfiguration();
+            return;
+        }
+        synchronized (ModDataCache.class) {
+            if (initialized) {
+                applyConfiguration();
+                return;
+            }
+            cacheDirectory = FMLPaths.GAMEDIR.get().resolve("wilderness_odyssey").resolve("cache");
+            indexFile = cacheDirectory.resolve("cache_index.json");
+
+            try {
+                Files.createDirectories(cacheDirectory);
+            } catch (IOException e) {
+                LOGGER.error("Failed to create cache directory {}", cacheDirectory, e);
+            }
+
+            loadIndex();
+            initialized = true;
+            applyConfiguration();
+            if (ModDataCacheConfig.isVerboseLogging()) {
+                LOGGER.info("[ModDataCache] Initialized cache at {} ({} entries)", cacheDirectory, ENTRIES.size());
+            }
+        }
+    }
+
+    /**
+     * Applies the latest configuration values (enable flag, pruning limits).
+     */
+    public static void applyConfiguration() {
+        cacheEnabled = ModDataCacheConfig.isCacheEnabled();
+        if (!cacheEnabled) {
+            if (ModDataCacheConfig.isVerboseLogging()) {
+                LOGGER.info("[ModDataCache] Cache disabled via configuration. Existing entries remain on disk.");
+            }
+            return;
+        }
+        pruneExpiredEntries();
+        enforceSizeLimit();
+    }
+
+    /**
+     * Retrieves a cached resource if it exists and matches the provided checksum.
+     */
+    public static Optional<Path> getCachedResource(String key, String checksum) {
+        Objects.requireNonNull(key, "key");
+        initialize();
+        if (!cacheEnabled) {
+            return Optional.empty();
+        }
+        LOCK.writeLock().lock();
+        try {
+            CacheEntry entry = ENTRIES.get(key);
+            if (entry == null) {
+                return Optional.empty();
+            }
+            if (checksum != null && !checksum.isEmpty() && !checksum.equalsIgnoreCase(entry.checksum())) {
+                removeEntry(key, entry);
+                return Optional.empty();
+            }
+            Path file = cacheDirectory.resolve(entry.fileName());
+            if (!Files.exists(file)) {
+                removeEntry(key, entry);
+                return Optional.empty();
+            }
+            CacheEntry updated = entry.withLastAccess(Instant.now().toEpochMilli());
+            ENTRIES.put(key, updated);
+            persistIndexAsync();
+            return Optional.of(file);
+        } finally {
+            LOCK.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Retrieves a cached resource or downloads and stores it using the provided supplier.
+     */
+    public static Optional<Path> getOrDownload(String key, String expectedChecksum, ResourceSupplier supplier) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(supplier, "supplier");
+        initialize();
+
+        if (cacheEnabled) {
+            Optional<Path> cached = getCachedResource(key, expectedChecksum);
+            if (cached.isPresent()) {
+                return cached;
+            }
+        }
+
+        try {
+            Path stored = storeResource(key, expectedChecksum, supplier);
+            return Optional.ofNullable(stored);
+        } catch (IOException e) {
+            LOGGER.error("[ModDataCache] Failed to download resource {}: {}", key, e.getMessage());
+            if (ModDataCacheConfig.isVerboseLogging()) {
+                LOGGER.debug("[ModDataCache] Exception while downloading resource {}", key, e);
+            }
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Stores data supplied by the provided supplier in the cache.
+     */
+    public static Path storeResource(String key, String expectedChecksum, ResourceSupplier supplier) throws IOException {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(supplier, "supplier");
+        initialize();
+
+        Path tempFile = Files.createTempFile("modcache-", ".tmp");
+        String computedChecksum;
+        long size;
+        try (InputStream raw = supplier.openStream()) {
+            if (raw == null) {
+                Files.deleteIfExists(tempFile);
+                throw new IOException("Resource supplier returned null for key " + key);
+            }
+            try (DigestInputStream digestStream = new DigestInputStream(raw, newDigest());
+             OutputStream out = Files.newOutputStream(tempFile)) {
+                size = digestStream.transferTo(out);
+                computedChecksum = bytesToHex(digestStream.getMessageDigest().digest());
+            }
+        }
+
+        if (expectedChecksum != null && !expectedChecksum.isEmpty() && !expectedChecksum.equalsIgnoreCase(computedChecksum)) {
+            Files.deleteIfExists(tempFile);
+            throw new IOException("Checksum mismatch for key " + key + ": expected " + expectedChecksum + " but found " + computedChecksum);
+        }
+
+        if (!cacheEnabled) {
+            // When caching is disabled we simply place the file inside the cache directory without indexing.
+            Path target = cacheDirectory.resolve(safeFileName(key, computedChecksum));
+            Files.createDirectories(target.getParent());
+            Files.move(tempFile, target, StandardCopyOption.REPLACE_EXISTING);
+            return target;
+        }
+
+        LOCK.writeLock().lock();
+        try {
+            CacheEntry existing = ENTRIES.get(key);
+            if (existing != null) {
+                removeEntry(key, existing);
+            }
+            Path target = cacheDirectory.resolve(safeFileName(key, computedChecksum));
+            Files.createDirectories(target.getParent());
+            Files.move(tempFile, target, StandardCopyOption.REPLACE_EXISTING);
+            CacheEntry entry = new CacheEntry(target.getFileName().toString(), computedChecksum, size,
+                    Instant.now().toEpochMilli(), Instant.now().toEpochMilli());
+            ENTRIES.put(key, entry);
+            persistIndexAsync();
+            enforceSizeLimit();
+            pruneExpiredEntries();
+            return target;
+        } finally {
+            LOCK.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Removes the cache entry for the given key.
+     */
+    public static void invalidate(String key) {
+        initialize();
+        LOCK.writeLock().lock();
+        try {
+            CacheEntry entry = ENTRIES.remove(key);
+            if (entry != null) {
+                deleteFileQuietly(cacheDirectory.resolve(entry.fileName()));
+                persistIndexAsync();
+            }
+        } finally {
+            LOCK.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Clears all cache entries and deletes cached files from disk.
+     */
+    public static void invalidateAll() {
+        initialize();
+        LOCK.writeLock().lock();
+        try {
+            ENTRIES.values().forEach(entry -> deleteFileQuietly(cacheDirectory.resolve(entry.fileName())));
+            ENTRIES.clear();
+            persistIndexAsync();
+        } finally {
+            LOCK.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Returns immutable snapshot statistics for the cache.
+     */
+    public static CacheStats getStats() {
+        initialize();
+        LOCK.readLock().lock();
+        try {
+            long totalSize = ENTRIES.values().stream().mapToLong(CacheEntry::size).sum();
+            return new CacheStats(ENTRIES.size(), totalSize, ModDataCacheConfig.getMaxCacheSizeBytes(), cacheEnabled,
+                    ImmutableMap.copyOf(ENTRIES));
+        } finally {
+            LOCK.readLock().unlock();
+        }
+    }
+
+    private static void loadIndex() {
+        if (!Files.exists(indexFile)) {
+            return;
+        }
+        LOCK.writeLock().lock();
+        try (Reader reader = Files.newBufferedReader(indexFile)) {
+            Map<String, CacheEntry> map = GSON.fromJson(reader, INDEX_TYPE);
+            ENTRIES.clear();
+            if (map != null) {
+                ENTRIES.putAll(map);
+            }
+        } catch (Exception e) {
+            LOGGER.error("[ModDataCache] Failed to read cache index {}: {}", indexFile, e.getMessage());
+            if (ModDataCacheConfig.isVerboseLogging()) {
+                LOGGER.debug("[ModDataCache] Index parse failure", e);
+            }
+        } finally {
+            LOCK.writeLock().unlock();
+        }
+    }
+
+    private static void persistIndexAsync() {
+        // Persist synchronously for simplicity; index is small and writes infrequent.
+        persistIndex();
+    }
+
+    private static void persistIndex() {
+        LOCK.readLock().lock();
+        try {
+            Files.createDirectories(cacheDirectory);
+            try (Writer writer = Files.newBufferedWriter(indexFile)) {
+                GSON.toJson(ENTRIES, INDEX_TYPE, writer);
+            }
+        } catch (IOException e) {
+            LOGGER.error("[ModDataCache] Failed to persist cache index {}: {}", indexFile, e.getMessage());
+            if (ModDataCacheConfig.isVerboseLogging()) {
+                LOGGER.debug("[ModDataCache] Index write failure", e);
+            }
+        } finally {
+            LOCK.readLock().unlock();
+        }
+    }
+
+    private static void removeEntry(String key, CacheEntry entry) {
+        ENTRIES.remove(key);
+        deleteFileQuietly(cacheDirectory.resolve(entry.fileName()));
+        persistIndexAsync();
+    }
+
+    private static void pruneExpiredEntries() {
+        Duration maxAge = ModDataCacheConfig.getMaxEntryAge();
+        if (maxAge.isZero() || maxAge.isNegative()) {
+            return;
+        }
+        long cutoff = Instant.now().minus(maxAge).toEpochMilli();
+        LOCK.writeLock().lock();
+        try {
+            ENTRIES.entrySet().removeIf(e -> {
+                boolean expired = e.getValue().lastAccess() < cutoff;
+                if (expired) {
+                    deleteFileQuietly(cacheDirectory.resolve(e.getValue().fileName()));
+                }
+                return expired;
+            });
+            persistIndexAsync();
+        } finally {
+            LOCK.writeLock().unlock();
+        }
+    }
+
+    private static void enforceSizeLimit() {
+        long limit = ModDataCacheConfig.getMaxCacheSizeBytes();
+        if (limit <= 0) {
+            return;
+        }
+        LOCK.writeLock().lock();
+        try {
+            long totalSize = ENTRIES.values().stream().mapToLong(CacheEntry::size).sum();
+            if (totalSize <= limit) {
+                return;
+            }
+            ArrayList<Map.Entry<String, CacheEntry>> entries = new ArrayList<>(ENTRIES.entrySet());
+            entries.sort(Comparator.comparingLong(e -> e.getValue().lastAccess()));
+            for (Map.Entry<String, CacheEntry> entry : entries) {
+                if (totalSize <= limit) {
+                    break;
+                }
+                removeEntry(entry.getKey(), entry.getValue());
+                totalSize -= entry.getValue().size();
+            }
+        } finally {
+            LOCK.writeLock().unlock();
+        }
+    }
+
+    private static void deleteFileQuietly(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            LOGGER.warn("[ModDataCache] Failed to delete cached file {}: {}", path, e.getMessage());
+        }
+    }
+
+    private static MessageDigest newDigest() throws IOException {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("SHA-256 not available", e);
+        }
+    }
+
+    private static String safeFileName(String key, String checksum) {
+        String safe = key.replaceAll("[^a-zA-Z0-9._-]", "_");
+        if (safe.length() > 80) {
+            safe = safe.substring(0, 80);
+        }
+        return safe + "-" + checksum + ".bin";
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Provides a stream to the resource that should be cached.
+     */
+    @FunctionalInterface
+    public interface ResourceSupplier {
+        InputStream openStream() throws IOException;
+    }
+
+    /**
+     * Immutable statistics snapshot returned by {@link #getStats()}.
+     */
+    public record CacheStats(int entryCount, long totalSizeBytes, long sizeLimitBytes, boolean enabled,
+                             Map<String, CacheEntry> entries) {
+    }
+
+    /**
+     * Metadata for a cached file. Stored in the on-disk index.
+     */
+    public record CacheEntry(String fileName, String checksum, long size, long createdAt, long lastAccess) {
+        CacheEntry withLastAccess(long lastAccess) {
+            return new CacheEntry(fileName, checksum, size, createdAt, lastAccess);
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/cache/ModDataCacheCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/cache/ModDataCacheCommand.java
@@ -1,0 +1,38 @@
+package com.thunder.wildernessodysseyapi.ModPackPatches.cache;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Server command utilities for inspecting and clearing the mod data cache.
+ */
+public final class ModDataCacheCommand {
+    private ModDataCacheCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("modcache")
+                .requires(source -> source.hasPermission(2))
+                .then(Commands.literal("clear")
+                        .executes(ctx -> {
+                            ModDataCache.invalidateAll();
+                            ctx.getSource().sendSuccess(() -> Component.literal("Cleared Wilderness Odyssey mod data cache."), true);
+                            return 1;
+                        }))
+                .then(Commands.literal("stats")
+                        .executes(ctx -> {
+                            ModDataCache.CacheStats stats = ModDataCache.getStats();
+                            long sizeMb = stats.totalSizeBytes() / 1024L / 1024L;
+                            long limitMb = stats.sizeLimitBytes() <= 0 ? -1 : stats.sizeLimitBytes() / 1024L / 1024L;
+                            String limitText = limitMb < 0 ? "no limit" : limitMb + "MB";
+                            ctx.getSource().sendSuccess(() -> Component.literal(
+                                    "Cache " + (stats.enabled() ? "enabled" : "disabled") + ": "
+                                            + stats.entryCount() + " entries, " + sizeMb + "MB used (limit " + limitText + ")"),
+                                    false);
+                            return 1;
+                        }))
+        );
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/cache/ModDataCacheConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/cache/ModDataCacheConfig.java
@@ -1,0 +1,64 @@
+package com.thunder.wildernessodysseyapi.ModPackPatches.cache;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+import java.time.Duration;
+
+/**
+ * Configuration toggles for the persistent mod data cache.
+ */
+public final class ModDataCacheConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+    public static final ModConfigSpec.BooleanValue enableCache;
+    public static final ModConfigSpec.IntValue maxCacheSizeMb;
+    public static final ModConfigSpec.IntValue maxEntryAgeHours;
+    public static final ModConfigSpec.BooleanValue verboseLogging;
+
+    static {
+        ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
+        enableCache = builder.comment("Enable persistent caching for downloaded modpack data")
+                .define("enableCache", true);
+        maxCacheSizeMb = builder.comment("Maximum size of the mod data cache in megabytes (0 disables the limit)")
+                .defineInRange("maxCacheSizeMb", 512, 0, Integer.MAX_VALUE);
+        maxEntryAgeHours = builder.comment("Maximum age of cached entries before they are pruned (0 disables age-based pruning)")
+                .defineInRange("maxEntryAgeHours", 168, 0, Integer.MAX_VALUE);
+        verboseLogging = builder.comment("Enable verbose cache logging for debugging purposes")
+                .define("verboseLogging", false);
+        CONFIG_SPEC = builder.build();
+    }
+
+    private ModDataCacheConfig() {
+    }
+
+    /**
+     * Returns whether the cache is enabled.
+     */
+    public static boolean isCacheEnabled() {
+        return enableCache.get();
+    }
+
+    /**
+     * Returns the configured maximum cache size in bytes.
+     */
+    public static long getMaxCacheSizeBytes() {
+        return maxCacheSizeMb.get().longValue() * 1024L * 1024L;
+    }
+
+    /**
+     * Returns the configured maximum age for cache entries.
+     */
+    public static Duration getMaxEntryAge() {
+        int hours = maxEntryAgeHours.get();
+        if (hours <= 0) {
+            return Duration.ZERO;
+        }
+        return Duration.ofHours(hours);
+    }
+
+    /**
+     * Returns whether verbose logging is enabled.
+     */
+    public static boolean isVerboseLogging() {
+        return verboseLogging.get();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/cache/ModPackDataSynchronizer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/cache/ModPackDataSynchronizer.java
@@ -1,0 +1,131 @@
+package com.thunder.wildernessodysseyapi.ModPackPatches.cache;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.server.ServerStartedEvent;
+import net.neoforged.neoforge.event.server.ServerStoppingEvent;
+import net.neoforged.fml.loading.FMLPaths;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
+
+/**
+ * Loads external modpack data listed in the optional data manifest and caches the resulting files.
+ */
+@EventBusSubscriber(modid = MOD_ID)
+public final class ModPackDataSynchronizer {
+    private static final Gson GSON = new Gson();
+    private static final Path MANIFEST_PATH = FMLPaths.GAMEDIR.get()
+            .resolve("config")
+            .resolve("wilderness_odyssey")
+            .resolve("data_manifest.json");
+    private static final Map<String, Path> RESOLVED_FILES = new ConcurrentHashMap<>();
+
+    private ModPackDataSynchronizer() {
+    }
+
+    /**
+     * Returns the cached file for the given identifier if present.
+     */
+    public static Optional<Path> getCachedFile(String id) {
+        return Optional.ofNullable(RESOLVED_FILES.get(id));
+    }
+
+    @SubscribeEvent
+    public static void onServerStarted(ServerStartedEvent event) {
+        ModDataCache.initialize();
+        RESOLVED_FILES.clear();
+        if (!Files.exists(MANIFEST_PATH)) {
+            LOGGER.info("[ModPackDataSync] No data manifest found at {}", MANIFEST_PATH);
+            return;
+        }
+
+        try (Reader reader = Files.newBufferedReader(MANIFEST_PATH)) {
+            ResourceManifest manifest = GSON.fromJson(reader, ResourceManifest.class);
+            if (manifest == null || manifest.resources().isEmpty()) {
+                LOGGER.info("[ModPackDataSync] Data manifest was empty");
+                return;
+            }
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(15))
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .build();
+            for (ResourceEntry entry : manifest.resources()) {
+                processEntry(client, entry);
+            }
+        } catch (IOException | JsonParseException e) {
+            LOGGER.error("[ModPackDataSync] Failed to read data manifest {}: {}", MANIFEST_PATH, e.getMessage());
+            if (ModDataCacheConfig.isVerboseLogging()) {
+                LOGGER.debug("[ModPackDataSync] Manifest parsing exception", e);
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void onServerStopping(ServerStoppingEvent event) {
+        RESOLVED_FILES.clear();
+    }
+
+    private static void processEntry(HttpClient client, ResourceEntry entry) {
+        if (entry == null || entry.id() == null || entry.uri() == null) {
+            return;
+        }
+        String id = entry.id();
+        String checksum = entry.checksum() == null ? "" : entry.checksum();
+        URI uri;
+        try {
+            uri = URI.create(entry.uri());
+        } catch (IllegalArgumentException ex) {
+            LOGGER.warn("[ModPackDataSync] Invalid URI for {}: {}", id, entry.uri());
+            return;
+        }
+
+        Optional<Path> cached = ModDataCache.getOrDownload("manifest:" + id, checksum, () -> openStream(client, uri));
+        cached.ifPresent(path -> RESOLVED_FILES.put(id, path));
+    }
+
+    private static InputStream openStream(HttpClient client, URI uri) throws IOException {
+        if ("file".equalsIgnoreCase(uri.getScheme()) || uri.getScheme() == null) {
+            Path local = Path.of(uri.getPath());
+            return Files.newInputStream(local);
+        }
+        try {
+            HttpRequest request = HttpRequest.newBuilder(uri).timeout(Duration.ofSeconds(30)).GET().build();
+            HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                return response.body();
+            }
+            throw new IOException("Unexpected HTTP status " + response.statusCode() + " for " + uri);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while downloading " + uri, e);
+        }
+    }
+
+    private record ResourceManifest(List<ResourceEntry> resources) {
+        ResourceManifest {
+            resources = resources == null ? Collections.emptyList() : List.copyOf(resources);
+        }
+    }
+
+    private record ResourceEntry(String id, String uri, String checksum) {
+    }
+}


### PR DESCRIPTION
## Summary
- add a configurable mod data cache that stores artifacts in the modpack directory and enforces size and age limits
- expose administrative commands and a manifest-driven synchronizer to manage cached resources
- wire the cache into the main mod lifecycle so configuration changes are honored and initialization happens during setup

## Testing
- `./gradlew compileJava` *(fails: existing LevelData to ServerLevelData cast in MeteorStructureSpawner.java)*

------
https://chatgpt.com/codex/tasks/task_e_6903855b01148328839366da35e2ba7d