### PR TITLE
Add dedicated opt-in commands and login prompt for global chat

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -13,6 +13,7 @@ import com.thunder.wildernessodysseyapi.MemUtils.MemoryUtils;
 import com.thunder.wildernessodysseyapi.ModListTracker.commands.ModListDiffCommand;
 import com.thunder.wildernessodysseyapi.ModListTracker.commands.ModListVersionCommand;
 import com.thunder.wildernessodysseyapi.command.GlobalChatCommand;
+import com.thunder.wildernessodysseyapi.command.GlobalChatOptToggleCommand;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.TerrainReplacerBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.worldgen.configurable.StructureConfig;
@@ -42,6 +43,7 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
@@ -194,6 +196,7 @@ public class WildernessOdysseyAPIMainModClass {
         AiAdvisorCommand.register(event.getDispatcher());
         AsyncStatsCommand.register(dispatcher);
         GlobalChatCommand.register(dispatcher);
+        GlobalChatOptToggleCommand.register(dispatcher);
     }
 
     /**
@@ -206,6 +209,7 @@ public class WildernessOdysseyAPIMainModClass {
         if (!(event.getEntity() instanceof ServerPlayer player)) return;
 
         MeteorStructureSpawner.scheduleInitialPlacement(player.serverLevel());
+        player.sendSystemMessage(Component.literal("[GlobalChat] Global chat is opt-in. Use /globalchatoptin to join or /globalchatoptout to leave."));
     }
     /**
      * On mob spawn.

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/GlobalChatOptToggleCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/GlobalChatOptToggleCommand.java
@@ -1,0 +1,40 @@
+package com.thunder.wildernessodysseyapi.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.thunder.wildernessodysseyapi.globalchat.GlobalChatOptIn;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+/**
+ * Simple opt-in/out command dedicated to the global chat feature.
+ */
+public final class GlobalChatOptToggleCommand {
+
+    private GlobalChatOptToggleCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("globalchatoptin")
+                .executes(ctx -> setOptIn(ctx, true))
+                .then(Commands.argument("enabled", BoolArgumentType.bool())
+                        .executes(ctx -> setOptIn(ctx, BoolArgumentType.getBool(ctx, "enabled")))));
+
+        dispatcher.register(Commands.literal("globalchatoptout")
+                .executes(ctx -> setOptIn(ctx, false)));
+    }
+
+    private static int setOptIn(CommandContext<CommandSourceStack> ctx, boolean enabled) {
+        ServerPlayer player = ctx.getSource().getPlayer();
+        if (player == null) {
+            ctx.getSource().sendFailure(Component.literal("Only players can change their global chat opt-in status."));
+            return 0;
+        }
+        GlobalChatOptIn.setOptIn(player, enabled);
+        ctx.getSource().sendSuccess(() -> Component.literal("Global chat opt-in set to " + (enabled ? "enabled" : "disabled")), false);
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated commands for players to opt into or out of global chat
- register the new commands and notify players at login about the opt-in choice

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dd8d494288328a36b0512eca6ef6d)