### PR TITLE
Ensure bundled libs on dev runtime classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,13 @@ configurations {
     bundledLibs
 }
 
+// Make sure Gradle run configurations (JavaExec tasks) also see bundled libraries when
+// launching directly from compiled classes, matching the crash log path
+// `/build/classes/java/main/`.
+tasks.withType(JavaExec).configureEach {
+    classpath += configurations.bundledLibs
+}
+
 repositories {
     maven {
         url "https://cursemaven.com"


### PR DESCRIPTION
## Summary
- ensure bundled library configuration is applied to JavaExec run tasks so dev launches include Moshi and other bundled deps
- avoid NoClassDefFoundError when running the mod directly from compiled classes during development

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d23557eb883288314556563f0413c)