### PR TITLE
Register bunker structure features for worldgen

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -17,6 +17,8 @@ import com.thunder.wildernessodysseyapi.command.GlobalChatOptToggleCommand;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.TerrainReplacerBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
+import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Features.ModFeatures;
+import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.biome.ModBiomeModifiers;
 import com.thunder.wildernessodysseyapi.async.AsyncTaskManager;
 import com.thunder.wildernessodysseyapi.async.AsyncThreadingConfig;
 import com.thunder.wildernessodysseyapi.command.AiAdvisorCommand;
@@ -122,6 +124,10 @@ public class WildernessOdysseyAPIMainModClass {
         modEventBus.addListener(this::commonSetup);
         modEventBus.addListener(this::onConfigLoaded);
         modEventBus.addListener(this::onConfigReloaded);
+        ModFeatures.FEATURES.register(modEventBus);
+        ModFeatures.CONFIGURED_FEATURES.register(modEventBus);
+        ModFeatures.PLACED_FEATURES.register(modEventBus);
+        ModBiomeModifiers.BIOME_MODIFIERS.register(modEventBus);
         ModCreativeTabs.register(modEventBus);
 
         // Register global events

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModConfiguredFeatures.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModConfiguredFeatures.java
@@ -1,11 +1,8 @@
 package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Features;
-
-
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
-import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
 
 import java.util.Objects;
@@ -26,7 +23,7 @@ public class ModConfiguredFeatures {
      * The constant CUSTOM_STRUCTURE.
      */
     public static final ConfiguredFeature<?, ?> CUSTOM_STRUCTURE = new ConfiguredFeature<>(
-            Feature.NO_OP, // Replace with your custom feature if available
-            NoneFeatureConfiguration.INSTANCE // Use the appropriate configuration
+            ModFeatures.BUNKER_FEATURE.get(),
+            NoneFeatureConfiguration.INSTANCE
     );
 }


### PR DESCRIPTION
## Summary
- register bunker feature, configured feature, placed feature, and biome modifier deferred registers so they load during mod initialization
- use the bunker feature for the configured feature instead of a no-op placeholder so bunker structures can be placed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f70f39ec8328a23ac9ada38541b1)