### PR TITLE
Force plains spawn datapack to load at highest priority

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/datapack/BuiltinDataPackRegistrations.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/datapack/BuiltinDataPackRegistrations.java
@@ -57,7 +57,7 @@ public class BuiltinDataPackRegistrations {
                 packLocationInfo,
                 supplier,
                 event.getPackType(),
-                new PackSelectionConfig(true, Pack.Position.BOTTOM, false)
+                new PackSelectionConfig(true, Pack.Position.TOP, true)
         );
 
         if (pack != null) {


### PR DESCRIPTION
## Summary
- adjust built-in plains spawn datapack registration to load at the top of the pack stack with a fixed position, ensuring its plains biome and impact zone rules are applied

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693124c1cb5c8328acfe994eed305e95)