### PR TITLE
Use EntityTickEvent for tick listener registration

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceMitigationHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_perf/PerformanceMitigationHandler.java
@@ -4,7 +4,7 @@ import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import net.minecraft.world.entity.Mob;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.event.entity.living.LivingEvent;
+import net.neoforged.neoforge.event.tick.EntityTickEvent;
 import net.neoforged.neoforge.event.tick.LevelTickEvent;
 
 /**
@@ -14,7 +14,7 @@ import net.neoforged.neoforge.event.tick.LevelTickEvent;
 public class PerformanceMitigationHandler {
 
     @SubscribeEvent
-    public static void onLivingTick(LivingEvent event) {
+    public static void onEntityTick(EntityTickEvent.Pre event) {
         if (!(event.getEntity() instanceof Mob mob)) return;
         if (!(mob.level() instanceof net.minecraft.server.level.ServerLevel serverLevel)) return;
 
@@ -22,6 +22,7 @@ public class PerformanceMitigationHandler {
                 && mob.tickCount % PerformanceMitigationController.getEntityTickInterval() != 0) {
             PerformanceMitigationController.maybeFreezeEntity(mob);
             mob.getNavigation().stop();
+            event.setCanceled(true);
             return;
         } else {
             PerformanceMitigationController.thawEntity(mob);


### PR DESCRIPTION
## Summary
- register performance mitigation handler on EntityTickEvent.Pre since LivingTickEvent is unavailable
- cancel entity ticks when throttling while continuing pathfinding throttle handling

## Testing
- not run (compileJava blocked waiting on shared decompile artifact lock)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a46cb8e2483288ace0c1a44176e51)