### PR TITLE
Rewrite worldgen placement pipeline with debug tooling

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -29,6 +29,7 @@ import com.thunder.wildernessodysseyapi.command.StructureInfoCommand;
 import com.thunder.wildernessodysseyapi.donations.command.DonateCommand;
 import com.thunder.wildernessodysseyapi.command.DoorLockCommand;
 import com.thunder.wildernessodysseyapi.command.WorldGenScanCommand;
+import com.thunder.wildernessodysseyapi.command.StructurePlacementDebugCommand;
 import com.thunder.wildernessodysseyapi.config.ConfigRegistrationValidator;
 import com.thunder.wildernessodysseyapi.config.StructureBlockConfig;
 import com.thunder.wildernessodysseyapi.item.ModCreativeTabs;
@@ -213,6 +214,7 @@ public class WildernessOdysseyAPIMainModClass {
         DonateCommand.register(event.getDispatcher());
         DoorLockCommand.register(event.getDispatcher());
         WorldGenScanCommand.register(event.getDispatcher());
+        StructurePlacementDebugCommand.register(event.getDispatcher());
         AiAdvisorCommand.register(event.getDispatcher());
         AsyncStatsCommand.register(dispatcher);
         ChunkStatsCommand.register(dispatcher);

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/BunkerFeature.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/BunkerStructure/Features/BunkerFeature.java
@@ -6,6 +6,8 @@ import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock.Cryo
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock.PlayerSpawnHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.BunkerStructure.SpawnBlock.WorldSpawnHandler;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.NBTStructurePlacer;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StructurePlacementDebugger;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StructurePlacementDebugger.PlacementAttempt;
 import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -32,23 +34,36 @@ public class BunkerFeature extends Feature<NoneFeatureConfiguration> {
         LevelAccessor levelAccessor = context.level();
         if (!(levelAccessor instanceof ServerLevel level)) return false;
 
+        BlockPos origin = context.origin();
+        PlacementAttempt attempt = StructurePlacementDebugger.startAttempt(level, BUNKER_PLACER.id(), BUNKER_PLACER.peekSize(level), origin);
+
         if (StructureConfig.DEBUG_DISABLE_BUNKER_SPAWNS.get()) {
+            StructurePlacementDebugger.markFailure(attempt, "bunker spawns disabled in config");
             return false;
         }
 
-        BlockPos origin = context.origin();
         StructureSpawnTracker tracker = StructureSpawnTracker.get(level);
 
-        if (tracker.hasSpawnedAt(origin)) return false;
+        if (tracker.hasSpawnedAt(origin)) {
+            StructurePlacementDebugger.markFailure(attempt, "already spawned at this anchor");
+            return false;
+        }
 
         int minDist = StructureConfig.BUNKER_MIN_DISTANCE.get();
         int maxCount = StructureConfig.BUNKER_MAX_COUNT.get();
 
-        if (tracker.getSpawnCount() >= maxCount) return false;
-        if (!tracker.isFarEnough(origin, minDist)) return false;
+        if (tracker.getSpawnCount() >= maxCount) {
+            StructurePlacementDebugger.markFailure(attempt, "spawn limit reached");
+            return false;
+        }
+        if (!tracker.isFarEnough(origin, minDist)) {
+            StructurePlacementDebugger.markFailure(attempt, "too close to prior bunker");
+            return false;
+        }
 
-        NBTStructurePlacer.PlacementResult result = BUNKER_PLACER.place(level, origin);
+        NBTStructurePlacer.PlacementResult result = BUNKER_PLACER.place(level, origin, attempt);
         if (result == null) {
+            StructurePlacementDebugger.markFailure(attempt, "placement failed");
             return false;
         }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/configurable/StructureConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/configurable/StructureConfig.java
@@ -23,6 +23,8 @@ public class StructureConfig {
     public static final ModConfigSpec.BooleanValue DEBUG_DISABLE_BUNKER_SPAWNS;
     /** Debug toggle to skip meteor impact site placement */
     public static final ModConfigSpec.BooleanValue DEBUG_DISABLE_IMPACT_SITES;
+    /** Emit detailed structure placement logs and retain a short history for debugging. */
+    public static final ModConfigSpec.BooleanValue DEBUG_LOG_PLACEMENTS;
     /** Toggle for replacing terrain marker blocks with sampled terrain */
     public static final ModConfigSpec.BooleanValue ENABLE_TERRAIN_REPLACER;
     /** Warn when terrain replacer usage exceeds this fraction of the template volume */
@@ -55,6 +57,13 @@ public class StructureConfig {
                         "If true, meteor impact sites will not be generated."
                 )
                 .define("debugDisableImpactSites", false);
+        BUILDER.pop();
+
+        BUILDER.push("debug");
+        DEBUG_LOG_PLACEMENTS = BUILDER.comment(
+                        "If true, every structure placement attempt is recorded and logged for troubleshooting."
+                )
+                .define("debugLogPlacements", false);
         BUILDER.pop();
 
         BUILDER.push("placement");

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/TerrainSurveyProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/TerrainSurveyProcessor.java
@@ -3,11 +3,11 @@ package com.thunder.wildernessodysseyapi.WorldGen.processor;
 import com.mojang.serialization.MapCodec;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.TerrainReplacerBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.TerrainReplacerEngine;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
@@ -46,20 +46,8 @@ public class TerrainSurveyProcessor extends StructureProcessor {
         }
 
         if (state.is(TerrainReplacerBlock.TERRAIN_REPLACER.get())) {
-            BlockPos target = placed.pos();
-            int surfaceY = level.getHeight(Heightmap.Types.WORLD_SURFACE_WG, target.getX(), target.getZ()) - 1;
-            BlockPos surfacePos = new BlockPos(target.getX(), surfaceY, target.getZ());
-            BlockState sampled = level.getBlockState(surfacePos);
-
-            if (sampled.isAir() && surfaceY > level.getMinBuildHeight()) {
-                sampled = level.getBlockState(surfacePos.below());
-            }
-
-            if (sampled.isAir()) {
-                sampled = Blocks.DIRT.defaultBlockState();
-            }
-
-            return new StructureTemplate.StructureBlockInfo(target, sampled, placed.nbt());
+            BlockState sampled = TerrainReplacerEngine.sampleSurfaceBlock(level, placed.pos());
+            return new StructureTemplate.StructureBlockInfo(placed.pos(), sampled, placed.nbt());
         }
 
         return placed;

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StructurePlacementDebugger.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StructurePlacementDebugger.java
@@ -1,0 +1,165 @@
+package com.thunder.wildernessodysseyapi.WorldGen.structure;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Vec3i;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Small debug utility that records structure placement attempts and exposes them to chat commands.
+ */
+public final class StructurePlacementDebugger {
+    private static final int MAX_ENTRIES = 50;
+    private static final Deque<PlacementAttempt> ATTEMPTS = new ArrayDeque<>();
+
+    private StructurePlacementDebugger() {
+    }
+
+    /**
+     * Starts tracking a placement attempt for the given structure.
+     */
+    public static PlacementAttempt startAttempt(ServerLevel level, ResourceLocation id, Vec3i size, BlockPos origin) {
+        PlacementAttempt attempt = new PlacementAttempt(
+                id,
+                level.dimension().location(),
+                origin,
+                size,
+                level.getGameTime()
+        );
+        ATTEMPTS.addFirst(attempt);
+        trim();
+        log("Starting placement", attempt, false);
+        return attempt;
+    }
+
+    /** Marks the attempt as successful and logs the detail. */
+    public static void markSuccess(PlacementAttempt attempt, String detail) {
+        if (attempt == null) {
+            return;
+        }
+        attempt.finish(true, detail);
+        log("Placed", attempt, false);
+    }
+
+    /** Marks the attempt as failed and logs the detail. */
+    public static void markFailure(PlacementAttempt attempt, String detail) {
+        if (attempt == null) {
+            return;
+        }
+        attempt.finish(false, detail);
+        log("Failed to place", attempt, true);
+    }
+
+    /** Returns up to {@code limit} most recent placement attempts (newest first). */
+    public static List<PlacementAttempt> recent(int limit) {
+        List<PlacementAttempt> copy = new ArrayList<>(ATTEMPTS);
+        Collections.sort(copy); // latest attempts first
+        return copy.subList(0, Math.min(limit, copy.size()));
+    }
+
+    private static void trim() {
+        while (ATTEMPTS.size() > MAX_ENTRIES) {
+            ATTEMPTS.removeLast();
+        }
+    }
+
+    private static void log(String prefix, PlacementAttempt attempt, boolean warn) {
+        if (!StructureConfig.DEBUG_LOG_PLACEMENTS.get()) {
+            return;
+        }
+
+        String formatted = "%s %s at %s size %s (%s)".formatted(
+                prefix,
+                attempt.id(),
+                formatPos(attempt.origin(), attempt.dimension()),
+                attempt.size(),
+                attempt.statusDetail()
+        );
+
+        if (warn) {
+            ModConstants.LOGGER.warn(formatted);
+        } else {
+            ModConstants.LOGGER.info(formatted);
+        }
+    }
+
+    private static String formatPos(BlockPos pos, ResourceLocation dimension) {
+        return "[%s] %s,%s,%s".formatted(dimension.toString(), pos.getX(), pos.getY(), pos.getZ());
+    }
+
+    /**
+     * Mutable attempt descriptor that can be sorted by creation time (newest first).
+     */
+    public static final class PlacementAttempt implements Comparable<PlacementAttempt> {
+        private final ResourceLocation id;
+        private final ResourceLocation dimension;
+        private final BlockPos origin;
+        private final Vec3i size;
+        private final long createdGameTime;
+        private boolean finished;
+        private boolean success;
+        private String detail = "pending";
+        private final Instant createdAt = Instant.now();
+
+        private PlacementAttempt(ResourceLocation id, ResourceLocation dimension, BlockPos origin, Vec3i size, long gameTime) {
+            this.id = id;
+            this.dimension = dimension;
+            this.origin = origin;
+            this.size = size;
+            this.createdGameTime = gameTime;
+        }
+
+        public ResourceLocation id() {
+            return id;
+        }
+
+        public ResourceLocation dimension() {
+            return dimension;
+        }
+
+        public BlockPos origin() {
+            return origin;
+        }
+
+        public Vec3i size() {
+            return size;
+        }
+
+        public long createdGameTime() {
+            return createdGameTime;
+        }
+
+        public boolean success() {
+            return success;
+        }
+
+        public String statusDetail() {
+            return detail;
+        }
+
+        private void finish(boolean success, String detail) {
+            this.finished = true;
+            this.success = success;
+            this.detail = detail;
+        }
+
+        @Override
+        public int compareTo(PlacementAttempt other) {
+            return other.createdAt.compareTo(this.createdAt);
+        }
+
+        @Override
+        public String toString() {
+            return "%s (%s)".formatted(id, success ? "ok" : finished ? "fail" : "pending");
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/TerrainReplacerEngine.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/TerrainReplacerEngine.java
@@ -1,0 +1,80 @@
+package com.thunder.wildernessodysseyapi.WorldGen.structure;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.Heightmap;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Shared terrain replacement helpers used by structure placement and template processors.
+ */
+public final class TerrainReplacerEngine {
+    private TerrainReplacerEngine() {
+    }
+
+    /**
+     * Samples the surface block at the given world position, walking down through replaceable blocks
+     * and fluids until a solid block is found. Falls back to dirt when nothing solid is encountered.
+     */
+    public static BlockState sampleSurfaceBlock(LevelReader level, BlockPos target) {
+        return sampleSurface(level, target).state();
+    }
+
+    /**
+     * Samples both the surface Y coordinate and the block used at that location.
+     */
+    public static SurfaceSample sampleSurface(LevelReader level, BlockPos target) {
+        int surfaceY = level.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, target.getX(), target.getZ()) - 1;
+        int minY = level.getMinBuildHeight();
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos(target.getX(), surfaceY, target.getZ());
+
+        for (int y = surfaceY; y >= minY; y--) {
+            cursor.setY(y);
+            BlockState state = level.getBlockState(cursor);
+            if (isSolidSurface(state)) {
+                return new SurfaceSample(y, state);
+            }
+        }
+
+        return new SurfaceSample(surfaceY, Blocks.DIRT.defaultBlockState());
+    }
+
+    /**
+     * Collects replacement blocks for each offset if terrain replacement is enabled.
+     */
+    public static TerrainReplacementPlan planReplacement(ServerLevel level, BlockPos origin, List<BlockPos> offsets, boolean enabled) {
+        if (!enabled || offsets.isEmpty()) {
+            return TerrainReplacementPlan.disabled();
+        }
+
+        List<BlockState> sampled = new ArrayList<>(offsets.size());
+        for (BlockPos offset : offsets) {
+            BlockPos worldPos = origin.offset(offset);
+            sampled.add(sampleSurfaceBlock(level, worldPos));
+        }
+
+        return new TerrainReplacementPlan(true, Collections.unmodifiableList(sampled));
+    }
+
+    private static boolean isSolidSurface(BlockState state) {
+        return !state.isAir() && state.getFluidState().isEmpty();
+    }
+
+    /**
+     * Immutable description of the blocks that should replace terrain markers.
+     */
+    public record TerrainReplacementPlan(boolean enabled, List<BlockState> samples) {
+        public static TerrainReplacementPlan disabled() {
+            return new TerrainReplacementPlan(false, List.of());
+        }
+    }
+
+    /** Position/state pair returned by {@link #sampleSurface(LevelReader, BlockPos)}. */
+    public record SurfaceSample(int y, BlockState state) { }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/StructurePlacementDebugCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/StructurePlacementDebugCommand.java
@@ -1,0 +1,55 @@
+package com.thunder.wildernessodysseyapi.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StructurePlacementDebugger;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StructurePlacementDebugger.PlacementAttempt;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+import java.util.List;
+
+/**
+ * Debug command that exposes the recent structure placement attempts recorded by the mod.
+ */
+public final class StructurePlacementDebugCommand {
+    private StructurePlacementDebugCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(
+                Commands.literal("structuredebug")
+                        .executes(ctx -> execute(ctx, 10))
+                        .then(Commands.argument("limit", IntegerArgumentType.integer(1, 50))
+                                .executes(ctx -> execute(ctx, IntegerArgumentType.getInteger(ctx, "limit"))))
+        );
+    }
+
+    private static int execute(CommandContext<CommandSourceStack> ctx, int limit) {
+        List<PlacementAttempt> attempts = StructurePlacementDebugger.recent(limit);
+        if (attempts.isEmpty()) {
+            ctx.getSource().sendSuccess(() -> Component.literal(ChatFormatting.RED + "No recorded structure placements yet."), false);
+            return 1;
+        }
+
+        ctx.getSource().sendSuccess(() -> Component.literal(ChatFormatting.GOLD + "Recent structure placements (newest first):"), false);
+        attempts.forEach(attempt -> ctx.getSource().sendSuccess(() -> Component.literal(formatAttempt(attempt)), false));
+        return 1;
+    }
+
+    private static String formatAttempt(PlacementAttempt attempt) {
+        String statusColor = attempt.success() ? ChatFormatting.GREEN.toString() : ChatFormatting.RED.toString();
+        String location = "[%s] %s,%s,%s".formatted(
+                attempt.dimension(), attempt.origin().getX(), attempt.origin().getY(), attempt.origin().getZ());
+        return "%s%s %s %s %s".formatted(
+                statusColor,
+                attempt.success() ? "✔" : "✖",
+                ChatFormatting.GRAY + attempt.id().toString(),
+                ChatFormatting.AQUA + location,
+                ChatFormatting.YELLOW + attempt.statusDetail()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- refactor structure placement to sample terrain via a shared engine and clamp leveling before placing templates
- add placement debugger utilities plus a `/structuredebug` command and config toggle to inspect recent worldgen attempts
- wire bunker generation through the new pipeline and reuse the improved terrain replacer processor

## Testing
- `./gradlew --version`
- `./gradlew compileJava -x test --console=plain` *(interrupted while waiting on a decompile lock)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693905a8b6108328af0efadfe72857ab)