### PR TITLE
Ensure bundled libraries available on runtime classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,11 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 configurations {
     runtimeClasspath.extendsFrom localRuntime
 
+    // Ensure bundled libraries are also available on the dev runtime classpath.
+    // Without this, running from compiled classes (not the shaded jar) can miss
+    // dependencies like Moshi and OkHttp, leading to NoClassDefFoundError at startup.
+    runtimeClasspath.extendsFrom bundledLibs
+
     // Libraries that must be bundled directly into the mod jar so they are available at runtime.
     bundledLibs
 }


### PR DESCRIPTION
## Summary
- extend the runtime classpath with bundled libraries so dev runs include Moshi and other dependencies

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d1a0848688328a882e1195473a367)