### PR TITLE
Assign unique config filenames

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -109,8 +109,8 @@ public class WildernessOdysseyAPIMainModClass {
         TerrainReplacerBlock.register(modEventBus);
         ModItems.register(modEventBus);
 
-        container.registerConfig(ModConfig.Type.COMMON, StructureConfig.CONFIG_SPEC);
-        container.registerConfig(ModConfig.Type.COMMON, ModDataCacheConfig.CONFIG_SPEC);
+        container.registerConfig(ModConfig.Type.COMMON, StructureConfig.CONFIG_SPEC, "wildernessodysseyapi-structures.toml");
+        container.registerConfig(ModConfig.Type.COMMON, ModDataCacheConfig.CONFIG_SPEC, "wildernessodysseyapi-cache.toml");
         // Previously registered client-only events have been removed
         container.registerConfig(ModConfig.Type.CLIENT, DonationReminderConfig.CONFIG_SPEC);
         DonationReminderConfig.validateVersion();


### PR DESCRIPTION
## Summary
- give the common configuration specs unique filenames to avoid NeoForge config registration conflicts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925ea61b7148328a2c9da6b06f42114)