### PR TITLE
Fix mixin bridge package

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/bridge/StructureBlockCornerCacheBridge.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/bridge/StructureBlockCornerCacheBridge.java
@@ -1,4 +1,4 @@
-package com.thunder.wildernessodysseyapi.mixin.bridge;
+package com.thunder.wildernessodysseyapi.bridge;
 
 /**
  * Provides hooks for structure block corner cache synchronization when lifecycle events occur on the

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/BlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/BlockEntityMixin.java
@@ -1,6 +1,6 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
-import com.thunder.wildernessodysseyapi.mixin.bridge.StructureBlockCornerCacheBridge;
+import com.thunder.wildernessodysseyapi.bridge.StructureBlockCornerCacheBridge;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
+import com.thunder.wildernessodysseyapi.bridge.StructureBlockCornerCacheBridge;
 import com.thunder.wildernessodysseyapi.util.StructureBlockCornerCache;
 import com.thunder.wildernessodysseyapi.util.StructureBlockSettings;
 import net.minecraft.core.BlockPos;
@@ -34,8 +35,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 /**
  * Expands the structure block capture size and automatically snaps the save area to the occupied blocks.
  */
-import com.thunder.wildernessodysseyapi.mixin.bridge.StructureBlockCornerCacheBridge;
-
 @Mixin(StructureBlockEntity.class)
 public abstract class StructureBlockEntityMixin extends BlockEntity implements StructureBlockCornerCacheBridge {
 


### PR DESCRIPTION
## Summary
- move StructureBlockCornerCacheBridge out of the mixin package so it can be referenced safely
- update mixins to import the relocated bridge interface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a433128d083289acf87961163532b