### PR TITLE
Increase tolerance for NBT parsing timeouts

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.thunder.wildernessodysseyapi.util.NbtParsingUtils;
+
 /**
  * Places vanilla structure templates loaded from NBT files and exposes metadata used by the mod.
  */
@@ -155,6 +157,7 @@ public class NBTStructurePlacer {
 
         Resource resource = resourceOpt.get();
         try (InputStream in = resource.open()) {
+            NbtParsingUtils.extendNbtParseTimeout();
             CompoundTag tag = NbtIo.readCompressed(in, NbtAccounter.unlimitedHeap());
             ListTag palette = tag.getList("palette", Tag.TAG_COMPOUND);
             List<String> paletteNames = new ArrayList<>(palette.size());

--- a/src/main/java/com/thunder/wildernessodysseyapi/loottable/StructureLootScanner.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/loottable/StructureLootScanner.java
@@ -5,6 +5,8 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.Tag;
+
+import com.thunder.wildernessodysseyapi.util.NbtParsingUtils;
 import net.minecraft.resources.ResourceLocation;
 
 import java.io.IOException;
@@ -36,6 +38,7 @@ public class StructureLootScanner {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(structuresDir, "*.nbt")) {
             for (Path path : stream) {
                 try {
+                    NbtParsingUtils.extendNbtParseTimeout();
                     CompoundTag nbt = NbtIo.readCompressed(path, NbtAccounter.unlimitedHeap());
                     scanTemplate(nbt, foundLootTables);
                 } catch (Exception e) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/util/NbtParsingUtils.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/util/NbtParsingUtils.java
@@ -1,0 +1,64 @@
+package com.thunder.wildernessodysseyapi.util;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.nbt.NbtIo;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Locale;
+
+/**
+ * Helpers for working around vanilla's NBT parsing safeguards.
+ */
+public final class NbtParsingUtils {
+    private static final int DESIRED_TIMEOUT_MS = 30_000;
+    private static boolean attemptedAdjustment = false;
+
+    private NbtParsingUtils() {
+    }
+
+    /**
+     * Attempts to extend the vanilla NBT parse timeout so large prefab files
+     * don't trip the default 10 second limit.
+     */
+    public static void extendNbtParseTimeout() {
+        if (attemptedAdjustment) {
+            return;
+        }
+        attemptedAdjustment = true;
+
+        try {
+            for (Field field : NbtIo.class.getDeclaredFields()) {
+                if (!Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+
+                String name = field.getName().toLowerCase(Locale.ROOT);
+                if (!name.contains("timeout")) {
+                    continue;
+                }
+
+                field.setAccessible(true);
+                if (field.getType() == int.class) {
+                    int previous = field.getInt(null);
+                    if (DESIRED_TIMEOUT_MS > previous) {
+                        field.setInt(null, DESIRED_TIMEOUT_MS);
+                        ModConstants.LOGGER.info("Raised NBT parse timeout from {}ms to {}ms via {}", previous, DESIRED_TIMEOUT_MS,
+                                field.getName());
+                    }
+                } else if (field.getType() == long.class) {
+                    long previous = field.getLong(null);
+                    if (DESIRED_TIMEOUT_MS > previous) {
+                        field.setLong(null, DESIRED_TIMEOUT_MS);
+                        ModConstants.LOGGER.info("Raised NBT parse timeout from {}ms to {}ms via {}", previous, DESIRED_TIMEOUT_MS,
+                                field.getName());
+                    }
+                }
+
+                return;
+            }
+        } catch (Exception e) {
+            ModConstants.LOGGER.debug("Failed to adjust NBT parse timeout; continuing with defaults", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an NBT parsing utility that raises the parse timeout when possible
- use the utility before reading structure templates and loot scanner files to avoid 10s parse timeouts

## Testing
- ./gradlew compileJava --no-daemon --console=plain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ddf18aeac8328983039ef22ada623)