### PR TITLE
Add Atlas wake-word chat responses

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_story/AIChatListener.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_story/AIChatListener.java
@@ -1,0 +1,52 @@
+package com.thunder.wildernessodysseyapi.AI_story;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.event.ServerChatEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Listens for chat messages that include the Atlas wake word and sends back
+ * lightweight AI replies using {@link AIClient}.
+ */
+public class AIChatListener {
+
+    private static final AIClient CLIENT = new AIClient();
+    private static final Set<UUID> ACTIVE_SESSIONS = ConcurrentHashMap.newKeySet();
+
+    @SubscribeEvent
+    public static void onChat(ServerChatEvent event) {
+        ServerPlayer player = event.getPlayer();
+        String message = event.getMessage().getString().trim();
+        if (message.isEmpty()) {
+            return;
+        }
+
+        String wakeWord = CLIENT.getWakeWord();
+        boolean mentionsWakeWord = message.toLowerCase(Locale.ROOT).contains(wakeWord);
+        boolean sessionActive = ACTIVE_SESSIONS.contains(player.getUUID());
+
+        if (!mentionsWakeWord && !sessionActive) {
+            return;
+        }
+
+        ACTIVE_SESSIONS.add(player.getUUID());
+
+        String worldKey = player.serverLevel().dimension().location().toString();
+        VoiceIntegration.VoiceResult reply = CLIENT.sendMessageWithVoice(worldKey,
+                player.getName().getString(), message);
+
+        player.sendSystemMessage(Component.literal("[Atlas] " + reply.text()));
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLogout(PlayerEvent.PlayerLoggedOutEvent event) {
+        ACTIVE_SESSIONS.remove(event.getEntity().getUUID());
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI_story/AIClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI_story/AIClient.java
@@ -35,6 +35,10 @@ public class AIClient {
         loadStory();
     }
 
+    public String getWakeWord() {
+        return settings.getWakeWord();
+    }
+
     private void loadStory() {
         try (InputStream in = requestperfadvice.class.getClassLoader().getResourceAsStream("ai_config.yaml")) {
             if (in == null) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -27,6 +27,7 @@ import com.thunder.wildernessodysseyapi.command.WorldGenScanCommand;
 import com.thunder.wildernessodysseyapi.config.ConfigRegistrationValidator;
 import com.thunder.wildernessodysseyapi.item.ModCreativeTabs;
 import com.thunder.wildernessodysseyapi.item.ModItems;
+import com.thunder.wildernessodysseyapi.AI_story.AIChatListener;
 import com.thunder.wildernessodysseyapi.AntiCheat.BlacklistChecker;
 import com.thunder.wildernessodysseyapi.AI_perf.requestperfadvice;
 import com.thunder.wildernessodysseyapi.AI_perf.PerformanceAdvisor;
@@ -119,6 +120,7 @@ public class WildernessOdysseyAPIMainModClass {
         NeoForge.EVENT_BUS.register(BlacklistChecker.class);
         NeoForge.EVENT_BUS.register(InfiniteSourceHandler.class);
         NeoForge.EVENT_BUS.register(DoorLockEvents.class);
+        NeoForge.EVENT_BUS.register(AIChatListener.class);
 
         CryoTubeBlock.register(modEventBus);
         TerrainReplacerBlock.register(modEventBus);


### PR DESCRIPTION
## Summary
- expose the configured wake word from AIClient and register a chat listener
- respond in chat when players mention Atlas or continue an active session, preserving per-world context
- hook the listener into the mod event bus for server-side processing

## Testing
- ./gradlew test --console=plain --no-daemon


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a7aef5c608328a3b007b9087e82b4)