### PR TITLE
Allow land biome meteor scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ structure by its namespace and path (without the `.nbt` extension) to have it
 placed during world generation. If no data pack override exists, the bundled
 templates under `data/<namespace>/structures/` in the mod resources are used.
 
+For a datapack-only workflow that still keeps the wool height markers you
+mentioned, see `docs/impact-bunker-datapack.md`. It outlines how the mod's
+built-in three impact sites and nearby bunkers interact with your custom
+templates and how to space each cluster far apart without changing code.
+
 The meteor impact site looks for the `wildernessodysseyapi:impact_zone`
 template. Drop your finished build at
 `data/wildernessodysseyapi/structures/impact_zone.nbt` so the crash craters are

--- a/docs/examples/impact_sites/overworld.json
+++ b/docs/examples/impact_sites/overworld.json
@@ -1,5 +1,5 @@
 {
   "dimension": "minecraft:overworld",
-  "impact": {"x": 4096, "z": -4096},
+  "impact": {"x": 4096, "y": 80, "z": -4096},
   "bunker_offset": {"x": 96, "z": 48}
 }

--- a/docs/examples/impact_sites/overworld.json
+++ b/docs/examples/impact_sites/overworld.json
@@ -1,0 +1,5 @@
+{
+  "dimension": "minecraft:overworld",
+  "impact": {"x": 4096, "z": -4096},
+  "bunker_offset": {"x": 96, "z": 48}
+}

