### PR TITLE
Add plains spawn datapack overworld registration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,9 @@ tasks.register('obfuscateFiles', JavaExec) {
 
 // Package bundled libraries directly into the mod jar so they are available when Minecraft loads the mod.
 tasks.named('jar', Jar).configure {
+    // Ensure all mod resources (including built-in datapacks) are packaged into the jar.
+    from(sourceSets.main.resources)
+
     from {
         configurations.bundledLibs.collect { it.isDirectory() ? it : zipTree(it) }
     }

--- a/src/main/resources/builtin/plains_spawn/data/minecraft/tags/worldgen/structure_set/impact_zone_spawn.json
+++ b/src/main/resources/builtin/plains_spawn/data/minecraft/tags/worldgen/structure_set/impact_zone_spawn.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "wildernessodysseyapi:impact_zone_spawn"
+  ]
+}

--- a/src/main/resources/builtin/plains_spawn/data/minecraft/tags/worldgen/structure_set/overworld.json
+++ b/src/main/resources/builtin/plains_spawn/data/minecraft/tags/worldgen/structure_set/overworld.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "wildernessodysseyapi:impact_zone_spawn"
+  ]
+}

--- a/src/main/resources/builtin/plains_spawn/data/wildernessodysseyapi/tags/worldgen/biome/spawn_in_plains.json
+++ b/src/main/resources/builtin/plains_spawn/data/wildernessodysseyapi/tags/worldgen/biome/spawn_in_plains.json
@@ -1,6 +1,11 @@
 {
   "replace": false,
   "values": [
-    "#c:is_plains"
+    "#c:is_plains",
+    "minecraft:plains",
+    "minecraft:sunflower_plains",
+    "minecraft:savanna",
+    "minecraft:windswept_savanna",
+    "minecraft:savanna_plateau"
   ]
 }


### PR DESCRIPTION
## Summary
- register the meteor impact structure set in the default overworld structure_set tag so the datapack contributes to worldgen
- add direct plains biome entries to the spawn_in_plains tag so plains detection works even when common tags are missing

## Testing
- ./gradlew jar --no-daemon --console=plain

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693113c73444832896c8be1e93892921)