### PR TITLE
Retarget NBT timeout mixin to TagParser

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -28,6 +28,7 @@ import com.thunder.wildernessodysseyapi.command.WorldGenScanCommand;
 import com.thunder.wildernessodysseyapi.config.ConfigRegistrationValidator;
 import com.thunder.wildernessodysseyapi.item.ModCreativeTabs;
 import com.thunder.wildernessodysseyapi.item.ModItems;
+import com.thunder.wildernessodysseyapi.util.NbtParsingUtils;
 import com.thunder.wildernessodysseyapi.AI_story.AIChatListener;
 import com.thunder.wildernessodysseyapi.AntiCheat.AntiCheatConfig;
 import com.thunder.wildernessodysseyapi.AntiCheat.BlacklistChecker;
@@ -114,6 +115,9 @@ public class WildernessOdysseyAPIMainModClass {
      */
     public WildernessOdysseyAPIMainModClass(IEventBus modEventBus, ModContainer container) {
         LOGGER.info("WildernessOdysseyAPI initialized. I will also start to track mod conflicts");
+
+        // Ensure large prefab NBT files can parse before any structures or UI attempt to load them.
+        NbtParsingUtils.extendNbtParseTimeout();
         // Register mod setup and creative tabs
         modEventBus.addListener(this::commonSetup);
         modEventBus.addListener(this::onConfigLoaded);

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/TagParserMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/TagParserMixin.java
@@ -1,17 +1,18 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
 import com.thunder.wildernessodysseyapi.util.NbtParsingUtils;
-import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.TagParser;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
- * Ensures vanilla NBT parsing uses the extended timeout limit.
+ * Ensures the vanilla SNBT parser uses the extended timeout limit when loading large prefab files.
  */
-@Mixin(NbtIo.class)
-public abstract class NbtIoMixin {
+@Mixin(TagParser.class)
+public abstract class TagParserMixin {
+
     @Inject(method = "<clinit>", at = @At("TAIL"))
     private static void wildernessodysseyapi$extendParseTimeout(CallbackInfo ci) {
         NbtParsingUtils.extendNbtParseTimeout();

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -9,7 +9,7 @@
       "CampfireBlockMixin",
       "DayNightCycleMixin",
       "EntityAccessor",
-      "NbtIoMixin",
+      "TagParserMixin",
       "ServerboundSetStructureBlockPacketMixin",
       "StructureBlockEntityMixin"
     ],


### PR DESCRIPTION
## Summary
- retarget the NBT timeout mixin to TagParser where the parse timeout is enforced
- ensure the extended timeout is applied during SNBT parser initialization instead of NbtIo

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e81ca492883288dab8f57c3ee5f3e)