### PR TITLE
Fix bunker feature registration initialization for bunker structure

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModConfiguredFeatures.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModConfiguredFeatures.java
@@ -3,7 +3,6 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
-import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
 
 import java.util.Objects;
 
@@ -19,11 +18,10 @@ public class ModConfiguredFeatures {
             Objects.requireNonNull(ResourceLocation.tryParse("wildernessodyssey:custom_structure")) // Use tryParse to create the ResourceLocation
     );
 
-    /**
-     * The constant CUSTOM_STRUCTURE.
-     */
-    public static final ConfiguredFeature<?, ?> CUSTOM_STRUCTURE = new ConfiguredFeature<>(
-            ModFeatures.BUNKER_FEATURE.get(),
-            NoneFeatureConfiguration.INSTANCE
-    );
+    private ModConfiguredFeatures() {
+    }
+
+    public static ConfiguredFeature<?, ?> getCustomStructure() {
+        return ModFeatures.CUSTOM_STRUCTURE.get();
+    }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModFeatures.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModFeatures.java
@@ -1,6 +1,5 @@
 package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Features;
 
-import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.placement.PlacementUtils;
 import net.minecraft.resources.ResourceKey;
@@ -50,25 +49,21 @@ public class ModFeatures {
     );
 
     // Configured feature using the bunker feature
-    public static final ConfiguredFeature<?, ?> CUSTOM_STRUCTURE = new ConfiguredFeature<>(
-            BUNKER_FEATURE.get(),
-            NoneFeatureConfiguration.INSTANCE
+    public static final DeferredHolder<ConfiguredFeature<?, ?>, ConfiguredFeature<NoneFeatureConfiguration, ?>> CUSTOM_STRUCTURE = CONFIGURED_FEATURES.register(
+            "custom_structure",
+            () -> new ConfiguredFeature<>(
+                    BUNKER_FEATURE.get(),
+                    NoneFeatureConfiguration.INSTANCE
+            )
     );
 
-    static {
-        CONFIGURED_FEATURES.register(
-                "custom_structure",
-                () -> CUSTOM_STRUCTURE
-        );
-
-        PLACED_FEATURES.register(
-                "custom_structure",
-                () -> new PlacedFeature(
-                        Holder.direct(CUSTOM_STRUCTURE), // Use direct holder for ConfiguredFeature
-                        List.of(PlacementUtils.HEIGHTMAP_WORLD_SURFACE) // Define placement rules
-                )
-        );
-    }
+    public static final DeferredHolder<PlacedFeature, PlacedFeature> CUSTOM_STRUCTURE_PLACED = PLACED_FEATURES.register(
+            "custom_structure",
+            () -> new PlacedFeature(
+                    CUSTOM_STRUCTURE.getHolder().orElseThrow(() -> new IllegalStateException("Custom structure not registered")),
+                    List.of(PlacementUtils.HEIGHTMAP_WORLD_SURFACE) // Define placement rules
+            )
+    );
 
     /**
      * The constant CUSTOM_STRUCTURE_PLACED_KEY.

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModPlacedFeatures.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModPlacedFeatures.java
@@ -5,7 +5,9 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.placement.PlacementUtils;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
 
 import java.util.List;
 import java.util.Objects;
@@ -22,11 +24,16 @@ public class ModPlacedFeatures {
             Objects.requireNonNull(ResourceLocation.tryParse("wildernessodyssey:custom_structure")) // Use tryParse to create ResourceLocation
     );
 
-    /**
-     * The constant CUSTOM_STRUCTURE_PLACED.
-     */
-    public static final PlacedFeature CUSTOM_STRUCTURE_PLACED = new PlacedFeature(
-            Holder.direct(ModConfiguredFeatures.CUSTOM_STRUCTURE),
-            List.of(PlacementUtils.HEIGHTMAP_WORLD_SURFACE) // Define placement rules here
-    );
+    private ModPlacedFeatures() {
+    }
+
+    public static PlacedFeature customStructurePlaced() {
+        Holder<ConfiguredFeature<?, ?>> configuredHolder = ModFeatures.CUSTOM_STRUCTURE.getHolder()
+                .orElseThrow(() -> new IllegalStateException("Custom structure not registered"));
+
+        return new PlacedFeature(
+                configuredHolder,
+                List.<PlacementModifier>of(PlacementUtils.HEIGHTMAP_WORLD_SURFACE) // Define placement rules here
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- defer bunker configured and placed feature creation to registry suppliers to avoid early access
- update configured and placed feature helpers to retrieve registered instances safely

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932855af04083288a13e65aa2721cd9)