### PR TITLE
Fix custom structure holder usage

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModFeatures.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModFeatures.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.Features;
 
+import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.placement.PlacementUtils;
 import net.minecraft.resources.ResourceKey;
@@ -60,7 +61,7 @@ public class ModFeatures {
     public static final DeferredHolder<PlacedFeature, PlacedFeature> CUSTOM_STRUCTURE_PLACED = PLACED_FEATURES.register(
             "custom_structure",
             () -> new PlacedFeature(
-                    CUSTOM_STRUCTURE.getHolder().orElseThrow(() -> new IllegalStateException("Custom structure not registered")),
+                    Holder.direct(CUSTOM_STRUCTURE.get()),
                     List.of(PlacementUtils.HEIGHTMAP_WORLD_SURFACE) // Define placement rules
             )
     );

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModPlacedFeatures.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/ModPlacedFeatures.java
@@ -28,8 +28,7 @@ public class ModPlacedFeatures {
     }
 
     public static PlacedFeature customStructurePlaced() {
-        Holder<ConfiguredFeature<?, ?>> configuredHolder = ModFeatures.CUSTOM_STRUCTURE.getHolder()
-                .orElseThrow(() -> new IllegalStateException("Custom structure not registered"));
+        Holder<ConfiguredFeature<?, ?>> configuredHolder = Holder.direct(ModFeatures.CUSTOM_STRUCTURE.get());
 
         return new PlacedFeature(
                 configuredHolder,


### PR DESCRIPTION
## Summary
- replace unsupported DeferredHolder#getHolder calls with direct holders for custom structure features
- ensure placed feature registration and factory wrap configured feature using Holder.direct

## Testing
- ./gradlew compileJava

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933c8097ba08328b776ce0ae971c908)