### PR TITLE
Fix structure block cache sync injection target

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -18,6 +18,7 @@ import net.minecraft.world.level.block.StructureBlock;
 import net.minecraft.world.level.block.state.properties.StructureMode;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.util.Mth;
+import net.minecraft.nbt.CompoundTag;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -63,8 +64,8 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
     @Unique
     private @org.jetbrains.annotations.Nullable ServerLevel wildernessodysseyapi$cachedCornerLevel;
 
-    @Inject(method = "onLoad", at = @At("TAIL"))
-    private void wildernessodysseyapi$registerOnLoad(CallbackInfo ci) {
+    @Inject(method = "load", at = @At("TAIL"))
+    private void wildernessodysseyapi$handleLoad(CompoundTag tag, CallbackInfo ci) {
         wildernessodysseyapi$syncCornerCache();
     }
 


### PR DESCRIPTION
## Summary
- retarget the structure block cache sync injection to the `load` method since `onLoad` is not defined on the mixin target
- ensure the corner cache still synchronizes when data is loaded into the block entity

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_690a1bfce3bc8328a4eb9688449927b0