### PR TITLE
Fix structure block cache lifecycle hooks

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/BlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/BlockEntityMixin.java
@@ -1,0 +1,34 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.thunder.wildernessodysseyapi.mixin.bridge.StructureBlockCornerCacheBridge;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BlockEntity.class)
+public abstract class BlockEntityMixin {
+
+    @Inject(method = "setLevel", at = @At("TAIL"))
+    private void wildernessodysseyapi$syncCornerCacheOnLevel(Level level, CallbackInfo ci) {
+        if ((Object) this instanceof StructureBlockCornerCacheBridge bridge) {
+            bridge.wildernessodysseyapi$bridge$syncCornerCache();
+        }
+    }
+
+    @Inject(method = "setRemoved", at = @At("TAIL"))
+    private void wildernessodysseyapi$cleanupCornerCacheOnRemoval(CallbackInfo ci) {
+        if ((Object) this instanceof StructureBlockCornerCacheBridge bridge) {
+            bridge.wildernessodysseyapi$bridge$removeCornerFromCache();
+        }
+    }
+
+    @Inject(method = "clearRemoved", at = @At("TAIL"))
+    private void wildernessodysseyapi$restoreCornerCacheOnClear(CallbackInfo ci) {
+        if ((Object) this instanceof StructureBlockCornerCacheBridge bridge) {
+            bridge.wildernessodysseyapi$bridge$syncCornerCache();
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -18,6 +18,7 @@ import net.minecraft.world.level.block.StructureBlock;
 import net.minecraft.world.level.block.state.properties.StructureMode;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.util.Mth;
+import net.minecraft.nbt.CompoundTag;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -32,8 +33,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 /**
  * Expands the structure block capture size and automatically snaps the save area to the occupied blocks.
  */
+import com.thunder.wildernessodysseyapi.mixin.bridge.StructureBlockCornerCacheBridge;
+
 @Mixin(StructureBlockEntity.class)
-public abstract class StructureBlockEntityMixin extends BlockEntity {
+public abstract class StructureBlockEntityMixin extends BlockEntity implements StructureBlockCornerCacheBridge {
 
     @Shadow @Final @Mutable private static int MAX_OFFSET_PER_AXIS;
     @Shadow @Final @Mutable private static int MAX_SIZE_PER_AXIS;
@@ -63,19 +66,9 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
     @Unique
     private @org.jetbrains.annotations.Nullable ServerLevel wildernessodysseyapi$cachedCornerLevel;
 
-    @Inject(method = "onLoad", at = @At("TAIL"))
-    private void wildernessodysseyapi$registerOnLoad(CallbackInfo ci) {
+    @Inject(method = "load", at = @At("TAIL"))
+    private void wildernessodysseyapi$handleLoad(CompoundTag tag, CallbackInfo ci) {
         wildernessodysseyapi$syncCornerCache();
-    }
-
-    @Inject(method = "setLevel", at = @At("TAIL"))
-    private void wildernessodysseyapi$handleLevelSet(Level level, CallbackInfo ci) {
-        wildernessodysseyapi$syncCornerCache();
-    }
-
-    @Inject(method = "setRemoved", at = @At("HEAD"))
-    private void wildernessodysseyapi$handleRemoval(CallbackInfo ci) {
-        wildernessodysseyapi$removeCornerFromCache();
     }
 
     @Inject(method = "setMode", at = @At("TAIL"))
@@ -770,6 +763,16 @@ public abstract class StructureBlockEntityMixin extends BlockEntity {
         this.wildernessodysseyapi$cacheRegistered = false;
         this.wildernessodysseyapi$cachedCornerName = null;
         this.wildernessodysseyapi$cachedCornerLevel = null;
+    }
+
+    @Override
+    public void wildernessodysseyapi$bridge$syncCornerCache() {
+        wildernessodysseyapi$syncCornerCache();
+    }
+
+    @Override
+    public void wildernessodysseyapi$bridge$removeCornerFromCache() {
+        wildernessodysseyapi$removeCornerFromCache();
     }
 
     @Unique

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/bridge/StructureBlockCornerCacheBridge.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/bridge/StructureBlockCornerCacheBridge.java
@@ -1,0 +1,18 @@
+package com.thunder.wildernessodysseyapi.mixin.bridge;
+
+/**
+ * Provides hooks for structure block corner cache synchronization when lifecycle events occur on the
+ * {@link net.minecraft.world.level.block.entity.StructureBlockEntity} instance.
+ */
+public interface StructureBlockCornerCacheBridge {
+
+    /**
+     * Ensures the structure block's corner marker registration matches the current state.
+     */
+    void wildernessodysseyapi$bridge$syncCornerCache();
+
+    /**
+     * Removes any registered corner markers tracked for the structure block.
+     */
+    void wildernessodysseyapi$bridge$removeCornerFromCache();
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "refmap": "mixins.wildernessodysseyapi.refmap.json",
   "mixins": [
+    "BlockEntityMixin",
     "CampfireBlockMixin",
     "DayNightCycleMixin",
     "EntityAccessor",


### PR DESCRIPTION
## Summary
- add a BlockEntity mixin that forwards lifecycle hooks to structure block corner cache syncing
- implement an internal bridge on the structure block mixin so shared cache logic is reused for lifecycle callbacks

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_690a1bfce3bc8328a4eb9688449927b0