### PR TITLE
Add missing localization entries

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/FAQ/FaqCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/FAQ/FaqCommand.java
@@ -25,9 +25,15 @@ public class FaqCommand {
                                     String id = StringArgumentType.getString(ctx, "id");
                                     FaqEntry entry = FaqManager.get(id);
                                     if (entry != null) {
-                                        ctx.getSource().sendSuccess(() -> Component.literal("[" + entry.category() + "] " + entry.question() + ": " + entry.answer()), false);
+                                        ctx.getSource().sendSuccess(() -> Component.translatable(
+                                                "command.wildernessodysseyapi.faq.view",
+                                                entry.category(),
+                                                entry.question(),
+                                                entry.answer()), false);
                                     } else {
-                                        ctx.getSource().sendFailure(Component.literal("FAQ not found for id: " + id));
+                                        ctx.getSource().sendFailure(Component.translatable(
+                                                "command.wildernessodysseyapi.faq.not_found",
+                                                id));
                                     }
                                     return 1;
                                 })))
@@ -38,10 +44,14 @@ public class FaqCommand {
                                     List<FaqEntry> results = FaqManager.search(query);
                                     results.sort(Comparator.comparing(FaqEntry::id));
                                     if (results.isEmpty()) {
-                                        ctx.getSource().sendFailure(Component.literal("No FAQs found."));
+                                        ctx.getSource().sendFailure(Component.translatable("command.wildernessodysseyapi.faq.no_results"));
                                     } else {
                                         for (FaqEntry entry : results) {
-                                            ctx.getSource().sendSuccess(() -> Component.literal("- [" + entry.category() + "] " + entry.id() + ": " + entry.question()), false);
+                                            ctx.getSource().sendSuccess(() -> Component.translatable(
+                                                    "command.wildernessodysseyapi.faq.search_result",
+                                                    entry.category(),
+                                                    entry.id(),
+                                                    entry.question()), false);
                                         }
                                     }
                                     return 1;
@@ -49,9 +59,14 @@ public class FaqCommand {
                 .then(Commands.literal("list")
                         .executes(ctx -> {
                             for (String cat : FaqManager.getCategories()) {
-                                ctx.getSource().sendSuccess(() -> Component.literal("Category: " + cat), false);
+                                ctx.getSource().sendSuccess(() -> Component.translatable(
+                                        "command.wildernessodysseyapi.faq.list_category",
+                                        cat), false);
                                 for (FaqEntry entry : FaqManager.getByCategory(cat)) {
-                                    ctx.getSource().sendSuccess(() -> Component.literal("- " + entry.id() + ": " + entry.question()), false);
+                                    ctx.getSource().sendSuccess(() -> Component.translatable(
+                                            "command.wildernessodysseyapi.faq.list_entry",
+                                            entry.id(),
+                                            entry.question()), false);
                                 }
                             }
                             return 1;

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/WorldVersionWarningScreen.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/WorldVersionWarningScreen.java
@@ -14,7 +14,7 @@ public class WorldVersionWarningScreen extends Screen {
     private final String updateType;
 
     public WorldVersionWarningScreen(String oldVersion, String newVersion, Runnable onProceed, Runnable onCancel) {
-        super(Component.literal("World Version Warning"));
+        super(Component.translatable("screen.wildernessodysseyapi.world_version.title"));
         this.oldVersion = oldVersion;
         this.newVersion = newVersion;
         this.onProceed = onProceed;
@@ -34,7 +34,7 @@ public class WorldVersionWarningScreen extends Screen {
         int buttonY = boxY + boxHeight - buttonHeight - margin;
 
         this.addRenderableWidget(Button.builder(
-                Component.literal("Proceed (Return to Play)"),
+                Component.translatable("screen.wildernessodysseyapi.world_version.proceed"),
                 b -> {
                     if (onProceed != null) {
                         LoggerUtil.log(LoggerUtil.ConflictSeverity.INFO, "[WorldVersionWarningScreen] User chose to proceed and continue playing.");
@@ -44,7 +44,7 @@ public class WorldVersionWarningScreen extends Screen {
         ).bounds(boxX + margin, buttonY, buttonWidth, buttonHeight).build());
 
         this.addRenderableWidget(Button.builder(
-                Component.literal("Cancel (Return to Title)"),
+                Component.translatable("screen.wildernessodysseyapi.world_version.cancel"),
                 button -> {
                     if (onCancel != null) {
                         LoggerUtil.log(LoggerUtil.ConflictSeverity.INFO, "[WorldVersionWarningScreen] User chose to cancel and return to title screen.");
@@ -63,15 +63,15 @@ public class WorldVersionWarningScreen extends Screen {
         int boxY = (this.height - boxHeight) / 2;
 
 
-        gfx.drawCenteredString(this.font, Component.literal("World Version Warning!"), this.width / 2, boxY + 16, 0xFFFFFFFF);
-        gfx.drawCenteredString(this.font, Component.literal(updateType + " Update Detected"), this.width / 2, boxY + 35, 0xFFFFFFFF);
-        gfx.drawCenteredString(this.font, Component.literal("World Version: " + oldVersion + " → " + newVersion), this.width / 2, boxY + 52, 0xFFFFFFFF);
-        gfx.drawCenteredString(this.font, Component.literal("Your world is outdated and needs updating."), this.width / 2, boxY + 70, 0xFFEEEEEE);
-        gfx.drawCenteredString(this.font, Component.literal("BACKUP YOUR WORLD BEFORE PROCEEDING"), this.width / 2, boxY + 87, 0xFFFF4444);
-        gfx.drawCenteredString(this.font, Component.literal("Only operators can update the world version."), this.width / 2, boxY + 104, 0xFFDDDDDD);
-        gfx.drawCenteredString(this.font, Component.literal("Run /updateworldversion in chat if you are an operator."), this.width / 2, boxY + 121, 0xFFDDDDDD);
-        gfx.drawCenteredString(this.font, Component.literal("World generation and structures may change."), this.width / 2, boxY + 138, 0xFFDDDDDD);
-        gfx.drawCenteredString(this.font, Component.literal("For bugs, test in a fresh world before reporting."), this.width / 2, boxY + 155, 0xFFDDDDDD);
+        gfx.drawCenteredString(this.font, Component.translatable("screen.wildernessodysseyapi.world_version.banner"), this.width / 2, boxY + 16, 0xFFFFFFFF);
+        gfx.drawCenteredString(this.font, Component.translatable("screen.wildernessodysseyapi.world_version.update_detected", updateType), this.width / 2, boxY + 35, 0xFFFFFF);
+        gfx.drawCenteredString(this.font, Component.translatable("screen.wildernessodysseyapi.world_version.version", oldVersion, newVersion), this.width / 2, boxY + 52, 0xFFFFFFFF);
+        gfx.drawCenteredString(this.font, Component.translatable("screen.wildernessodysseyapi.world_version.outdated"), this.width / 2, boxY + 70, 0xFFEEEEEE);
+        gfx.drawCenteredString(this.font, Component.translatable("screen.wildernessodysseyapi.world_version.backup"), this.width / 2, boxY + 87, 0xFFFF4444);
+        gfx.drawCenteredString(this.font, Component.translatable("screen.wildernessodysseyapi.world_version.ops_only"), this.width / 2, boxY + 104, 0xFFDDDDDD);
+        gfx.drawCenteredString(this.font, Component.translatable("screen.wildernessodysseyapi.world_version.command"), this.width / 2, boxY + 121, 0xFFDDDDDD);
+        gfx.drawCenteredString(this.font, Component.translatable("screen.wildernessodysseyapi.world_version.worldgen_warning"), this.width / 2, boxY + 138, 0xFFDDDDDD);
+        gfx.drawCenteredString(this.font, Component.translatable("screen.wildernessodysseyapi.world_version.bug_tip"), this.width / 2, boxY + 155, 0xFFDDDDDD);
     }
 
     @Override
@@ -94,7 +94,7 @@ public class WorldVersionWarningScreen extends Screen {
 
     @Override
     public boolean shouldCloseOnEsc() {
-            return false;
+        return false;
     }
 
     @Override

--- a/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
+++ b/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
@@ -3,8 +3,10 @@
   "message.wildernessodysseyapi.wake_up": "Waking from cryostasis...",
   "message.wildernessodysseyapi.cryo_tube_locked": "The cryo tube can no longer be used.",
   "block.wildernessodysseyapi.cryo_tube": "Cryo Tube",
+  "block.wildernessodysseyapi.terrain_replacer": "Terrain Replacer",
   "item.wildernessodysseyapi.cloak_item": "Handheld Cloak",
   "item.wildernessodysseyapi.sky_torch_staff": "Sky Torch Staff",
+  "item.wildernessodysseyapi.terrain_replacer": "Terrain Replacer",
 
   "screen.wildernessodyssey.hardware.title": "Hardware Requirements",
   "screen.wildernessodyssey.hardware.section.current": "Detected hardware",
@@ -39,5 +41,25 @@
   "command.wildernessodyssey.autoshader.no_shader": "No shader recommendation is configured for the %s tier.",
   "command.wildernessodyssey.autoshader.write_error": "Failed to update Iris configuration: %s",
   "command.wildernessodyssey.autoshader.pack_missing": "Recommended shader pack '%s' is not installed; saved preference anyway.",
-  "command.wildernessodyssey.autoshader.unknown_tier": "Unknown shader tier '%s'. Valid options: %s."
+  "command.wildernessodyssey.autoshader.unknown_tier": "Unknown shader tier '%s'. Valid options: %s.",
+
+  "command.wildernessodysseyapi.faq.view": "[%s] %s: %s",
+  "command.wildernessodysseyapi.faq.not_found": "FAQ not found for id: %s",
+  "command.wildernessodysseyapi.faq.no_results": "No FAQs found.",
+  "command.wildernessodysseyapi.faq.search_result": "- [%s] %s: %s",
+  "command.wildernessodysseyapi.faq.list_category": "Category: %s",
+  "command.wildernessodysseyapi.faq.list_entry": "- %s: %s",
+
+  "screen.wildernessodysseyapi.world_version.title": "World Version Warning",
+  "screen.wildernessodysseyapi.world_version.proceed": "Proceed (Return to Play)",
+  "screen.wildernessodysseyapi.world_version.cancel": "Cancel (Return to Title)",
+  "screen.wildernessodysseyapi.world_version.banner": "World Version Warning!",
+  "screen.wildernessodysseyapi.world_version.update_detected": "%s Update Detected",
+  "screen.wildernessodysseyapi.world_version.version": "World Version: %s → %s",
+  "screen.wildernessodysseyapi.world_version.outdated": "Your world is outdated and needs updating.",
+  "screen.wildernessodysseyapi.world_version.backup": "BACKUP YOUR WORLD BEFORE PROCEEDING",
+  "screen.wildernessodysseyapi.world_version.ops_only": "Only operators can update the world version.",
+  "screen.wildernessodysseyapi.world_version.command": "Run /updateworldversion in chat if you are an operator.",
+  "screen.wildernessodysseyapi.world_version.worldgen_warning": "World generation and structures may change.",
+  "screen.wildernessodysseyapi.world_version.bug_tip": "For bugs, test in a fresh world before reporting."
 }


### PR DESCRIPTION
## Summary
- convert FAQ command output to translated messages and add localization strings
- localize the world version warning screen content with new lang entries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930938b845c8328915cd99efa3a1a84)