### PR TITLE
Add plains spawn structure set for meteor impact sites

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/datapack/BuiltinDataPackRegistrations.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/datapack/BuiltinDataPackRegistrations.java
@@ -1,0 +1,49 @@
+package com.thunder.wildernessodysseyapi.worldgen.datapack;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.PathPackResources;
+import net.minecraft.server.packs.Pack;
+import net.minecraft.server.packs.repository.PackSource;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.AddPackFindersEvent;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.loading.moddiscovery.ModFile;
+
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+@EventBusSubscriber(modid = ModConstants.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+public class BuiltinDataPackRegistrations {
+    private static final String PLAINS_SPAWN_PACK_ID = ModConstants.MOD_ID + ":plains_spawn_pack";
+    private static final String PLAINS_PACK_PATH = "builtin/plains_spawn";
+
+    @SubscribeEvent
+    public static void onAddPackFinders(AddPackFindersEvent event) {
+        if (event.getPackType() != PackType.SERVER_DATA) {
+            return;
+        }
+
+        ModFile modFile = ModList.get().getModFileById(ModConstants.MOD_ID).getFile();
+        Path packPath = modFile.findResource(PLAINS_PACK_PATH);
+
+        Supplier<PathPackResources> supplier = () -> new PathPackResources(PLAINS_SPAWN_PACK_ID, true, packPath);
+
+        Pack pack = Pack.readMetaAndCreate(
+                PLAINS_SPAWN_PACK_ID,
+                Component.translatable("pack.%s.plains_spawn.title".formatted(ModConstants.MOD_ID)),
+                false,
+                supplier,
+                event.getPackType(),
+                Pack.Position.BOTTOM,
+                PackSource.BUILT_IN,
+                false
+        );
+
+        if (pack != null) {
+            event.addRepositorySource(consumer -> consumer.accept(pack));
+        }
+    }
+}

--- a/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
+++ b/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
@@ -39,5 +39,6 @@
   "command.wildernessodyssey.autoshader.no_shader": "No shader recommendation is configured for the %s tier.",
   "command.wildernessodyssey.autoshader.write_error": "Failed to update Iris configuration: %s",
   "command.wildernessodyssey.autoshader.pack_missing": "Recommended shader pack '%s' is not installed; saved preference anyway.",
-  "command.wildernessodyssey.autoshader.unknown_tier": "Unknown shader tier '%s'. Valid options: %s."
+  "command.wildernessodyssey.autoshader.unknown_tier": "Unknown shader tier '%s'. Valid options: %s.",
+  "pack.wildernessodysseyapi.plains_spawn.title": "Wilderness Odyssey Plains Spawn"
 }

--- a/src/main/resources/builtin/plains_spawn/data/c/tags/worldgen/biome/is_plains.json
+++ b/src/main/resources/builtin/plains_spawn/data/c/tags/worldgen/biome/is_plains.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:plains",
+    "minecraft:sunflower_plains",
+    "minecraft:savanna",
+    "minecraft:windswept_savanna",
+    "minecraft:savanna_plateau"
+  ]
+}

--- a/src/main/resources/builtin/plains_spawn/data/wildernessodysseyapi/tags/worldgen/biome/spawn_in_plains.json
+++ b/src/main/resources/builtin/plains_spawn/data/wildernessodysseyapi/tags/worldgen/biome/spawn_in_plains.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#c:is_plains"
+  ]
+}

--- a/src/main/resources/builtin/plains_spawn/data/wildernessodysseyapi/worldgen/structure/impact_zone.json
+++ b/src/main/resources/builtin/plains_spawn/data/wildernessodysseyapi/worldgen/structure/impact_zone.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:jigsaw",
+  "biomes": "#wildernessodysseyapi:spawn_in_plains",
+  "step": "surface_structures",
+  "spawn_overrides": {},
+  "terrain_adaptation": "none",
+  "start_pool": "wildernessodysseyapi:impact_zone/start_pool",
+  "size": 1,
+  "start_height": {
+    "type": "minecraft:world_surface"
+  },
+  "project_start_to_heightmap": "WORLD_SURFACE_WG",
+  "max_distance_from_center": 80,
+  "use_expansion_hack": false
+}

--- a/src/main/resources/builtin/plains_spawn/data/wildernessodysseyapi/worldgen/structure_set/impact_zone_spawn.json
+++ b/src/main/resources/builtin/plains_spawn/data/wildernessodysseyapi/worldgen/structure_set/impact_zone_spawn.json
@@ -1,0 +1,15 @@
+{
+  "structures": [
+    {
+      "structure": "wildernessodysseyapi:impact_zone",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "type": "minecraft:concentric_rings",
+    "distance": 16,
+    "spread": 2,
+    "count": 3,
+    "preferred_biomes": "#wildernessodysseyapi:spawn_in_plains"
+  }
+}

--- a/src/main/resources/builtin/plains_spawn/data/wildernessodysseyapi/worldgen/template_pool/impact_zone.json
+++ b/src/main/resources/builtin/plains_spawn/data/wildernessodysseyapi/worldgen/template_pool/impact_zone.json
@@ -1,0 +1,14 @@
+{
+  "elements": [
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "wildernessodysseyapi:impact_zone",
+        "processors": "minecraft:empty",
+        "projection": "rigid"
+      },
+      "weight": 1
+    }
+  ],
+  "fallback": "minecraft:empty"
+}

--- a/src/main/resources/builtin/plains_spawn/pack.mcmeta
+++ b/src/main/resources/builtin/plains_spawn/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 48,
+    "description": "Optional plains spawn tweaks and meteor landing sites"
+  }
+}


### PR DESCRIPTION
## Summary
- add concentric ring structure placement in the optional plains spawn data pack so meteor impact zones can generate around spawn plains patches
- define the accompanying jigsaw structure and template pool entries for the impact zone template and update the pack description

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69308b36cbf88328bb1127cca92ad3a0)