### PR TITLE
Fix chunk cache path initialization

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -190,7 +190,7 @@ public class WildernessOdysseyAPIMainModClass {
         BunkerProtectionHandler.clear();
         AsyncTaskManager.initialize(AsyncThreadingConfig.values());
         ChunkStreamingConfig.ChunkConfigValues chunkConfig = ChunkStreamingConfig.values();
-        chunkStorageRoot = event.getServer().getFile("config/" + CONFIG_FOLDER + "chunk-cache").toPath();
+        chunkStorageRoot = event.getServer().getFile("config/" + CONFIG_FOLDER + "chunk-cache");
         ChunkStreamManager.initialize(chunkConfig, new DiskChunkStorageAdapter(chunkStorageRoot, chunkConfig.compressionLevel()));
         globalChatManager.initialize(event.getServer(), event.getServer().getFile("config"));
         AnalyticsTracker.initialize(event.getServer(), event.getServer().getFile("config"));


### PR DESCRIPTION
## Summary
- use the server-provided Path directly for chunk cache storage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938da3b3950832892189f932715808d)