### PR TITLE
Fix template pool entries for bunker and impact zone

### DIFF
--- a/src/main/resources/data/wildernessodysseyapi/worldgen/template_pool/bunker/start.json
+++ b/src/main/resources/data/wildernessodysseyapi/worldgen/template_pool/bunker/start.json
@@ -3,10 +3,13 @@
   "fallback": "minecraft:empty",
   "elements": [
     {
-      "element_type": "minecraft:single_pool_element",
-      "projection": "rigid",
-      "location": "wildernessodysseyapi:bunker",
-      "processors": "wildernessodysseyapi:terrain_survey"
+      "weight": 1,
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "projection": "rigid",
+        "location": "wildernessodysseyapi:bunker",
+        "processors": "wildernessodysseyapi:terrain_survey"
+      }
     }
   ]
 }

--- a/src/main/resources/data/wildernessodysseyapi/worldgen/template_pool/impact_zone/start.json
+++ b/src/main/resources/data/wildernessodysseyapi/worldgen/template_pool/impact_zone/start.json
@@ -3,10 +3,13 @@
   "fallback": "minecraft:empty",
   "elements": [
     {
-      "element_type": "minecraft:single_pool_element",
-      "projection": "rigid",
-      "location": "wildernessodysseyapi:impact_zone",
-      "processors": "wildernessodysseyapi:terrain_survey"
+      "weight": 1,
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "projection": "rigid",
+        "location": "wildernessodysseyapi:impact_zone",
+        "processors": "wildernessodysseyapi:terrain_survey"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- wrap bunker template pool entry in weight/element object to satisfy structure pool format
- do the same for the impact_zone template pool entry

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934bc73eb94832891d2ff15e01beddb)