### PR TITLE
Respect terrain replacer config in survey processor

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/TerrainSurveyProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/TerrainSurveyProcessor.java
@@ -2,6 +2,7 @@ package com.thunder.wildernessodysseyapi.WorldGen.processor;
 
 import com.mojang.serialization.MapCodec;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.TerrainReplacerBlock;
+import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
@@ -40,6 +41,10 @@ public class TerrainSurveyProcessor extends StructureProcessor {
         }
 
         // Replace terrain markers with the local surface block to blend the footprint into the biome.
+        if (!StructureConfig.ENABLE_TERRAIN_REPLACER.get()) {
+            return placed;
+        }
+
         if (state.is(TerrainReplacerBlock.TERRAIN_REPLACER.get())) {
             BlockPos target = placed.pos();
             int surfaceY = level.getHeight(Heightmap.Types.WORLD_SURFACE_WG, target.getX(), target.getZ()) - 1;


### PR DESCRIPTION
## Summary
- prevent the terrain survey processor from replacing terrain markers when the `enableTerrainReplacer` config flag is disabled

## Testing
- `./gradlew test --console=plain --no-daemon` *(hangs during Vineflower decompile; aborted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69383b1b83f083288165645c5c79bcc9)