### PR TITLE
Set explicit bounds when placing templates

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/LargeStructurePlacementOptimizer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/LargeStructurePlacementOptimizer.java
@@ -3,6 +3,7 @@ package com.thunder.wildernessodysseyapi.WorldGen.structure;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.phys.AABB;
 
 import java.util.ArrayList;
@@ -55,6 +56,19 @@ public final class LargeStructurePlacementOptimizer {
         return new AABB(
                 origin.getX(), origin.getY(), origin.getZ(),
                 max.getX() + 1, max.getY() + 1, max.getZ() + 1
+        );
+    }
+
+    /**
+     * Computes the levelgen {@link BoundingBox} occupied by a structure that starts at {@code origin}.
+     * The resulting bounds are inclusive of all blocks touched by the template and mirror the extents
+     * used by {@link #createBounds(BlockPos, Vec3i)}.
+     */
+    public static BoundingBox createPlacementBox(BlockPos origin, Vec3i size) {
+        BlockPos max = origin.offset(Math.max(0, size.getX() - 1), Math.max(0, size.getY() - 1), Math.max(0, size.getZ() - 1));
+        return new BoundingBox(
+                origin.getX(), origin.getY(), origin.getZ(),
+                max.getX(), max.getY(), max.getZ()
         );
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -107,7 +107,7 @@ public class NBTStructurePlacer {
                 // Supplying the bounds up-front prevents the vanilla placer from bailing out when it cannot
                 // infer them (which resulted in the template refusing to place while terrain markers still
                 // ran).
-                .setBoundingBox(LargeStructurePlacementOptimizer.createBounds(foundation.origin(), data.size()));
+                .setBoundingBox(LargeStructurePlacementOptimizer.createPlacementBox(foundation.origin(), data.size()));
         boolean placed = data.template().placeInWorld(level, foundation.origin(), foundation.origin(), settings, level.random, 2);
         if (!placed) {
             StructurePlacementDebugger.markFailure(attempt, "template refused placement");

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -101,7 +101,13 @@ public class NBTStructurePlacer {
             }
         }
 
-        StructurePlaceSettings settings = new StructurePlaceSettings();
+        StructurePlaceSettings settings = new StructurePlaceSettings()
+                // We already know the template dimensions, so skip the expensive shape discovery pass.
+                .setKnownShape(true)
+                // Supplying the bounds up-front prevents the vanilla placer from bailing out when it cannot
+                // infer them (which resulted in the template refusing to place while terrain markers still
+                // ran).
+                .setBoundingBox(LargeStructurePlacementOptimizer.createBounds(foundation.origin(), data.size()));
         boolean placed = data.template().placeInWorld(level, foundation.origin(), foundation.origin(), settings, level.random, 2);
         if (!placed) {
             StructurePlacementDebugger.markFailure(attempt, "template refused placement");


### PR DESCRIPTION
## Summary
- provide known shape and bounding box when placing NBT structures so placement cannot bail out early

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e2851bd7c832881bfa76985f440cf)