### PR TITLE
Raise NBT parse timeout limit

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/TagParserMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/TagParserMixin.java
@@ -5,6 +5,8 @@ import net.minecraft.nbt.TagParser;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
@@ -16,5 +18,10 @@ public abstract class TagParserMixin {
     @Inject(method = "<clinit>", at = @At("TAIL"))
     private static void wildernessodysseyapi$extendParseTimeout(CallbackInfo ci) {
         NbtParsingUtils.extendNbtParseTimeout();
+    }
+
+    @ModifyConstant(method = "<clinit>", constant = @Constant(intValue = 10_000))
+    private static int wildernessodysseyapi$raiseTimeoutConstant(int original) {
+        return Math.max(original, NbtParsingUtils.getDesiredTimeoutMillis());
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/util/NbtParsingUtils.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/util/NbtParsingUtils.java
@@ -18,6 +18,13 @@ public final class NbtParsingUtils {
     }
 
     /**
+     * Returns the timeout the mod would like vanilla to use when parsing large NBT payloads.
+     */
+    public static int getDesiredTimeoutMillis() {
+        return DESIRED_TIMEOUT_MS;
+    }
+
+    /**
      * Attempts to extend the vanilla NBT parse timeout so large prefab files
      * don't trip the default 10 second limit.
      */


### PR DESCRIPTION
## Summary
- expose the desired NBT parse timeout so it can be reused by mixins
- raise TagParser's static SNBT parse timeout constant to match the extended limit
- keep the reflection-based timeout extension for any remaining vanilla fields

## Testing
- Not run (blocked by Neoform decompile cache lock while running `./gradlew test --console=plain --no-daemon`)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f00bfdd7c83289f2d03137e0c5845)