### PR TITLE
Remove unsupported NeoForge bunker biome modifier

### DIFF
--- a/src/main/resources/data/wildernessodysseyapi/neoforge/biome_modifier/bunker.json
+++ b/src/main/resources/data/wildernessodysseyapi/neoforge/biome_modifier/bunker.json
@@ -1,7 +1,0 @@
-{
-  "type": "neoforge:add_structures",
-  "biomes": "#minecraft:is_overworld",
-  "structures": [
-    "wildernessodysseyapi:bunker"
-  ]
-}


### PR DESCRIPTION
## Summary
- remove the outdated bunker biome modifier that referenced the unsupported `neoforge:add_structures` serializer

## Testing
- ./gradlew build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935e216d0788328a1ab4733c59da276)