--- a/docs/impact-bunker-datapack.md
+++ b/docs/impact-bunker-datapack.md
@@ -18,17 +18,18 @@ The current worldgen pipeline already looks up `impact_zone.nbt` and `bunker.nbt
 4. If you need to realign heights, adjust the wool markers in your template, re-export, and retry. The mod reuses your datapack assets on the next world creation.
 
 ## Pinning anchors with datapacks (first site only)
-If you want to lock in the first crater + bunker location, add JSON files under `data/<namespace>/impact_sites/`. Each file can target a dimension and give exact anchors plus optional bunker offsets:
+If you want to lock in the first crater + bunker location, add JSON files under `data/<namespace>/impact_sites/`. Each file can target a dimension and give exact anchors plus optional bunker offsets. You can also pin a **Y height** for the crater if you do not want it to follow the local terrain automatically:
 
 ```json
 {
   "dimension": "minecraft:overworld",
-  "impact": {"x": 1024, "z": -2048},
+  "impact": {"x": 1024, "y": 72, "z": -2048},
   "bunker_offset": {"x": 64, "z": 32}
 }
 ```
 
 - The game honors only the **first entry** per dimension as an anchor; the other two craters still use land-biome scanning so you do not need to curate multiple coordinates.
+- If `impact.y` is greater than zero, the crater uses that fixed height instead of auto-snapping to the terrain. Update any existing datapacks to include a target Y when you want to preserve a specific build elevation.
 - `bunker_offset` is optional; when present the bunker will try to spawn at that offset from its paired impact anchor before trying random rings.
 - Leaving these files out keeps the original land-scanning workflow intact; adding them simply locks in the first cluster and reduces scanning for that pair.
 - For a ready-made template, copy `docs/examples/impact_sites/overworld.json` into your datapack and tweak the coordinates.

--- a/docs/impact-bunker-datapack.md
+++ b/docs/impact-bunker-datapack.md
@@ -1,0 +1,38 @@
+# Datapack-driven impact sites and bunkers
+
+The current worldgen pipeline already looks up `impact_zone.nbt` and `bunker.nbt` from datapacks before falling back to the built-in assets, so you can ship your own terrain-matched builds without touching code. This playbook matches the requested layout of three impact sites and three nearby bunkers while keeping each cluster far apart from the others.
+
+## Structure count and spacing
+- **Impact sites:** `MeteorStructureSpawner` always targets three sites and enforces at least 32 chunks (512 blocks) between crater anchors. This keeps each cluster far apart while still letting you tune the exact shape in your datapack.
+- **Bunkers:** One bunker is placed adjacent to a random impact site by default, but you can raise `bunker.maxSpawnCount` in `config/wildernessodysseyapi/wildernessodysseyapi-common.toml` to allow up to three bunkers (one per crater) while keeping a minimum spacing set by `bunker.spawnDistanceChunks`.
+
+## Building with wool height guides
+- Build the crater and bunker shells in a flat world, then add wool "survey" pillars at the points where you need to measure surface offsets. The `NBTStructurePlacer` preserves these blocks, so you can read them in-game after placement to verify that the terrain alignment matches your expectations.
+- Use different wool colors for key landmarks (e.g., crater rim, bunker doorway, roof corners) to make vertical deltas obvious when the structure is pasted onto varied terrain.
+- Once you are satisfied with fit and clearance, replace the wool with the final blocks before exporting the structure to `data/<namespace>/structures/impact_zone.nbt` and `data/<namespace>/structures/bunker.nbt`.
+
+## Placement flow
+1. Drop both NBTs into a datapack so they override the bundled templates. No Java changes are required because the placer already references these paths.
+2. Start a fresh world. By default the game will pick solid land biomes, generate three impact sites ~16,000 blocks apart, and anchor a bunker beside one of them (or up to three if you raise the max count).
+3. If you add a datapack anchor (see below), the **first crater + bunker** will honor that coordinate while the other two craters continue using land-biome scanning so you keep wide spacing without hand-curating every site.
+4. If you need to realign heights, adjust the wool markers in your template, re-export, and retry. The mod reuses your datapack assets on the next world creation.
+
+## Pinning anchors with datapacks (first site only)
+If you want to lock in the first crater + bunker location, add JSON files under `data/<namespace>/impact_sites/`. Each file can target a dimension and give exact anchors plus optional bunker offsets:
+
+```json
+{
+  "dimension": "minecraft:overworld",
+  "impact": {"x": 1024, "z": -2048},
+  "bunker_offset": {"x": 64, "z": 32}
+}
+```
+
+- The game honors only the **first entry** per dimension as an anchor; the other two craters still use land-biome scanning so you do not need to curate multiple coordinates.
+- `bunker_offset` is optional; when present the bunker will try to spawn at that offset from its paired impact anchor before trying random rings.
+- Leaving these files out keeps the original land-scanning workflow intact; adding them simply locks in the first cluster and reduces scanning for that pair.
+- For a ready-made template, copy `docs/examples/impact_sites/overworld.json` into your datapack and tweak the coordinates.
+
+## Tips for wider separation between clusters
+- Keep `bunker.spawnDistanceChunks` at or above the default 32 to maintain distance from the nearby crater while avoiding overlap with the other two clusters.
+- To maximize exploration distance between clusters, avoid lowering the 32-chunk impact separation baked into `MeteorStructureSpawner`.

--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -50,6 +50,7 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerProtectionHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.BunkerStructureGenerator;
+import com.thunder.wildernessodysseyapi.WorldGen.datapack.ImpactSitePlacementLoader;
 import com.thunder.wildernessodysseyapi.WorldGen.structures.MeteorStructureSpawner;
 import com.thunder.wildernessodysseyapi.WorldGen.util.DeferredTaskScheduler;
 import net.minecraft.world.phys.AABB;
@@ -293,6 +294,7 @@ public class WildernessOdysseyAPIMainModClass {
     @SubscribeEvent
     public void onReload(AddReloadListenerEvent event) {
         event.addListener(new FaqReloadListener());
+        event.addListener(new ImpactSitePlacementLoader());
     }
 
     public void onConfigLoaded(ModConfigEvent.Loading event) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structures/MeteorStructureSpawner.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structures/MeteorStructureSpawner.java
@@ -128,8 +128,8 @@ public class MeteorStructureSpawner {
 
         if (!definitions.isEmpty() && storedSites.isEmpty()) {
             PlacementDefinition anchor = definitions.get(0);
-            BlockPos surface = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, anchor.impactPos());
-            BlockPos anchoredImpact = placeMeteorSite(level, surface);
+            BlockPos anchorPos = resolveAnchorPosition(level, anchor.impactPos());
+            BlockPos anchoredImpact = placeMeteorSite(level, anchorPos);
             if (anchoredImpact == null) {
                 ModConstants.LOGGER.warn("Failed to place meteor impact from datapack anchor {}; retrying", anchor.impactPos());
                 scheduleRetry(level, attempt + 1);
@@ -439,6 +439,14 @@ public class MeteorStructureSpawner {
         candidates.add(() -> impactPos.offset(minDistanceBlocks, 0, 0));
         java.util.Collections.shuffle(candidates, new java.util.Random(random.nextLong()));
         return candidates;
+    }
+
+    private static BlockPos resolveAnchorPosition(ServerLevel level, BlockPos anchor) {
+        if (anchor.getY() > 0) {
+            return anchor;
+        }
+
+        return level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, anchor);
     }
 
     private static BlockPos pickAnchoredBunkerAnchor(List<PlacementDefinition> definitions, List<BlockPos> placedSites) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structures/MeteorStructureSpawner.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structures/MeteorStructureSpawner.java
@@ -6,15 +6,16 @@ import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.StructureSpawnT
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock.CryoSpawnData;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock.PlayerSpawnHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock.WorldSpawnHandler;
+import com.thunder.wildernessodysseyapi.WorldGen.datapack.ImpactSitePlacementLoader;
+import com.thunder.wildernessodysseyapi.WorldGen.datapack.ImpactSitePlacementLoader.PlacementDefinition;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.NBTStructurePlacer;
 import com.thunder.wildernessodysseyapi.WorldGen.util.DeferredTaskScheduler;
 import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.BiomeTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
@@ -22,7 +23,6 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Biomes;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.storage.ServerLevelData;
-import net.minecraft.tags.TagKey;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,17 +37,15 @@ import java.util.function.Supplier;
  * Handles initial meteor impact site and bunker placement when a world is created.
  */
 public class MeteorStructureSpawner {
-    private static final TagKey<Biome> IS_PLAINS_TAG =
-            TagKey.create(Registries.BIOME, ResourceLocation.parse("c:is_plains"));
     private static final int IMPACT_SITE_COUNT = 3;
-    private static final int SPAWN_PLAINS_SEARCH_RADIUS = 256;
+    private static final int SPAWN_LAND_SEARCH_RADIUS = 256;
     private static final int MIN_CHUNK_SEPARATION = 32;
     private static final int MIN_BLOCK_SEPARATION = MIN_CHUNK_SEPARATION * 16;
     private static final int POSITION_ATTEMPTS = 64;
     private static final int MIN_POSITION_ATTEMPTS = 16;
     private static final int MAX_DEFERRED_ATTEMPTS = 20 * 60 * 5; // five minutes worth of retries
     private static final double GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
-    private static double plainsHitRate = 0.5D;
+    private static double landHitRate = 0.5D;
 
     private static final NBTStructurePlacer METEOR_SITE_PLACER =
             new NBTStructurePlacer(ModConstants.MOD_ID, "impact_zone.nbt");
@@ -107,7 +105,14 @@ public class MeteorStructureSpawner {
             return;
         }
 
+        if (!ImpactSitePlacementLoader.isLoaded()) {
+            ModConstants.LOGGER.info("Delaying meteor impact placement until datapack anchors are loaded");
+            scheduleRetry(level, attempt + 1);
+            return;
+        }
+
         MeteorImpactData impactData = MeteorImpactData.get(level);
+        List<PlacementDefinition> definitions = ImpactSitePlacementLoader.get(level.dimension());
         if (impactData.getBunkerPos() != null) {
             markPlacementComplete(level);
             return;
@@ -121,14 +126,26 @@ public class MeteorStructureSpawner {
         List<BlockPos> storedSites = new ArrayList<>(impactData.getImpactPositions());
         int originalCount = storedSites.size();
 
+        if (!definitions.isEmpty() && storedSites.isEmpty()) {
+            PlacementDefinition anchor = definitions.get(0);
+            BlockPos surface = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, anchor.impactPos());
+            BlockPos anchoredImpact = placeMeteorSite(level, surface);
+            if (anchoredImpact == null) {
+                ModConstants.LOGGER.warn("Failed to place meteor impact from datapack anchor {}; retrying", anchor.impactPos());
+                scheduleRetry(level, attempt + 1);
+                return;
+            }
+            storedSites.add(anchoredImpact);
+        }
+
         if (storedSites.isEmpty()) {
-            BlockPos spawnPlains = findSpawnPlains(level, spawn);
-            if (spawnPlains != null) {
-                BlockPos anchor = placeMeteorSite(level, spawnPlains);
+            BlockPos spawnLand = findSpawnLand(level, spawn);
+            if (spawnLand != null) {
+                BlockPos anchor = placeMeteorSite(level, spawnLand);
                 if (anchor != null) {
                     storedSites.add(anchor);
                 } else {
-                    failedOrigins.add(spawnPlains.asLong());
+                    failedOrigins.add(spawnLand.asLong());
                 }
             }
         }
@@ -136,7 +153,7 @@ public class MeteorStructureSpawner {
         for (int i = storedSites.size(); i < IMPACT_SITE_COUNT; i++) {
             BlockPos origin = findImpactOrigin(level, random, spawn, storedSites, failedOrigins);
             if (origin == null) {
-                ModConstants.LOGGER.info("Delaying meteor impact placement; no plains biome found near {} yet", spawn);
+                ModConstants.LOGGER.info("Delaying meteor impact placement; no land biome found near {} yet", spawn);
                 scheduleRetry(level, attempt + 1);
                 return;
             }
@@ -159,8 +176,15 @@ public class MeteorStructureSpawner {
         }
 
         if (impactData.getBunkerPos() == null && !storedSites.isEmpty()) {
-            BlockPos bunkerAnchor = storedSites.get(random.nextInt(storedSites.size()));
-            PlacementState bunkerState = placeBunker(level, bunkerAnchor, impactData);
+            BlockPos bunkerAnchor = pickAnchoredBunkerAnchor(definitions, storedSites);
+            PlacementState bunkerState = PlacementState.FAILED;
+            if (bunkerAnchor != null) {
+                bunkerState = placeBunker(level, bunkerAnchor, impactData);
+            }
+            if (bunkerState == PlacementState.FAILED) {
+                bunkerAnchor = storedSites.get(random.nextInt(storedSites.size()));
+                bunkerState = placeBunker(level, bunkerAnchor, impactData);
+            }
             if (bunkerState == PlacementState.SUCCESS) {
                 markPlacementComplete(level);
                 return;
@@ -213,13 +237,13 @@ public class MeteorStructureSpawner {
     }
 
     private static PlacementState placeBunker(ServerLevel level, BlockPos impactPos, MeteorImpactData impactData) {
-        Map<Long, Boolean> plainsCache = new HashMap<>();
+        Map<Long, Boolean> landCache = new HashMap<>();
         StructureSpawnTracker tracker = StructureSpawnTracker.get(level);
         int minDistanceBlocks = Math.max(MIN_BLOCK_SEPARATION, StructureConfig.BUNKER_MIN_DISTANCE.get() * 16);
 
         List<Supplier<BlockPos>> bunkerCandidates = buildBunkerCandidates(impactPos, minDistanceBlocks);
         for (Supplier<BlockPos> candidateSupplier : bunkerCandidates) {
-            BlockPos bunkerPos = ensurePlainsSurface(level, candidateSupplier.get(), plainsCache);
+            BlockPos bunkerPos = ensureLandSurface(level, candidateSupplier.get(), landCache);
 
             if (!tracker.isFarEnough(bunkerPos, StructureConfig.BUNKER_MIN_DISTANCE.get())) {
                 continue;
@@ -290,22 +314,22 @@ public class MeteorStructureSpawner {
         }
     }
 
-    private static BlockPos findSpawnPlains(ServerLevel level, BlockPos spawn) {
-        Map<Long, Boolean> plainsCache = new HashMap<>();
+    private static BlockPos findSpawnLand(ServerLevel level, BlockPos spawn) {
+        Map<Long, Boolean> landCache = new HashMap<>();
         BlockPos surfaceSpawn = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, spawn);
-        if (isPlains(level, surfaceSpawn, plainsCache)) {
+        if (isLand(level, surfaceSpawn, landCache)) {
             return surfaceSpawn;
         }
 
-        return findNearbyPlains(level, surfaceSpawn, SPAWN_PLAINS_SEARCH_RADIUS, plainsCache);
+        return findNearbyLand(level, surfaceSpawn, SPAWN_LAND_SEARCH_RADIUS, landCache);
     }
 
     private static BlockPos findImpactOrigin(ServerLevel level, RandomSource random, BlockPos reference,
                                              List<BlockPos> existing, Set<Long> failedOrigins) {
         long minDistanceSq = (long) MIN_BLOCK_SEPARATION * (long) MIN_BLOCK_SEPARATION;
         int positionAttempts = getAdaptivePositionAttempts();
-        Map<Long, Boolean> plainsCache = new HashMap<>();
-        int plainsHits = 0;
+        Map<Long, Boolean> landCache = new HashMap<>();
+        int landHits = 0;
         int attemptsUsed = 0;
         double baseAngle = random.nextDouble() * Math.PI * 2.0D;
 
@@ -331,49 +355,49 @@ public class MeteorStructureSpawner {
 
             if (farEnough && !failedOrigins.contains(candidate.asLong())) {
                 BlockPos surface = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, candidate);
-                if (isPlains(level, surface, plainsCache)) {
-                    plainsHits++;
-                    updatePlainsHitRate(plainsHits, attemptsUsed);
+                if (isLand(level, surface, landCache)) {
+                    landHits++;
+                    updateLandHitRate(landHits, attemptsUsed);
                     return surface;
                 }
             }
         }
 
-        updatePlainsHitRate(plainsHits, attemptsUsed);
+        updateLandHitRate(landHits, attemptsUsed);
 
         int[] searchMultipliers = new int[] {existing.size() + 1, existing.size() + 2, existing.size() + 3};
         for (int multiplier : searchMultipliers) {
             BlockPos fallback = reference.offset(MIN_BLOCK_SEPARATION * multiplier, 0, 0);
             BlockPos surface = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, fallback);
-            BlockPos plains = findNearbyPlains(level, surface, MIN_BLOCK_SEPARATION * 3, plainsCache);
-            if (plains != null && !failedOrigins.contains(plains.asLong())) {
-                return plains;
+            BlockPos land = findNearbyLand(level, surface, MIN_BLOCK_SEPARATION * 3, landCache);
+            if (land != null && !failedOrigins.contains(land.asLong())) {
+                return land;
             }
         }
 
         BlockPos surface = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, reference);
-        BlockPos plains = findNearbyPlains(level, surface, MIN_BLOCK_SEPARATION * 4, plainsCache);
-        if (plains != null && !failedOrigins.contains(plains.asLong())) {
-            return plains;
+        BlockPos land = findNearbyLand(level, surface, MIN_BLOCK_SEPARATION * 4, landCache);
+        if (land != null && !failedOrigins.contains(land.asLong())) {
+            return land;
         }
 
         return null;
     }
 
-    private static BlockPos ensurePlainsSurface(ServerLevel level, BlockPos position, Map<Long, Boolean> plainsCache) {
+    private static BlockPos ensureLandSurface(ServerLevel level, BlockPos position, Map<Long, Boolean> landCache) {
         BlockPos surface = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, position);
-        if (isPlains(level, surface, plainsCache)) {
+        if (isLand(level, surface, landCache)) {
             return surface;
         }
-        BlockPos plains = findNearbyPlains(level, surface, MIN_BLOCK_SEPARATION, plainsCache);
-        return plains != null ? plains : surface;
+        BlockPos land = findNearbyLand(level, surface, MIN_BLOCK_SEPARATION, landCache);
+        return land != null ? land : surface;
     }
 
-    private static BlockPos findNearbyPlains(ServerLevel level, BlockPos center, int radius) {
-        return findNearbyPlains(level, center, radius, new HashMap<>());
+    private static BlockPos findNearbyLand(ServerLevel level, BlockPos center, int radius) {
+        return findNearbyLand(level, center, radius, new HashMap<>());
     }
 
-    private static BlockPos findNearbyPlains(ServerLevel level, BlockPos center, int radius, Map<Long, Boolean> plainsCache) {
+    private static BlockPos findNearbyLand(ServerLevel level, BlockPos center, int radius, Map<Long, Boolean> landCache) {
         int chunkRadius = Math.max(0, radius >> 4);
         ChunkPos originChunk = new ChunkPos(center);
         BlockPos closestLand = null;
@@ -383,7 +407,7 @@ public class MeteorStructureSpawner {
             for (int dz = -chunkRadius; dz <= chunkRadius; dz++) {
                 ChunkPos chunkPos = new ChunkPos(originChunk.x + dx, originChunk.z + dz);
                 BlockPos surface = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, chunkPos.getWorldPosition());
-                if (isPlains(level, surface, plainsCache)) {
+                if (isLand(level, surface, landCache)) {
                     double distSq = surface.distSqr(center);
                     if (distSq < closestLandDistSq) {
                         closestLandDistSq = distSq;
@@ -417,41 +441,49 @@ public class MeteorStructureSpawner {
         return candidates;
     }
 
+    private static BlockPos pickAnchoredBunkerAnchor(List<PlacementDefinition> definitions, List<BlockPos> placedSites) {
+        if (definitions.isEmpty() || placedSites.isEmpty()) {
+            return null;
+        }
+
+        BlockPos offset = definitions.get(0).bunkerOffset();
+        return offset != null ? placedSites.get(0).offset(offset) : placedSites.get(0);
+    }
+
     private static int getAdaptivePositionAttempts() {
-        double effortFactor = 1.0D - Math.min(0.6D, plainsHitRate * 0.6D);
+        double effortFactor = 1.0D - Math.min(0.6D, landHitRate * 0.6D);
         int attempts = (int) Math.round(MIN_POSITION_ATTEMPTS
                 + (POSITION_ATTEMPTS - MIN_POSITION_ATTEMPTS) * effortFactor);
         return Math.max(MIN_POSITION_ATTEMPTS, Math.min(POSITION_ATTEMPTS, attempts));
     }
 
-    private static void updatePlainsHitRate(int plainsHits, int attemptsUsed) {
+    private static void updateLandHitRate(int landHits, int attemptsUsed) {
         if (attemptsUsed <= 0) {
             return;
         }
-        double sampleRate = (double) plainsHits / attemptsUsed;
-        plainsHitRate = (plainsHitRate * 0.75D) + (sampleRate * 0.25D);
+        double sampleRate = (double) landHits / attemptsUsed;
+        landHitRate = (landHitRate * 0.75D) + (sampleRate * 0.25D);
     }
 
-    private static boolean isPlains(ServerLevel level, BlockPos pos) {
-        return isPlains(level, pos, new HashMap<>());
+    private static boolean isLand(ServerLevel level, BlockPos pos) {
+        return isLand(level, pos, new HashMap<>());
     }
 
-    private static boolean isPlains(ServerLevel level, BlockPos pos, Map<Long, Boolean> plainsCache) {
+    private static boolean isLand(ServerLevel level, BlockPos pos, Map<Long, Boolean> landCache) {
         long key = pos.asLong();
-        Boolean cached = plainsCache.get(key);
+        Boolean cached = landCache.get(key);
         if (cached != null) {
             return cached;
         }
 
         Holder<Biome> biomeHolder = level.getBiome(pos);
-        boolean result = biomeHolder.is(IS_PLAINS_TAG)
-                || biomeHolder.is(Biomes.PLAINS)
-                || biomeHolder.is(Biomes.SUNFLOWER_PLAINS)
-                || biomeHolder.is(Biomes.SAVANNA)
-                || biomeHolder.is(Biomes.SAVANNA_PLATEAU)
-                || biomeHolder.is(Biomes.WINDSWEPT_SAVANNA)
-                || biomeHolder.is(Biomes.SNOWY_PLAINS);
-        plainsCache.put(key, result);
+        boolean waterBiome = biomeHolder.is(BiomeTags.IS_OCEAN)
+                || biomeHolder.is(BiomeTags.IS_DEEP_OCEAN)
+                || biomeHolder.is(BiomeTags.IS_RIVER)
+                || biomeHolder.is(Biomes.RIVER)
+                || biomeHolder.is(Biomes.FROZEN_RIVER);
+        boolean result = !waterBiome;
+        landCache.put(key, result);
         return result;
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/datapack/ImpactSitePlacementLoader.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/datapack/ImpactSitePlacementLoader.java
@@ -1,0 +1,102 @@
+package com.thunder.wildernessodysseyapi.WorldGen.datapack;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Loads optional datapack-provided anchor points for meteor impacts and bunkers.
+ */
+public class ImpactSitePlacementLoader extends SimpleJsonResourceReloadListener {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final String DIRECTORY = "impact_sites";
+
+    private static final Map<ResourceKey<Level>, List<PlacementDefinition>> DEFINITIONS = new ConcurrentHashMap<>();
+    private static volatile boolean loaded = false;
+
+    public ImpactSitePlacementLoader() {
+        super(GSON, DIRECTORY);
+    }
+
+    @Override
+    protected void apply(Map<ResourceLocation, JsonElement> entries, ResourceManager resourceManager, ProfilerFiller profiler) {
+        DEFINITIONS.clear();
+        loaded = false;
+
+        for (Map.Entry<ResourceLocation, JsonElement> entry : entries.entrySet()) {
+            try {
+                JsonObject root = GsonHelper.convertToJsonObject(entry.getValue(), DIRECTORY);
+                ResourceLocation dimensionId = ResourceLocation.tryParse(GsonHelper.getAsString(root, "dimension", "minecraft:overworld"));
+                if (dimensionId == null) {
+                    ModConstants.LOGGER.warn("Skipping impact site entry {} due to invalid dimension id", entry.getKey());
+                    continue;
+                }
+
+                ResourceKey<Level> dimension = ResourceKey.create(Registries.DIMENSION, dimensionId);
+                BlockPos impactPos = parsePos(root, "impact");
+                if (impactPos == null) {
+                    ModConstants.LOGGER.warn("Skipping impact site entry {} because it lacks a valid impact position", entry.getKey());
+                    continue;
+                }
+
+                BlockPos bunkerOffset = parsePos(root, "bunker_offset");
+                DEFINITIONS.computeIfAbsent(dimension, dim -> new ArrayList<>())
+                        .add(new PlacementDefinition(impactPos, bunkerOffset));
+            } catch (Exception ex) {
+                ModConstants.LOGGER.warn("Failed to parse impact site definition {}: {}", entry.getKey(), ex.getMessage());
+            }
+        }
+
+        ModConstants.LOGGER.info("Loaded {} impact site anchor sets from datapacks", DEFINITIONS.values().stream().mapToInt(List::size).sum());
+        loaded = true;
+    }
+
+    public static List<PlacementDefinition> get(ResourceKey<Level> dimension) {
+        return DEFINITIONS.getOrDefault(dimension, List.of());
+    }
+
+    public static boolean hasConfiguredPlacements(ServerLevel level) {
+        return !get(level.dimension()).isEmpty();
+    }
+
+    public static boolean isLoaded() {
+        return loaded;
+    }
+
+    @Nullable
+    private BlockPos parsePos(JsonObject root, String field) {
+        if (!root.has(field)) {
+            return null;
+        }
+
+        JsonObject obj = GsonHelper.getAsJsonObject(root, field);
+        if (!obj.has("x") || !obj.has("z")) {
+            return null;
+        }
+
+        int x = GsonHelper.getAsInt(obj, "x");
+        int y = GsonHelper.getAsInt(obj, "y", 0);
+        int z = GsonHelper.getAsInt(obj, "z");
+        return new BlockPos(x, y, z);
+    }
+
+    public record PlacementDefinition(BlockPos impactPos, @Nullable BlockPos bunkerOffset) {}
+}


### PR DESCRIPTION
## Summary
- allow fallback meteor impact placement to target any solid land biome instead of just plains while keeping datapack anchors first
- reuse land-surface checks for bunker placement and adaptive search metrics to avoid oceans and rivers
- update datapack guidance to describe the land-biome scanning behavior

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931b19916848328a155505bf63c0413)