### PR TITLE
Fix bunker biome modifier for structure placement

### DIFF
--- a/src/main/resources/data/wildernessodysseyapi/neoforge/biome_modifier/bunker.json
+++ b/src/main/resources/data/wildernessodysseyapi/neoforge/biome_modifier/bunker.json
@@ -1,8 +1,7 @@
 {
-  "type": "neoforge:add_features",
+  "type": "neoforge:add_structures",
   "biomes": "#minecraft:is_overworld",
-  "features": [
+  "structures": [
     "wildernessodysseyapi:bunker"
-  ],
-  "step": "surface_structures"
+  ]
 }


### PR DESCRIPTION
## Summary
- replace the bunker biome modifier with `add_structures` so the structure can be scheduled for overworld biomes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934fa0710b88328b0b2e062028bcabe)