### PR TITLE
Add human-approved AI performance mitigations

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceAction.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceAction.java
@@ -1,0 +1,84 @@
+package com.thunder.wildernessodysseyapi.AI_perf;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Represents a concrete, human-approvable performance action derived from AI advice.
+ */
+public class PerformanceAction {
+    private final String id;
+    private final String subsystem;
+    private final String summary;
+    private final String detail;
+    private final int durationSeconds;
+    private final int severity;
+    private PerformanceActionStatus status;
+    private final Instant createdAt;
+
+    public PerformanceAction(String subsystem, String summary, String detail, int durationSeconds, int severity) {
+        this(UUID.randomUUID().toString(), subsystem, summary, detail, durationSeconds, severity,
+                PerformanceActionStatus.PENDING, Instant.now());
+    }
+
+    public PerformanceAction(String id, String subsystem, String summary, String detail, int durationSeconds,
+                             int severity, PerformanceActionStatus status, Instant createdAt) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.subsystem = Objects.requireNonNull(subsystem, "subsystem");
+        this.summary = Objects.requireNonNull(summary, "summary");
+        this.detail = Objects.requireNonNull(detail, "detail");
+        this.durationSeconds = durationSeconds;
+        this.severity = severity;
+        this.status = Objects.requireNonNull(status, "status");
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getSubsystem() {
+        return subsystem;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public int getDurationSeconds() {
+        return durationSeconds;
+    }
+
+    public int getSeverity() {
+        return severity;
+    }
+
+    public PerformanceActionStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void markApproved() {
+        status = PerformanceActionStatus.APPROVED;
+    }
+
+    public void markApplied() {
+        status = PerformanceActionStatus.APPLIED;
+    }
+
+    public void markRejected() {
+        status = PerformanceActionStatus.REJECTED;
+    }
+
+    public void markExpired() {
+        status = PerformanceActionStatus.EXPIRED;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceActionQueue.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceActionQueue.java
@@ -1,0 +1,98 @@
+package com.thunder.wildernessodysseyapi.AI_perf;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Tracks advisory actions that require human approval before execution.
+ */
+public class PerformanceActionQueue {
+    private final List<PerformanceAction> actions = new ArrayList<>();
+
+    public synchronized void replacePending(List<PerformanceAction> proposals) {
+        actions.removeIf(action -> action.getStatus() == PerformanceActionStatus.PENDING);
+        actions.addAll(proposals);
+    }
+
+    public synchronized List<PerformanceAction> getActions() {
+        return Collections.unmodifiableList(new ArrayList<>(actions));
+    }
+
+    public synchronized Optional<PerformanceAction> findPending(String id) {
+        return actions.stream()
+                .filter(action -> action.getId().equals(id) && action.getStatus() == PerformanceActionStatus.PENDING)
+                .findFirst();
+    }
+
+    public synchronized Optional<PerformanceAction> findActive(String id) {
+        return actions.stream()
+                .filter(action -> action.getId().equals(id)
+                        && (action.getStatus() == PerformanceActionStatus.APPLIED
+                        || action.getStatus() == PerformanceActionStatus.APPROVED))
+                .findFirst();
+    }
+
+    public synchronized boolean hasPendingOrActive(String subsystem) {
+        return actions.stream()
+                .anyMatch(action -> action.getSubsystem().equals(subsystem)
+                        && (action.getStatus() == PerformanceActionStatus.PENDING
+                        || action.getStatus() == PerformanceActionStatus.APPROVED
+                        || action.getStatus() == PerformanceActionStatus.APPLIED));
+    }
+
+    public synchronized void markExpired(List<String> ids) {
+        for (String id : ids) {
+            actions.stream()
+                    .filter(action -> action.getId().equals(id))
+                    .forEach(PerformanceAction::markExpired);
+        }
+    }
+
+    public synchronized List<PerformanceAction> getPending() {
+        return actions.stream()
+                .filter(action -> action.getStatus() == PerformanceActionStatus.PENDING)
+                .collect(Collectors.toList());
+    }
+
+    public synchronized List<PerformanceAction> getActive() {
+        return actions.stream()
+                .filter(action -> action.getStatus() == PerformanceActionStatus.APPROVED
+                        || action.getStatus() == PerformanceActionStatus.APPLIED)
+                .collect(Collectors.toList());
+    }
+
+    public synchronized void reject(String id) {
+        actions.stream()
+                .filter(action -> action.getId().equals(id))
+                .findFirst()
+                .ifPresent(PerformanceAction::markRejected);
+    }
+
+    public synchronized void cleanupExpired() {
+        Iterator<PerformanceAction> iterator = actions.iterator();
+        while (iterator.hasNext()) {
+            PerformanceAction action = iterator.next();
+            if (action.getStatus() == PerformanceActionStatus.EXPIRED
+                    || action.getStatus() == PerformanceActionStatus.REJECTED) {
+                iterator.remove();
+            }
+        }
+    }
+
+    public synchronized List<PerformanceAction> expirePendingOlderThan(Instant cutoff) {
+        List<PerformanceAction> expired = new ArrayList<>();
+        for (PerformanceAction action : actions) {
+            if (action.getStatus() == PerformanceActionStatus.PENDING
+                    && action.getCreatedAt().isBefore(cutoff)) {
+                action.markExpired();
+                expired.add(action);
+            }
+        }
+        return expired;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceActionStatus.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceActionStatus.java
@@ -1,0 +1,13 @@
+package com.thunder.wildernessodysseyapi.AI_perf;
+
+/**
+ * Lifecycle states for a performance action that started as AI advice
+ * and requires human approval before execution.
+ */
+public enum PerformanceActionStatus {
+    PENDING,
+    APPROVED,
+    APPLIED,
+    REJECTED,
+    EXPIRED
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceMitigationController.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceMitigationController.java
@@ -1,0 +1,209 @@
+package com.thunder.wildernessodysseyapi.AI_perf;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Applies approved performance mitigations on the main thread and rolls them back
+ * when they expire.
+ */
+public final class PerformanceMitigationController {
+    private static final int DEFAULT_DURATION_SECONDS = 30;
+    private static final int MIN_SIM_DISTANCE = 2;
+    private static final int MIN_SEVERITY_FOR_ACTION = 2;
+    private static final int PENDING_TTL_SECONDS = 120;
+
+    private static final PerformanceActionQueue ACTION_QUEUE = new PerformanceActionQueue();
+
+    private static volatile int pathfindingThrottleInterval = 1;
+    private static volatile long pathfindingThrottleUntil = 0L;
+
+    private static volatile int entityTickInterval = 1;
+    private static volatile long entityTickUntil = 0L;
+
+    private static volatile int chunkDistanceDrop = 0;
+    private static volatile long chunkDistanceUntil = 0L;
+    private static volatile Integer originalSimulationDistance = null;
+
+    private static final ConcurrentHashMap<UUID, Boolean> frozenEntities = new ConcurrentHashMap<>();
+
+    private PerformanceMitigationController() {
+    }
+
+    public static PerformanceActionQueue getActionQueue() {
+        return ACTION_QUEUE;
+    }
+
+    public static List<PerformanceAction> buildActionsFromRequest(PerformanceAdvisoryRequest request) {
+        List<PerformanceAction> proposals = new ArrayList<>();
+        for (PerformanceAdvisoryRequest.SubsystemLoad load : request.subsystemLoads()) {
+            if (load.observedValue() < MIN_SEVERITY_FOR_ACTION) {
+                continue;
+            }
+            String subsystem = load.id();
+            switch (load.id()) {
+                case "entity-pathfinding" -> subsystem = "entity-pathfinding";
+                case "entity-behavior" -> subsystem = "entity-ticking";
+                case "chunk-processing" -> subsystem = "chunk-processing";
+                default -> {
+                    subsystem = null;
+                }
+            }
+            if (subsystem == null) {
+                continue;
+            }
+            if (ACTION_QUEUE.hasPendingOrActive(subsystem)) {
+                continue;
+            }
+            switch (subsystem) {
+                case "entity-pathfinding" -> proposals.add(new PerformanceAction(
+                        subsystem,
+                        "Throttle pathfinding for dense clusters (every 3 ticks).",
+                        load.evidence(),
+                        DEFAULT_DURATION_SECONDS,
+                        load.observedValue()));
+                case "entity-ticking" -> proposals.add(new PerformanceAction(
+                        subsystem,
+                        "Lower idle mob tick rate to ease behavior costs.",
+                        load.evidence(),
+                        DEFAULT_DURATION_SECONDS,
+                        load.observedValue()));
+                case "chunk-processing" -> proposals.add(new PerformanceAction(
+                        subsystem,
+                        "Temporarily shrink simulation distance to ease chunk queues.",
+                        load.evidence(),
+                        DEFAULT_DURATION_SECONDS,
+                        load.observedValue()));
+                default -> {
+                }
+            }
+        }
+        ACTION_QUEUE.replacePending(proposals);
+        return proposals;
+    }
+
+    public static void approveAndApply(MinecraftServer server, PerformanceAction action) {
+        action.markApproved();
+        switch (action.getSubsystem()) {
+            case "entity-pathfinding" -> applyPathfindingThrottle(server, 3, action.getDurationSeconds());
+            case "entity-ticking" -> applyEntityTickThrottle(server, 3, action.getDurationSeconds());
+            case "chunk-processing" -> applyChunkMitigation(server, 1, action.getDurationSeconds());
+            default -> {
+                ModConstants.LOGGER.warn("Unknown subsystem {} in performance action {}", action.getSubsystem(), action.getId());
+                return;
+            }
+        }
+        action.markApplied();
+    }
+
+    public static void tick(MinecraftServer server) {
+        long gameTime = server.overworld().getGameTime();
+        List<String> expired = new ArrayList<>();
+
+        if (pathfindingThrottleInterval > 1 && gameTime > pathfindingThrottleUntil) {
+            pathfindingThrottleInterval = 1;
+            expired.addAll(expireMatching("entity-pathfinding"));
+        }
+        if (entityTickInterval > 1 && gameTime > entityTickUntil) {
+            entityTickInterval = 1;
+            expired.addAll(expireMatching("entity-ticking"));
+        }
+        if (chunkDistanceDrop > 0 && gameTime > chunkDistanceUntil) {
+            rollbackChunkMitigation(server);
+            expired.addAll(expireMatching("chunk-processing"));
+        }
+
+        List<PerformanceAction> stalePending = ACTION_QUEUE
+                .expirePendingOlderThan(Instant.now().minusSeconds(PENDING_TTL_SECONDS));
+        if (!stalePending.isEmpty()) {
+            expired.addAll(stalePending.stream().map(PerformanceAction::getId).toList());
+        }
+        ACTION_QUEUE.markExpired(expired);
+        ACTION_QUEUE.cleanupExpired();
+    }
+
+    public static boolean isPathfindingThrottled(ServerLevel level) {
+        return pathfindingThrottleInterval > 1 && level.getGameTime() <= pathfindingThrottleUntil;
+    }
+
+    public static int getPathfindingThrottleInterval() {
+        return pathfindingThrottleInterval;
+    }
+
+    public static boolean isEntityTickThrottled(ServerLevel level) {
+        return entityTickInterval > 1 && level.getGameTime() <= entityTickUntil;
+    }
+
+    public static int getEntityTickInterval() {
+        return entityTickInterval;
+    }
+
+    public static void maybeFreezeEntity(Mob mob) {
+        if (!mob.isNoAi()) {
+            mob.setNoAi(true);
+            frozenEntities.put(mob.getUUID(), Boolean.TRUE);
+        }
+    }
+
+    public static void thawEntity(Mob mob) {
+        if (frozenEntities.remove(mob.getUUID()) != null) {
+            mob.setNoAi(false);
+        }
+    }
+
+    private static void applyPathfindingThrottle(MinecraftServer server, int intervalTicks, int durationSeconds) {
+        pathfindingThrottleInterval = Math.max(2, intervalTicks);
+        pathfindingThrottleUntil = server.overworld().getGameTime() + durationSeconds * 20L;
+    }
+
+    private static void applyEntityTickThrottle(MinecraftServer server, int intervalTicks, int durationSeconds) {
+        entityTickInterval = Math.max(2, intervalTicks);
+        entityTickUntil = server.overworld().getGameTime() + durationSeconds * 20L;
+    }
+
+    private static void applyChunkMitigation(MinecraftServer server, int dropBy, int durationSeconds) {
+        int desiredDrop = Math.max(0, dropBy);
+        if (desiredDrop == 0) return;
+
+        if (originalSimulationDistance == null) {
+            originalSimulationDistance = server.getPlayerList().getSimulationDistance();
+        }
+        int newDistance = Math.max(MIN_SIM_DISTANCE, originalSimulationDistance - desiredDrop);
+        if (newDistance < server.getPlayerList().getSimulationDistance()) {
+            server.getPlayerList().setSimulationDistance(newDistance);
+        }
+        chunkDistanceDrop = desiredDrop;
+        chunkDistanceUntil = server.overworld().getGameTime() + durationSeconds * 20L;
+    }
+
+    private static void rollbackChunkMitigation(MinecraftServer server) {
+        if (originalSimulationDistance != null) {
+            server.getPlayerList().setSimulationDistance(originalSimulationDistance);
+        }
+        originalSimulationDistance = null;
+        chunkDistanceDrop = 0;
+    }
+
+    private static List<String> expireMatching(String subsystem) {
+        return ACTION_QUEUE.getActive().stream()
+                .filter(action -> action.getSubsystem().equals(subsystem))
+                .peek(PerformanceAction::markExpired)
+                .map(PerformanceAction::getId)
+                .toList();
+    }
+
+    public static void thawNearbyPlayers(ServerLevel level) {
+        for (ServerPlayer ignored : level.players()) {
+            // Players visiting the level thaw nearby mobs by ticking them again
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceMitigationHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceMitigationHandler.java
@@ -1,0 +1,46 @@
+package com.thunder.wildernessodysseyapi.AI_perf;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.world.entity.Mob;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.event.TickEvent;
+import net.neoforged.neoforge.event.entity.living.LivingEvent;
+
+/**
+ * Performs lightweight, main-thread throttles once an action is approved.
+ */
+@Mod.EventBusSubscriber(modid = ModConstants.MOD_ID)
+public class PerformanceMitigationHandler {
+
+    @SubscribeEvent
+    public static void onLivingTick(LivingEvent.LivingTickEvent event) {
+        if (!(event.getEntity() instanceof Mob mob)) return;
+        if (!(mob.level() instanceof net.minecraft.server.level.ServerLevel serverLevel)) return;
+
+        if (PerformanceMitigationController.isEntityTickThrottled(serverLevel)
+                && mob.tickCount % PerformanceMitigationController.getEntityTickInterval() != 0) {
+            PerformanceMitigationController.maybeFreezeEntity(mob);
+            mob.getNavigation().stop();
+            return;
+        } else {
+            PerformanceMitigationController.thawEntity(mob);
+        }
+
+        if (PerformanceMitigationController.isPathfindingThrottled(serverLevel)
+                && mob.tickCount % PerformanceMitigationController.getPathfindingThrottleInterval() != 0) {
+            mob.getNavigation().stop();
+        }
+    }
+
+    @SubscribeEvent
+    public static void onLevelTick(TickEvent.LevelTickEvent event) {
+        if (event.level().isClientSide()) return;
+        if (event.phase != TickEvent.Phase.END) return;
+        if (event.level() instanceof net.minecraft.server.level.ServerLevel serverLevel) {
+            if (PerformanceMitigationController.isEntityTickThrottled(serverLevel)) {
+                PerformanceMitigationController.thawNearbyPlayers(serverLevel);
+            }
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/requestperfadvice.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/requestperfadvice.java
@@ -3,6 +3,8 @@ package com.thunder.wildernessodysseyapi.AI_perf;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.thunder.wildernessodysseyapi.AI_perf.PerformanceMitigationController;
+
 /**
  * Simple client that reads lore from {@code ai_config.yaml} and
  * echoes player messages. This acts as a placeholder for a future
@@ -26,6 +28,7 @@ public class requestperfadvice {
         String reply = PerformanceAdvisor.buildLocalAdvice(request);
         memoryStore.addMessage("server", prompt);
         memoryStore.addMessage("server", reply);
+        PerformanceMitigationController.buildActionsFromRequest(request);
         return reply;
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -15,6 +15,7 @@ import com.thunder.wildernessodysseyapi.ModListTracker.commands.ModListVersionCo
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.TerrainReplacerBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.configurable.StructureConfig;
+import com.thunder.wildernessodysseyapi.command.AiAdvisorCommand;
 import com.thunder.wildernessodysseyapi.command.StructureInfoCommand;
 import com.thunder.wildernessodysseyapi.donations.command.DonateCommand;
 import com.thunder.wildernessodysseyapi.doorlock.DoorLockEvents;
@@ -27,6 +28,7 @@ import com.thunder.wildernessodysseyapi.AntiCheat.BlacklistChecker;
 import com.thunder.wildernessodysseyapi.AI_perf.requestperfadvice;
 import com.thunder.wildernessodysseyapi.AI_perf.PerformanceAdvisor;
 import com.thunder.wildernessodysseyapi.AI_perf.PerformanceAdvisoryRequest;
+import com.thunder.wildernessodysseyapi.AI_perf.PerformanceMitigationController;
 import com.thunder.wildernessodysseyapi.donations.config.DonationReminderConfig;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.FriendlyByteBuf;
@@ -175,6 +177,7 @@ public class WildernessOdysseyAPIMainModClass {
         DonateCommand.register(event.getDispatcher());
         DoorLockCommand.register(event.getDispatcher());
         WorldGenScanCommand.register(event.getDispatcher());
+        AiAdvisorCommand.register(event.getDispatcher());
     }
 
     /**
@@ -235,6 +238,7 @@ public class WildernessOdysseyAPIMainModClass {
             worstTickTimeNanos = Math.max(worstTickTimeNanos, duration);
         }
         lastTickTimeNanos = now;
+        PerformanceMitigationController.tick(server);
         DeferredTaskScheduler.tick();
         if (!event.hasTime()) return;
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/AiAdvisorCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/AiAdvisorCommand.java
@@ -1,0 +1,70 @@
+package com.thunder.wildernessodysseyapi.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.thunder.wildernessodysseyapi.AI_perf.PerformanceAction;
+import com.thunder.wildernessodysseyapi.AI_perf.PerformanceActionQueue;
+import com.thunder.wildernessodysseyapi.AI_perf.PerformanceMitigationController;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class AiAdvisorCommand {
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("aiadvisor")
+                .requires(source -> source.hasPermission(2))
+                .then(Commands.literal("list").executes(AiAdvisorCommand::list))
+                .then(Commands.literal("approve")
+                        .then(Commands.argument("id", StringArgumentType.string())
+                                .executes(AiAdvisorCommand::approve)))
+                .then(Commands.literal("reject")
+                        .then(Commands.argument("id", StringArgumentType.string())
+                                .executes(AiAdvisorCommand::reject))));
+    }
+
+    private static int list(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+        PerformanceActionQueue queue = PerformanceMitigationController.getActionQueue();
+        List<PerformanceAction> actions = queue.getActions();
+        if (actions.isEmpty()) {
+            ctx.getSource().sendSuccess(() -> Component.literal("No AI advisor actions are queued."), false);
+            return 1;
+        }
+
+        String display = actions.stream()
+                .map(action -> action.getId() + " [" + action.getSubsystem() + "] " + action.getStatus()
+                        + " -> " + action.getSummary())
+                .collect(Collectors.joining("\n"));
+        ctx.getSource().sendSuccess(() -> Component.literal(display), false);
+        return 1;
+    }
+
+    private static int approve(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+        ServerPlayer player = ctx.getSource().getPlayerOrException();
+        String id = StringArgumentType.getString(ctx, "id");
+        PerformanceActionQueue queue = PerformanceMitigationController.getActionQueue();
+        Optional<PerformanceAction> action = queue.findPending(id);
+        if (action.isEmpty()) {
+            ctx.getSource().sendFailure(Component.literal("No pending AI advisor action with id " + id));
+            return 0;
+        }
+        PerformanceMitigationController.approveAndApply(player.serverLevel().getServer(), action.get());
+        ctx.getSource().sendSuccess(() -> Component.literal("Approved and applied action " + id), true);
+        return 1;
+    }
+
+    private static int reject(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+        String id = StringArgumentType.getString(ctx, "id");
+        PerformanceActionQueue queue = PerformanceMitigationController.getActionQueue();
+        queue.reject(id);
+        ctx.getSource().sendSuccess(() -> Component.literal("Rejected action " + id), true);
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- filter AI advisor proposals to skip low-severity subsystems and ignore duplicates already pending or active
- expire stale pending mitigation requests to keep the approval queue lean

## Testing
- ./gradlew test --console=plain *(aborted after a long setup/download phase)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69292d5063f48328a41d8af660c9b8c1)