### PR TITLE
Fix LevelTickEvent handler for NeoForge

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceMitigationHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceMitigationHandler.java
@@ -34,10 +34,12 @@ public class PerformanceMitigationHandler {
     }
 
     @SubscribeEvent
-    public static void onLevelTick(LevelTickEvent event) {
-        if (event.level().isClientSide()) return;
-        if (event.phase != TickEvent.Phase.END) return;
-        if (event.level() instanceof net.minecraft.server.level.ServerLevel serverLevel) {
+    public static void onLevelTick(LevelTickEvent.Post event) {
+        var level = event.getLevel();
+
+        if (level.isClientSide()) return;
+
+        if (level instanceof net.minecraft.server.level.ServerLevel serverLevel) {
             if (PerformanceMitigationController.isEntityTickThrottled(serverLevel)) {
                 PerformanceMitigationController.thawNearbyPlayers(serverLevel);
             }


### PR DESCRIPTION
## Summary
- update level tick event handler to target LevelTickEvent.Post and use the provided accessor
- keep server-level safety checks aligned with the current NeoForge tick event API

## Testing
- ./gradlew compileJava --console=plain --no-daemon


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c682242c8328ad47f467a1f21427)