### PR TITLE
Add default meteor impact datapack anchor near spawn

### DIFF
--- a/src/main/resources/data/wildernessodysseyapi/impact_sites/spawn_anchor.json
+++ b/src/main/resources/data/wildernessodysseyapi/impact_sites/spawn_anchor.json
@@ -1,0 +1,13 @@
+{
+  "dimension": "minecraft:overworld",
+  "impact": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "bunker_offset": {
+    "x": 120,
+    "y": 0,
+    "z": 0
+  }
+}


### PR DESCRIPTION
## Summary
- add a built-in datapack anchor for the meteor impact in the overworld
- include a bunker offset so the bunker spawns near the starting crater

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e48875448328803a65f9ebe6f080)