### PR TITLE
Add null check before locating builtin datapack

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/datapack/BuiltinDataPackRegistrations.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/datapack/BuiltinDataPackRegistrations.java
@@ -27,9 +27,12 @@ public class BuiltinDataPackRegistrations {
             return;
         }
 
-        Path packPath = ModList.get().getModFileById(ModConstants.MOD_ID)
-                .getFile()
-                .findResource(PLAINS_PACK_PATH);
+        var modFileInfo = ModList.get().getModFileById(ModConstants.MOD_ID);
+        if (modFileInfo == null) {
+            return;
+        }
+
+        Path packPath = modFileInfo.getFile().findResource(PLAINS_PACK_PATH);
 
         PackLocationInfo packLocationInfo = new PackLocationInfo(
                 PLAINS_SPAWN_PACK_ID,


### PR DESCRIPTION
## Summary
- add a guard when resolving the mod file before registering the builtin plains spawn datapack so the code exits cleanly if the file info is missing

## Testing
- ./gradlew compileJava -x test --console=plain

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b18d6d188328884c8327867c7477)