### PR TITLE
Populate AI advisor action queue from performance observations

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -279,6 +279,7 @@ public class WildernessOdysseyAPIMainModClass {
             worstTickTimeNanos = 0L;
             if (worstTickMillis > PerformanceAdvisor.DEFAULT_TICK_BUDGET_MS) {
                 PerformanceAdvisoryRequest request = PerformanceAdvisor.observe(server, worstTickMillis);
+                PerformanceMitigationController.buildActionsFromRequest(request);
                 String advisory = requestperfadvice.requestPerformanceAdvice(request);
                 LOGGER.info("[AI Advisor] {}", advisory);
             }


### PR DESCRIPTION
## Summary
- enqueue AI advisor performance actions whenever a heavy tick is observed so they appear in the /aiadvisor list command

## Testing
- `./gradlew test --console=plain` *(fails: interrupted while waiting on Gradle artifact lock)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de530c800832882b69caf93a2f05d)