### PR TITLE
Organize configs and add debug spawn toggles

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -78,6 +78,7 @@ import static com.thunder.wildernessodysseyapi.Core.ModConstants.VERSION;
 public class WildernessOdysseyAPIMainModClass {
 
     public static int dynamicModCount = 0;
+    private static final String CONFIG_FOLDER = ModConstants.MOD_ID + "/";
 
     private static AABB structureBoundingBox;
 
@@ -119,11 +120,11 @@ public class WildernessOdysseyAPIMainModClass {
         ModItems.register(modEventBus);
 
         ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, StructureConfig.CONFIG_SPEC,
-                "wildernessodysseyapi-structures.toml");
+                CONFIG_FOLDER + "wildernessodysseyapi-structures.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, ModDataCacheConfig.CONFIG_SPEC,
-                "wildernessodysseyapi-cache.toml");
+                CONFIG_FOLDER + "wildernessodysseyapi-cache.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.CLIENT, DonationReminderConfig.CONFIG_SPEC,
-                "wildernessodysseyapi-donations-client.toml");
+                CONFIG_FOLDER + "wildernessodysseyapi-donations-client.toml");
         // Previously registered client-only events have been removed
         DonationReminderConfig.validateVersion();
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/configurable/StructureConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/configurable/StructureConfig.java
@@ -19,6 +19,10 @@ public class StructureConfig {
     public static final ModConfigSpec.IntValue BUNKER_MAX_COUNT;
     /** Debug toggle to bypass cryo tube spawning */
     public static final ModConfigSpec.BooleanValue DEBUG_IGNORE_CRYO_TUBE;
+    /** Debug toggle to skip bunker placement entirely */
+    public static final ModConfigSpec.BooleanValue DEBUG_DISABLE_BUNKER_SPAWNS;
+    /** Debug toggle to skip meteor impact site placement */
+    public static final ModConfigSpec.BooleanValue DEBUG_DISABLE_IMPACT_SITES;
 
     private static final HashMap<String, BooleanValue> STRUCTURES = new HashMap<>();
     private static final HashMap<String, BooleanValue> POIS = new HashMap<>();
@@ -34,6 +38,17 @@ public class StructureConfig {
                         "If true, players spawn at a random position inside the bunker instead of inside cryo tubes."
                 )
                 .define("debugIgnoreCryoTubeSpawns", false);
+        DEBUG_DISABLE_BUNKER_SPAWNS = BUILDER.comment(
+                        "If true, the bunker structure will not be spawned during world generation."
+                )
+                .define("debugDisableBunkerSpawns", false);
+        BUILDER.pop();
+
+        BUILDER.push("impactSites");
+        DEBUG_DISABLE_IMPACT_SITES = BUILDER.comment(
+                        "If true, meteor impact sites will not be generated."
+                )
+                .define("debugDisableImpactSites", false);
         BUILDER.pop();
 
         registerAll();

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/worldgen/structures/MeteorStructureSpawner.java
@@ -8,6 +8,7 @@ import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock.Play
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock.WorldSpawnHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.NBTStructurePlacer;
 import com.thunder.wildernessodysseyapi.WorldGen.util.DeferredTaskScheduler;
+import com.thunder.wildernessodysseyapi.WorldGen.worldgen.configurable.StructureConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
@@ -94,6 +95,11 @@ public class MeteorStructureSpawner {
             return;
         }
 
+        if (StructureConfig.DEBUG_DISABLE_IMPACT_SITES.get()) {
+            markPlacementComplete(level);
+            return;
+        }
+
         MeteorImpactData impactData = MeteorImpactData.get(level);
         if (impactData.getBunkerPos() != null) {
             markPlacementComplete(level);
@@ -119,6 +125,11 @@ public class MeteorStructureSpawner {
 
         if (storedSites.size() != originalCount) {
             impactData.setImpactPositions(storedSites);
+        }
+
+        if (StructureConfig.DEBUG_DISABLE_BUNKER_SPAWNS.get()) {
+            markPlacementComplete(level);
+            return;
         }
 
         if (impactData.getBunkerPos() == null && !storedSites.isEmpty()) {


### PR DESCRIPTION
## Summary
- group all mod configuration files under a shared wildernessodysseyapi folder
- add debug config toggles to skip bunker or meteor impact site spawning
- short-circuit structure placement logic when the new debug flags are enabled

## Testing
- `./gradlew test --console=plain --no-daemon` *(fails: existing compile error in PerformanceAdvisor.java about Iterable size())*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692930f2e7808328b5787932382c0dc9)