### PR TITLE
Add anchor relay command and default global chat endpoint

### DIFF
--- a/docs/global-chat-beginner.md
+++ b/docs/global-chat-beginner.md
@@ -15,15 +15,15 @@ This guide walks through the minimum steps to host the central relay on one dedi
 
 ## Step 1: Start the relay on the host server
 1. Copy the mod jar to the host machine.
-2. On that machine, start the relay once with your secrets (replace the values):
+2. On that machine, start the relay once with your secrets (replace the values) on the hard-coded endpoint the clients expect (`198.51.100.77:39876`):
    ```bash
    java -Dwilderness.globalchat.token=YOUR_MODERATION_TOKEN \
         -Dwilderness.globalchat.clustertoken=YOUR_CLUSTER_TOKEN \
         -cp <path-to-mod-jar-or-classpath> \
         com.thunder.wildernessodysseyapi.globalchat.server.GlobalChatRelayServer 39876
    ```
-   - `39876` is the default port; change it if needed.
-   - Only this host should run the relay. Other servers will connect to it.
+   - `39876` is the default port; keep it in sync with the built-in client default.
+   - Only this host should run the relay. Other servers will connect to it at `198.51.100.77:39876`.
 3. (Optional) Allow the relay to auto-start alongside this server if you prefer the built-in sidecar:
    ```
    /globalchat allowautostart true
@@ -32,17 +32,16 @@ This guide walks through the minimum steps to host the central relay on one dedi
    /globalchat startserver
    ```
 
-## Step 2: Bind each Minecraft server to the relay
+## Step 2: Anchor each Minecraft server to the relay
 Run these commands in-game or from the server console on **every** participating server (including the host):
-``` 
+```
 /globalchat clustertoken YOUR_CLUSTER_TOKEN
 /globalchat moderationtoken YOUR_MODERATION_TOKEN
-/globalchat bind <relay-hostname-or-ip> 39876
-/globalchat enable true
+/globalchat anchorrelay
 ```
-- `bind` saves the host/port to `config/wildernessodysseyapi/global-chat.json` and immediately connects.
-- `enable true` lets the client reconnect automatically after restarts.
+- `anchorrelay` pins the client to `198.51.100.77:39876`, saves the endpoint to `config/wildernessodysseyapi/global-chat.json`, and immediately connects.
 - Keep `/globalchat startserver` **disabled** on all non-host servers to avoid duplicate relays.
+- Use `/globalchat bind <relay-hostname-or-ip> <port>` only for short-term testing if you need a non-default endpoint.
 
 ## Step 3: Players opt in and chat
 - Players must opt in once per player:

--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -8,25 +8,26 @@ The global chat system lets multiple Wilderness Odyssey servers share messages t
 - **Commands**: Registered under `/globalchat` for binding, status checks, opt-in, messaging, relay lifecycle, and moderation.
 
 ## Anchoring the relay to a dedicated host
-1. Pick the Minecraft server that should host the central relay. On that machine, launch the relay directly:
+1. Pick the Minecraft server that should host the central relay. On that machine, launch the relay directly, pinned to the hard-coded endpoint the clients expect (`198.51.100.77:39876`):
    ```bash
    java -Dwilderness.globalchat.token=<moderationToken> \
         -Dwilderness.globalchat.clustertoken=<clusterSecret> \
         -cp <path-to-mod-jar-or-classpath> \
         com.thunder.wildernessodysseyapi.globalchat.server.GlobalChatRelayServer <port>
    ```
-   - Replace `<port>` with the TCP port you want the relay to listen on (defaults to `39876` if omitted).
+   - Replace `<port>` with the TCP port you want the relay to listen on (defaults to `39876` if omitted) and match the hard-coded client port.
    - The `wilderness.globalchat.token` system property must match the moderation token you configure on each participating server.
    - (Optional but recommended) Set `wilderness.globalchat.clustertoken` to a shared secret that every server must present during the handshake. Connections without the matching token are dropped before the relay will process messages.
 2. On every other server, **keep relay autostart disabled** (the default) so the `startserver` command is blocked and the relay stays anchored to your chosen host.
 3. If you explicitly want a server to be allowed to spawn the relay sidecar, run `/globalchat allowautostart true` as an operator on that server.
 
 ## Connecting a server to the relay
-1. As an operator, bind the server to the relay host and port:
+1. As an operator, anchor the server to the shared relay endpoint:
    ```
-   /globalchat bind <host> <port>
+   /globalchat anchorrelay
    ```
-   This persists to `config/wildernessodysseyapi/global-chat.json` and immediately attempts a connection.
+   This pins the client to `198.51.100.77:39876`, persists to `config/wildernessodysseyapi/global-chat.json`, and immediately attempts a connection.
+   If you need to override the endpoint for testing, `/globalchat bind <host> <port>` is still available but production clusters should stick to the anchored IP/port.
 2. Verify connectivity and latency:
    ```
    /globalchat status

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/GlobalChatCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/GlobalChatCommand.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.context.CommandContext;
 import com.thunder.wildernessodysseyapi.globalchat.GlobalChatManager;
 import com.thunder.wildernessodysseyapi.globalchat.GlobalChatOptIn;
 import com.thunder.wildernessodysseyapi.globalchat.GlobalChatServerProcess;
