### PR TITLE
Optimize structure metadata extraction from templates

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/util/NbtParsingUtils.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/util/NbtParsingUtils.java
@@ -21,42 +21,66 @@ public final class NbtParsingUtils {
      * Attempts to extend the vanilla NBT parse timeout so large prefab files
      * don't trip the default 10 second limit.
      */
-    public static void extendNbtParseTimeout() {
+    public static synchronized void extendNbtParseTimeout() {
         if (attemptedAdjustment) {
             return;
         }
-        attemptedAdjustment = true;
 
         try {
+            Field target = null;
             for (Field field : NbtIo.class.getDeclaredFields()) {
                 if (!Modifier.isStatic(field.getModifiers())) {
                     continue;
                 }
 
                 String name = field.getName().toLowerCase(Locale.ROOT);
-                if (!name.contains("timeout")) {
-                    continue;
+                if (name.contains("timeout") || name.contains("time_limit") || name.contains("timeconstraint")) {
+                    target = field;
+                    break;
                 }
+            }
 
-                field.setAccessible(true);
-                if (field.getType() == int.class) {
-                    int previous = field.getInt(null);
-                    if (DESIRED_TIMEOUT_MS > previous) {
-                        field.setInt(null, DESIRED_TIMEOUT_MS);
-                        ModConstants.LOGGER.info("Raised NBT parse timeout from {}ms to {}ms via {}", previous, DESIRED_TIMEOUT_MS,
-                                field.getName());
+            if (target == null) {
+                for (Field field : NbtIo.class.getDeclaredFields()) {
+                    if (!Modifier.isStatic(field.getModifiers())) {
+                        continue;
                     }
-                } else if (field.getType() == long.class) {
-                    long previous = field.getLong(null);
-                    if (DESIRED_TIMEOUT_MS > previous) {
-                        field.setLong(null, DESIRED_TIMEOUT_MS);
-                        ModConstants.LOGGER.info("Raised NBT parse timeout from {}ms to {}ms via {}", previous, DESIRED_TIMEOUT_MS,
-                                field.getName());
+                    if (field.getType() != int.class && field.getType() != long.class) {
+                        continue;
+                    }
+
+                    field.setAccessible(true);
+                    long value = field.getType() == int.class ? field.getInt(null) : field.getLong(null);
+                    if (value >= 5_000 && value <= DESIRED_TIMEOUT_MS) {
+                        target = field;
+                        break;
                     }
                 }
+            }
 
+            if (target == null) {
+                ModConstants.LOGGER.debug("No timeout-like field found on NbtIo; leaving vanilla parse timeout intact");
                 return;
             }
+
+            target.setAccessible(true);
+            if (target.getType() == int.class) {
+                int previous = target.getInt(null);
+                if (DESIRED_TIMEOUT_MS > previous) {
+                    target.setInt(null, DESIRED_TIMEOUT_MS);
+                    ModConstants.LOGGER.info("Raised NBT parse timeout from {}ms to {}ms via {}", previous, DESIRED_TIMEOUT_MS,
+                            target.getName());
+                }
+            } else if (target.getType() == long.class) {
+                long previous = target.getLong(null);
+                if (DESIRED_TIMEOUT_MS > previous) {
+                    target.setLong(null, DESIRED_TIMEOUT_MS);
+                    ModConstants.LOGGER.info("Raised NBT parse timeout from {}ms to {}ms via {}", previous, DESIRED_TIMEOUT_MS,
+                            target.getName());
+                }
+            }
+
+            attemptedAdjustment = true;
         } catch (Exception e) {
             ModConstants.LOGGER.debug("Failed to adjust NBT parse timeout; continuing with defaults", e);
         }


### PR DESCRIPTION
## Summary
- reuse loaded structure templates to find cryo tubes, terrain replacers, and leveling markers instead of re-reading the compressed NBT
- log when expected marker blocks are missing and ensure the NBT timeout is raised before template loading begins

## Testing
- ./gradlew test --console=plain

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e6951fc6c832885945724ad8d2dca)