### PR TITLE
Add config registration guard

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -20,6 +20,7 @@ import com.thunder.wildernessodysseyapi.donations.command.DonateCommand;
 import com.thunder.wildernessodysseyapi.doorlock.DoorLockEvents;
 import com.thunder.wildernessodysseyapi.command.DoorLockCommand;
 import com.thunder.wildernessodysseyapi.command.WorldGenScanCommand;
+import com.thunder.wildernessodysseyapi.config.ConfigRegistrationValidator;
 import com.thunder.wildernessodysseyapi.item.ModCreativeTabs;
 import com.thunder.wildernessodysseyapi.item.ModItems;
 import com.thunder.wildernessodysseyapi.AntiCheat.BlacklistChecker;
@@ -109,10 +110,13 @@ public class WildernessOdysseyAPIMainModClass {
         TerrainReplacerBlock.register(modEventBus);
         ModItems.register(modEventBus);
 
-        container.registerConfig(ModConfig.Type.COMMON, StructureConfig.CONFIG_SPEC, "wildernessodysseyapi-structures.toml");
-        container.registerConfig(ModConfig.Type.COMMON, ModDataCacheConfig.CONFIG_SPEC, "wildernessodysseyapi-cache.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, StructureConfig.CONFIG_SPEC,
+                "wildernessodysseyapi-structures.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, ModDataCacheConfig.CONFIG_SPEC,
+                "wildernessodysseyapi-cache.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.CLIENT, DonationReminderConfig.CONFIG_SPEC,
+                "wildernessodysseyapi-donations-client.toml");
         // Previously registered client-only events have been removed
-        container.registerConfig(ModConfig.Type.CLIENT, DonationReminderConfig.CONFIG_SPEC);
         DonationReminderConfig.validateVersion();
 
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/config/ConfigRegistrationValidator.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/config/ConfigRegistrationValidator.java
@@ -1,0 +1,58 @@
+package com.thunder.wildernessodysseyapi.config;
+
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.config.ModConfig;
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Validates mod config registrations to avoid conflicting file names or reused specs.
+ */
+public final class ConfigRegistrationValidator {
+
+    private static final Map<String, ModConfig.Type> FILE_USAGE = new HashMap<>();
+    private static final Map<ModConfigSpec, String> SPEC_USAGE = new IdentityHashMap<>();
+
+    private ConfigRegistrationValidator() {
+    }
+
+    /**
+     * Registers a config spec while checking for duplicate file usage or spec reuse.
+     *
+     * @param container the owning mod container
+     * @param type      the config type (client, common, server)
+     * @param spec      the config specification to register
+     * @param fileName  the target config filename
+     */
+    public static void register(ModContainer container, ModConfig.Type type, ModConfigSpec spec, String fileName) {
+        Objects.requireNonNull(container, "ModContainer cannot be null");
+        Objects.requireNonNull(type, "ModConfig.Type cannot be null");
+        Objects.requireNonNull(spec, "ModConfigSpec cannot be null");
+
+        String normalized = normalizeFileName(fileName);
+        ModConfig.Type existingType = FILE_USAGE.putIfAbsent(normalized, type);
+        if (existingType != null) {
+            throw new IllegalStateException("Config file '" + normalized + "' already registered for type " + existingType);
+        }
+
+        String existingFile = SPEC_USAGE.putIfAbsent(spec, normalized);
+        if (existingFile != null) {
+            throw new IllegalStateException("Config spec already registered for file '" + existingFile + "'");
+        }
+
+        container.registerConfig(type, spec, normalized);
+    }
+
+    private static String normalizeFileName(String fileName) {
+        Objects.requireNonNull(fileName, "Config filename cannot be null");
+        String normalized = fileName.trim();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("Config filename cannot be blank");
+        }
+        return normalized;
+    }
+}


### PR DESCRIPTION
## Summary
- add a ConfigRegistrationValidator utility to block duplicate config file registrations
- register all mod configs through the validator with explicit filenames to avoid conflicts

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927eb978c588328baabe50a6a443c28)