### PR TITLE
Add Okio runtime bundling for global chat Moshi dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,11 +149,13 @@ dependencies {
     // AI advisory helpers (HTTP client, JSON, and fault tolerance)
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.squareup.moshi:moshi:1.15.1'
+    implementation 'com.squareup.okio:okio:3.9.0'
     implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
 
     // Bundle third-party libraries into the final mod jar to avoid missing-class errors at runtime.
     bundledLibs 'com.squareup.okhttp3:okhttp:4.12.0'
     bundledLibs 'com.squareup.moshi:moshi:1.15.1'
+    bundledLibs 'com.squareup.okio:okio:3.9.0'
     bundledLibs 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
 
     // Example optional mod dependency with JEI


### PR DESCRIPTION
## Summary
- add Okio as a Moshi dependency and include it in the bundled libraries configuration
- ensure the mod jar packages Moshi and Okio to avoid missing-class errors at runtime

## Testing
- ./gradlew --no-daemon --console=plain build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d1ac45f4c83288964fd44fb1a5139)