### PR TITLE
Ensure NBT parse timeout is raised via mixin

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/NbtIoMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/NbtIoMixin.java
@@ -1,0 +1,19 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.thunder.wildernessodysseyapi.util.NbtParsingUtils;
+import net.minecraft.nbt.NbtIo;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Ensures vanilla NBT parsing uses the extended timeout limit.
+ */
+@Mixin(NbtIo.class)
+public abstract class NbtIoMixin {
+    @Inject(method = "<clinit>", at = @At("TAIL"))
+    private static void wildernessodysseyapi$extendParseTimeout(CallbackInfo ci) {
+        NbtParsingUtils.extendNbtParseTimeout();
+    }
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -4,14 +4,15 @@
   "package": "com.thunder.wildernessodysseyapi.mixin",
   "compatibilityLevel": "JAVA_17",
   "refmap": "mixins.wildernessodysseyapi.refmap.json",
-  "mixins": [
-    "BlockEntityMixin",
-    "CampfireBlockMixin",
-    "DayNightCycleMixin",
-    "EntityAccessor",
-    "ServerboundSetStructureBlockPacketMixin",
-    "StructureBlockEntityMixin"
-  ],
+    "mixins": [
+      "BlockEntityMixin",
+      "CampfireBlockMixin",
+      "DayNightCycleMixin",
+      "EntityAccessor",
+      "NbtIoMixin",
+      "ServerboundSetStructureBlockPacketMixin",
+      "StructureBlockEntityMixin"
+    ],
   "injectors": {
     "defaultRequire": 1
   },


### PR DESCRIPTION
## Summary
- add an NbtIo mixin that automatically extends the NBT parse timeout when vanilla initializes
- register the new mixin in the mod mixin configuration

## Testing
- ./gradlew classes -x test --console=plain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de7809a608328a0b4a394b4ec864a)