### PR TITLE
Add biome tags to enable bunker and impact zone spawning

### DIFF
--- a/src/main/resources/data/wildernessodysseyapi/tags/worldgen/biome/has_structure/bunker.json
+++ b/src/main/resources/data/wildernessodysseyapi/tags/worldgen/biome/has_structure/bunker.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_overworld"
+  ]
+}

--- a/src/main/resources/data/wildernessodysseyapi/tags/worldgen/biome/has_structure/impact_zone.json
+++ b/src/main/resources/data/wildernessodysseyapi/tags/worldgen/biome/has_structure/impact_zone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_overworld"
+  ]
+}


### PR DESCRIPTION
## Summary
- add biome has_structure tags for bunkers and impact zones
- scope both structures to overworld biomes so generation can occur

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934d6eab0548328a0efae2e1b1910ce)