### PR TITLE
Add Atlas wake-word activation and voice stub

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/MemoryStore.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/MemoryStore.java
@@ -6,21 +6,28 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Minimal per-player conversation history.
+ * Minimal per-player and per-world conversation history.
  */
 public class MemoryStore {
 
     private static final int MAX_HISTORY = 20;
-    private final Map<String, Deque<String>> messages = new HashMap<>();
+    private final Map<String, Map<String, Deque<String>>> worldMessages = new HashMap<>();
+
+    private static String normalizeWorld(String world) {
+        return world == null || world.isBlank() ? "default" : world;
+    }
 
     /**
      * Stores a player message.
      *
+     * @param world   world or save identifier
      * @param player  player name
      * @param message message text
      */
-    public void addMessage(String player, String message) {
-        Deque<String> deque = messages.computeIfAbsent(player, p -> new ArrayDeque<>());
+    public void addMessage(String world, String player, String message) {
+        String worldKey = normalizeWorld(world);
+        Map<String, Deque<String>> worldBucket = worldMessages.computeIfAbsent(worldKey, w -> new HashMap<>());
+        Deque<String> deque = worldBucket.computeIfAbsent(player, p -> new ArrayDeque<>());
         if (deque.size() >= MAX_HISTORY) {
             deque.removeFirst();
         }
@@ -30,11 +37,17 @@ public class MemoryStore {
     /**
      * Returns a newline-separated view of recent messages.
      *
+     * @param world  world or save identifier
      * @param player player name
      * @return context string or empty if none
      */
-    public String getRecentContext(String player) {
-        Deque<String> deque = messages.get(player);
+    public String getRecentContext(String world, String player) {
+        String worldKey = normalizeWorld(world);
+        Map<String, Deque<String>> worldBucket = worldMessages.get(worldKey);
+        if (worldBucket == null) {
+            return "";
+        }
+        Deque<String> deque = worldBucket.get(player);
         if (deque == null) {
             return "";
         }

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/requestperfadvice.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/requestperfadvice.java
@@ -24,8 +24,10 @@ public class requestperfadvice {
     public String requestPerformanceAdvice(PerformanceAdvisoryRequest request) {
         String prompt = PerformanceAdvisor.buildPrompt(request);
         String reply = PerformanceAdvisor.buildLocalAdvice(request);
-        memoryStore.addMessage("server", prompt);
-        memoryStore.addMessage("server", reply);
+        String worldKey = "server";
+        String assistantId = "advisor";
+        memoryStore.addMessage(worldKey, assistantId, prompt);
+        memoryStore.addMessage(worldKey, assistantId, reply);
         return reply;
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_story/AIClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_story/AIClient.java
@@ -8,17 +8,28 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 /**
- * Simple client that reads lore from {@code ai_config.yaml} and
- * echoes player messages. This acts as a placeholder for a future
- * networked AI service.
+ * Offline story helper that mixes the configured lore with recent
+ * player context to build lightweight, deterministic responses.
+ *
+ * All data is loaded from resources at startup so no external
+ * service or hosting is required.
  */
 public class AIClient {
 
     private final List<String> story = new ArrayList<>();
+    private final AISettings settings = new AISettings();
+    private final VoiceIntegration voiceIntegration = new VoiceIntegration(settings);
     private final MemoryStore memoryStore = new MemoryStore();
+    private final Map<String, StorySession> sessions = new HashMap<>();
 
     public AIClient() {
         loadStory();
@@ -31,11 +42,18 @@ public class AIClient {
             }
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
                 boolean inStory = false;
+                boolean inSettings = false;
                 String line;
                 while ((line = reader.readLine()) != null) {
                     line = line.trim();
                     if (line.startsWith("story:")) {
                         inStory = true;
+                        inSettings = false;
+                        continue;
+                    }
+                    if (line.startsWith("settings:")) {
+                        inSettings = true;
+                        inStory = false;
                         continue;
                     }
                     if (inStory) {
@@ -45,6 +63,9 @@ public class AIClient {
                             inStory = false;
                         }
                     }
+                    if (inSettings) {
+                        parseSetting(line);
+                    }
                 }
             }
         } catch (IOException ignored) {
@@ -52,17 +73,205 @@ public class AIClient {
         }
     }
 
+    private void parseSetting(String line) {
+        if (line.startsWith("voice_enabled:")) {
+            settings.setVoiceEnabled(parseBoolean(line));
+        } else if (line.startsWith("speech_recognition:")) {
+            settings.setSpeechRecognition(parseBoolean(line));
+        } else if (line.startsWith("model:")) {
+            settings.setModelName(parseStringValue(line));
+        } else if (line.startsWith("wake_word:")) {
+            settings.setWakeWord(parseStringValue(line));
+        }
+    }
+
+    private boolean parseBoolean(String line) {
+        String value = parseStringValue(line);
+        return "true".equalsIgnoreCase(value) || "yes".equalsIgnoreCase(value);
+    }
+
+    private String parseStringValue(String line) {
+        int colon = line.indexOf(":");
+        if (colon == -1 || colon == line.length() - 1) {
+            return "";
+        }
+        return line.substring(colon + 1).trim().replace("\"", "");
+    }
+
     /**
-     * Adds the message to memory and returns a canned reply that includes
-     * the first line of the loaded story as context.
+     * Adds the message to memory and returns an offline generated reply that
+     * blends world lore, recent player context, and a small set of
+     * deterministic templates.
      *
      * @param player  player name
      * @param message player message
      * @return AI reply
      */
     public String sendMessage(String player, String message) {
-        memoryStore.addMessage(player, message);
-        String prefix = story.isEmpty() ? "" : story.get(0) + " ";
-        return prefix + "You said: " + message;
+        return sendMessage(null, player, message);
+    }
+
+    /**
+     * Adds the message to per-world memory and returns an offline generated reply that
+     * blends world lore, recent player context, and a small set of
+     * deterministic templates.
+     *
+     * @param world   world or save identifier
+     * @param player  player name
+     * @param message player message
+     * @return AI reply
+     */
+    public String sendMessage(String world, String player, String message) {
+        return sendMessageWithVoice(world, player, message).text();
+    }
+
+    public VoiceIntegration.VoiceResult sendMessageWithVoice(String world, String player, String message) {
+        memoryStore.addMessage(world, player, message);
+        StorySession session = sessions.computeIfAbsent(sessionKey(world, player),
+                p -> new StorySession(world, settings.getWakeWord()));
+        String reply = session.buildResponse(world, player, message, story,
+                memoryStore.getRecentContext(world, player));
+        return voiceIntegration.wrap(reply);
+    }
+
+    private String sessionKey(String world, String player) {
+        String worldKey = world == null || world.isBlank() ? "default" : world.trim();
+        return worldKey + "::" + player;
+    }
+
+    private static class StorySession {
+
+        private final String world;
+        private final String wakeWord;
+        private boolean activated = false;
+
+        private int beat = 0;
+        private final Random random = ThreadLocalRandom.current();
+
+        StorySession(String world, String wakeWord) {
+            this.world = world == null ? "" : world;
+            this.wakeWord = wakeWord == null || wakeWord.isBlank() ? "atlas" : wakeWord.toLowerCase(Locale.ROOT);
+        }
+
+        String buildResponse(String world, String player, String message, List<String> story, String context) {
+            String cleanMessage = message == null ? "" : message.trim();
+            if (!activated && !mentionsWakeWord(cleanMessage)) {
+                return "Hi, I'm Atlas. Say \"" + wakeWord + "\" to get me chatting, and we can plan this world together.";
+            }
+            activated = activated || mentionsWakeWord(cleanMessage);
+            String loreHook = selectLoreHook(story);
+
+            StringBuilder reply = new StringBuilder();
+            if (!loreHook.isEmpty()) {
+                reply.append(loreHook).append(" ");
+            }
+
+            String focus = pickFocus(cleanMessage, player);
+            reply.append(focus);
+
+            String contextSnippet = summarizeContext(context);
+            if (!contextSnippet.isEmpty()) {
+                reply.append(" I remember what we sketched out: \"")
+                        .append(contextSnippet)
+                        .append("\". Want me to build on that?");
+            }
+
+            reply.append(" ");
+            reply.append(flavorLine(world, player));
+
+            return reply.toString().trim();
+        }
+
+        private String selectLoreHook(List<String> story) {
+            if (story.isEmpty()) {
+                return "The expedition AI hums softly.";
+            }
+            int index = Math.min(beat % story.size(), story.size() - 1);
+            beat++;
+            String base = story.get(index);
+            if (!world.isBlank()) {
+                return base + " I'm keeping notes for us in " + world + ".";
+            }
+            return base;
+        }
+
+        private String pickFocus(String message, String player) {
+            String lower = message.toLowerCase(Locale.ROOT);
+            if (lower.contains("help") || lower.contains("hint")) {
+                return "I've got us—let's salvage wood, secure water, and expand the platform before nightfall. What do you want me to handle while you gather?";
+            }
+            if (lower.contains("where") || lower.contains("location")) {
+                return "Our scanners show nearby islands with ore veins and a derelict lab; we can bridge there together. Which one should we scout first?";
+            }
+            if (lower.contains("why") || lower.contains("how")) {
+                return "Logs are fuzzy, but the collapse started when the core shattered. Rebuilding keeps the shards calm—I'll walk you through it and spot-check your builds.";
+            }
+            if (lower.contains("story") || lower.contains("lore")) {
+                return "Long ago this world was whole; now each island hides a memory we can piece together, side by side. Which tale do you want to chase next, %s?".formatted(player);
+            }
+            if (lower.contains("quest") || lower.contains("next")) {
+                return "Next, let's craft better tools, map the skies, and prep for a supply drop—I'll keep the checklist for us. Want me to pin the highest-priority task?";
+            }
+            if (lower.contains("thanks") || lower.contains("thank")) {
+                return "Anytime. I'm right here keeping the mission running with you. What should I watch for while you work?";
+            }
+            if (lower.isEmpty()) {
+                return "I'm listening—what do you feel like tackling together? I can fetch notes or track materials if you tell me.";
+            }
+            return "Got it. I'll weave that into our plan so we move as a team. Anything you want me to remember for this world?";
+        }
+
+        private boolean mentionsWakeWord(String message) {
+            if (message == null || message.isBlank()) {
+                return false;
+            }
+            return message.toLowerCase(Locale.ROOT).contains(wakeWord);
+        }
+
+        private String summarizeContext(String context) {
+            if (context == null || context.isEmpty()) {
+                return "";
+            }
+            List<String> lines = context.lines()
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty())
+                    .collect(Collectors.toList());
+            int size = lines.size();
+            if (size == 0) {
+                return "";
+            }
+            int start = Math.max(0, size - 3);
+            return String.join(" / ", lines.subList(start, size));
+        }
+
+        private String flavorLine(String world, String player) {
+            String[] moods = new String[]{
+                    "The air tastes metallic; keep your visor down and I'll watch your gauges, %s.",
+                    "Solar panels are charging, %s—we can risk a longer bridge over %s soon if you feel up for it.",
+                    "Wind turbines sing your name, %s; let's give them something to cheer about on %s.",
+                    "Data crystals hum with potential; I'll line up a recipe while you gather the parts, %s.",
+                    "Your footsteps echo across the void; I'm right beside you, %s.",
+                    "This save still smells like fresh planks, %s—want me to bookmark resource spots on %s for us?",
+                    "Our camp is cozy, %s. If you want, I can keep a tidy reminder list for us on %s."
+            };
+            String choice = moods[random.nextInt(moods.length)];
+            String worldNote = world == null || world.isBlank() ? "this world" : world;
+            int placeholders = countPlaceholders(choice);
+            return switch (placeholders) {
+                case 0 -> choice;
+                case 1 -> choice.formatted(player);
+                default -> choice.formatted(player, worldNote);
+            };
+        }
+
+        private int countPlaceholders(String text) {
+            int count = 0;
+            int index = text.indexOf("%s");
+            while (index != -1) {
+                count++;
+                index = text.indexOf("%s", index + 2);
+            }
+            return count;
+        }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_story/AISettings.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_story/AISettings.java
@@ -1,0 +1,46 @@
+package com.thunder.wildernessodysseyapi.AI_story;
+
+/**
+ * Lightweight settings parsed from ai_config.yaml.
+ */
+public class AISettings {
+
+    private boolean voiceEnabled = false;
+    private boolean speechRecognition = false;
+    private String modelName = "local-story-engine";
+    private String wakeWord = "atlas";
+
+    public boolean isVoiceEnabled() {
+        return voiceEnabled;
+    }
+
+    public void setVoiceEnabled(boolean voiceEnabled) {
+        this.voiceEnabled = voiceEnabled;
+    }
+
+    public boolean isSpeechRecognition() {
+        return speechRecognition;
+    }
+
+    public void setSpeechRecognition(boolean speechRecognition) {
+        this.speechRecognition = speechRecognition;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public void setModelName(String modelName) {
+        this.modelName = modelName;
+    }
+
+    public String getWakeWord() {
+        return wakeWord;
+    }
+
+    public void setWakeWord(String wakeWord) {
+        if (wakeWord != null && !wakeWord.isBlank()) {
+            this.wakeWord = wakeWord.trim().toLowerCase();
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_story/VoiceIntegration.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_story/VoiceIntegration.java
@@ -1,0 +1,24 @@
+package com.thunder.wildernessodysseyapi.AI_story;
+
+/**
+ * Offline-friendly voice stub that can be swapped for an actual TTS/ASR pipeline.
+ */
+public class VoiceIntegration {
+
+    public record VoiceResult(String text, String voiceLine, boolean voiceQueued, boolean speechInputAllowed) {
+    }
+
+    private final AISettings settings;
+
+    public VoiceIntegration(AISettings settings) {
+        this.settings = settings;
+    }
+
+    public VoiceResult wrap(String text) {
+        if (!settings.isVoiceEnabled()) {
+            return new VoiceResult(text, null, false, settings.isSpeechRecognition());
+        }
+        String voice = "Atlas (voice): " + text;
+        return new VoiceResult(text, voice, true, settings.isSpeechRecognition());
+    }
+}

--- a/src/main/resources/ai_config.yaml
+++ b/src/main/resources/ai_config.yaml
@@ -5,4 +5,5 @@ story:
 settings:
   voice_enabled: true
   speech_recognition: false
-  model: "gpt-4o-mini"
+  wake_word: "atlas"
+  model: "local-story-engine"


### PR DESCRIPTION
## Summary
- require the Atlas wake word before chats respond and remember activation per world session
- add AI settings parsing plus a voice integration stub that can wrap replies for playback or speech input support
- expose configurable wake word alongside the existing local model settings in `ai_config.yaml`

## Testing
- ./gradlew test --no-daemon --console=plain *(fails: existing PerformanceAdvisor dimension counting compile error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c54b97388328aff8bee4c8e1204b)