+import com.thunder.wildernessodysseyapi.globalchat.GlobalChatSettings;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
@@ -34,6 +35,9 @@ public class GlobalChatCommand {
                 .then(Commands.literal("optin")
                         .then(Commands.argument("enabled", BoolArgumentType.bool())
                                 .executes(GlobalChatCommand::optIn)))
+                .then(Commands.literal("anchorrelay")
+                        .requires(source -> source.hasPermission(2))
+                        .executes(GlobalChatCommand::anchorRelay))
                 .then(Commands.literal("send")
                         .then(Commands.argument("message", StringArgumentType.greedyString())
                                 .executes(GlobalChatCommand::send)))
@@ -150,6 +154,15 @@ public class GlobalChatCommand {
         boolean enabled = BoolArgumentType.getBool(ctx, "enabled");
         GlobalChatOptIn.setOptIn(player, enabled);
         ctx.getSource().sendSuccess(() -> Component.literal("Global chat opt-in set to " + (enabled ? "enabled" : "disabled")), false);
+        return 1;
+    }
+
+    private static int anchorRelay(CommandContext<CommandSourceStack> ctx) {
+        GlobalChatManager.getInstance().anchorToDefaultRelay();
+        ctx.getSource().sendSuccess(() -> Component.literal(
+                "Anchored to central relay at "
+                        + GlobalChatSettings.DEFAULT_RELAY_HOST + ":" + GlobalChatSettings.DEFAULT_RELAY_PORT
+                        + " and auto-connect enabled."), true);
         return 1;
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatManager.java
@@ -52,6 +52,7 @@ public class GlobalChatManager {
         this.server = server;
         this.settingsFile = configDir.resolve("wildernessodysseyapi/global-chat.json");
         this.settings = GlobalChatSettings.load(settingsFile);
+        this.settings.save(settingsFile);
         if (settings.enabled() && !settings.host().isEmpty() && settings.port() > 0) {
             connect();
         }
@@ -157,6 +158,12 @@ public class GlobalChatManager {
         settings.setHost(host);
         settings.setPort(port);
         settings.setEnabled(true);
+        settings.save(settingsFile);
+        connect();
+    }
+
+    public void anchorToDefaultRelay() {
+        settings.anchorToDefaultRelay();
         settings.save(settingsFile);
         connect();
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatSettings.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatSettings.java
@@ -17,12 +17,15 @@ import java.util.Objects;
  */
 public class GlobalChatSettings {
 
+    public static final String DEFAULT_RELAY_HOST = "198.51.100.77";
+    public static final int DEFAULT_RELAY_PORT = 39876;
+
     private static final Moshi MOSHI = new Moshi.Builder().build();
     private static final JsonAdapter<GlobalChatSettings> ADAPTER = MOSHI.adapter(GlobalChatSettings.class);
 
-    private String host = "";
-    private int port = 0;
-    private boolean enabled = false;
+    private String host = DEFAULT_RELAY_HOST;
+    private int port = DEFAULT_RELAY_PORT;
+    private boolean enabled = true;
     private List<String> downtimeHistory = new ArrayList<>();
     private boolean allowServerAutostart = false;
     private String moderationToken = "";
@@ -34,6 +37,7 @@ public class GlobalChatSettings {
                 String raw = Files.readString(file);
                 GlobalChatSettings settings = ADAPTER.fromJson(raw);
                 if (settings != null) {
+                    settings.applyDefaultRelayIfUnset();
                     return settings;
                 }
             } catch (IOException ignored) {
@@ -110,5 +114,20 @@ public class GlobalChatSettings {
 
     public void setClusterToken(String clusterToken) {
         this.clusterToken = clusterToken == null ? "" : clusterToken;
+    }
+
+    public void applyDefaultRelayIfUnset() {
+        if (host == null || host.isEmpty()) {
+            host = DEFAULT_RELAY_HOST;
+        }
+        if (port <= 0) {
+            port = DEFAULT_RELAY_PORT;
+        }
+    }
+
+    public void anchorToDefaultRelay() {
+        host = DEFAULT_RELAY_HOST;
+        port = DEFAULT_RELAY_PORT;
+        enabled = true;
     }
 }


### PR DESCRIPTION
## Summary
- add default relay host/port defaults to global chat settings and ensure configs persist them
- provide a /globalchat anchorrelay admin command to pin clients to the central relay endpoint
- document the hard-coded relay IP/port and updated anchoring workflow in both guides

## Testing
- ./gradlew test --console=plain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cf2e2694c8328ad1c3bec21445b72)