### PR TITLE
Add configurable tide system

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -30,6 +30,7 @@ import com.thunder.wildernessodysseyapi.donations.command.DonateCommand;
 import com.thunder.wildernessodysseyapi.command.DoorLockCommand;
 import com.thunder.wildernessodysseyapi.command.WorldGenScanCommand;
 import com.thunder.wildernessodysseyapi.command.StructurePlacementDebugCommand;
+import com.thunder.wildernessodysseyapi.command.TideInfoCommand;
 import com.thunder.wildernessodysseyapi.config.ConfigRegistrationValidator;
 import com.thunder.wildernessodysseyapi.config.StructureBlockConfig;
 import com.thunder.wildernessodysseyapi.item.ModCreativeTabs;
@@ -44,6 +45,8 @@ import com.thunder.wildernessodysseyapi.AI.AI_perf.PerformanceAdvisoryRequest;
 import com.thunder.wildernessodysseyapi.AI.AI_perf.PerformanceMitigationController;
 import com.thunder.wildernessodysseyapi.donations.config.DonationReminderConfig;
 import com.thunder.wildernessodysseyapi.globalchat.GlobalChatManager;
+import com.thunder.wildernessodysseyapi.tide.TideConfig;
+import com.thunder.wildernessodysseyapi.tide.TideManager;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -160,6 +163,8 @@ public class WildernessOdysseyAPIMainModClass {
                 CONFIG_FOLDER + "wildernessodysseyapi-anticheat-server.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, StructureBlockConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-structureblocks-server.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, TideConfig.CONFIG_SPEC,
+                CONFIG_FOLDER + "wildernessodysseyapi-tides-server.toml");
         // Previously registered client-only events have been removed
         DonationReminderConfig.validateVersion();
 
@@ -221,6 +226,7 @@ public class WildernessOdysseyAPIMainModClass {
         AnalyticsCommand.register(dispatcher);
         GlobalChatCommand.register(dispatcher);
         GlobalChatOptToggleCommand.register(dispatcher);
+        TideInfoCommand.register(dispatcher);
     }
 
     /**
@@ -331,6 +337,9 @@ public class WildernessOdysseyAPIMainModClass {
         if (event.getConfig().getSpec() == StructureBlockConfig.CONFIG_SPEC) {
             StructureBlockSettings.reloadFromConfig();
         }
+        if (event.getConfig().getSpec() == TideConfig.CONFIG_SPEC) {
+            TideManager.reloadConfig();
+        }
     }
 
     public void onConfigReloaded(ModConfigEvent.Reloading event) {
@@ -346,6 +355,9 @@ public class WildernessOdysseyAPIMainModClass {
         }
         if (event.getConfig().getSpec() == StructureBlockConfig.CONFIG_SPEC) {
             StructureBlockSettings.reloadFromConfig();
+        }
+        if (event.getConfig().getSpec() == TideConfig.CONFIG_SPEC) {
+            TideManager.reloadConfig();
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/TideInfoCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/TideInfoCommand.java
@@ -1,0 +1,49 @@
+package com.thunder.wildernessodysseyapi.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import com.thunder.wildernessodysseyapi.tide.TideManager;
+import com.thunder.wildernessodysseyapi.tide.TideManager.TideSnapshot;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+
+/**
+ * Simple command for surfacing tide information to operators and curious players.
+ */
+public final class TideInfoCommand {
+
+    private TideInfoCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("tide")
+                .requires(source -> source.hasPermission(0))
+                .executes(TideInfoCommand::reportTide));
+    }
+
+    private static int reportTide(CommandContext<CommandSourceStack> context) {
+        CommandSourceStack source = context.getSource();
+        ServerLevel level = source.getLevel();
+        TideSnapshot snapshot = TideManager.snapshot(level);
+        BlockPos pos = BlockPos.containing(source.getPosition());
+
+        double amplitude = TideManager.getLocalAmplitude(level, pos);
+        double tideHeight = snapshot.normalizedHeight() * amplitude;
+        double trendPerTick = snapshot.verticalChangePerTick() * amplitude;
+
+        String message = String.format(
+                "Tide at %d %d %d: %.2f blocks (%s, Δ=%.4f/tick, cycle %.1f min)",
+                pos.getX(), pos.getY(), pos.getZ(),
+                tideHeight,
+                snapshot.trendDescription(),
+                trendPerTick,
+                snapshot.cycleTicks() / 20.0D / 60.0D
+        );
+
+        source.sendSuccess(() -> Component.literal(message), false);
+        return (int) Math.round(tideHeight * 100.0D);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/tide/TideConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/tide/TideConfig.java
@@ -1,0 +1,79 @@
+package com.thunder.wildernessodysseyapi.tide;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+/**
+ * Configuration for the tide simulation.
+ */
+public final class TideConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+
+    public static final ModConfigSpec.BooleanValue ENABLED;
+    public static final ModConfigSpec.DoubleValue CYCLE_MINUTES;
+    public static final ModConfigSpec.DoubleValue OCEAN_AMPLITUDE_BLOCKS;
+    public static final ModConfigSpec.DoubleValue RIVER_AMPLITUDE_BLOCKS;
+    public static final ModConfigSpec.DoubleValue PHASE_OFFSET_MINUTES;
+    public static final ModConfigSpec.DoubleValue CURRENT_STRENGTH;
+
+    private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
+
+    static {
+        BUILDER.push("tides");
+
+        ENABLED = BUILDER.comment("Master toggle for the dynamic tide simulation.")
+                .define("enabled", true);
+
+        CYCLE_MINUTES = BUILDER.comment("Duration of a full tide cycle (rise + fall) in real-time minutes.")
+                .defineInRange("cycleMinutes", 40.0D, 5.0D, 240.0D);
+
+        OCEAN_AMPLITUDE_BLOCKS = BUILDER.comment("Maximum vertical change (in blocks) applied to ocean tides.")
+                .defineInRange("oceanAmplitudeBlocks", 2.5D, 0.0D, 16.0D);
+
+        RIVER_AMPLITUDE_BLOCKS = BUILDER.comment("Maximum vertical change (in blocks) applied to river tides.")
+                .defineInRange("riverAmplitudeBlocks", 1.5D, 0.0D, 16.0D);
+
+        PHASE_OFFSET_MINUTES = BUILDER.comment("Optional offset to desynchronize tide peaks from the day/night cycle.")
+                .defineInRange("phaseOffsetMinutes", 0.0D, 0.0D, 240.0D);
+
+        CURRENT_STRENGTH = BUILDER.comment("Vertical force multiplier applied to entities in water to reflect rising/falling tides.")
+                .defineInRange("currentStrength", 0.004D, 0.0D, 0.05D);
+
+        BUILDER.pop();
+
+        CONFIG_SPEC = BUILDER.build();
+    }
+
+    private TideConfig() {
+    }
+
+    public static TideConfigValues values() {
+        return new TideConfigValues(
+                ENABLED.get(),
+                CYCLE_MINUTES.get(),
+                OCEAN_AMPLITUDE_BLOCKS.get(),
+                RIVER_AMPLITUDE_BLOCKS.get(),
+                PHASE_OFFSET_MINUTES.get(),
+                CURRENT_STRENGTH.get()
+        );
+    }
+
+    /**
+     * Convenience record used to avoid repeated config lookups every tick.
+     */
+    public record TideConfigValues(
+            boolean enabled,
+            double cycleMinutes,
+            double oceanAmplitudeBlocks,
+            double riverAmplitudeBlocks,
+            double phaseOffsetMinutes,
+            double currentStrength
+    ) {
+        public long cycleTicks() {
+            return (long) Math.max(1L, Math.round(cycleMinutes * 60.0D * 20.0D));
+        }
+
+        public long phaseOffsetTicks() {
+            return (long) Math.max(0L, Math.round(phaseOffsetMinutes * 60.0D * 20.0D));
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/tide/TideManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/tide/TideManager.java
@@ -1,0 +1,163 @@
+package com.thunder.wildernessodysseyapi.tide;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.BiomeTags;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.tick.EntityTickEvent;
+import net.neoforged.neoforge.event.server.ServerStartingEvent;
+import net.neoforged.neoforge.event.server.ServerStoppingEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.lang.Math.PI;
+
+/**
+ * Simulates a simple ocean/river tide that can be queried by other systems and gently influences entities in water.
+ */
+@EventBusSubscriber(modid = ModConstants.MOD_ID)
+public final class TideManager {
+    private static final Map<ResourceKey<Level>, TideState> TIDE_STATES = new ConcurrentHashMap<>();
+
+    private static TideConfig.TideConfigValues cachedConfig = TideConfig.values();
+
+    private TideManager() {
+    }
+
+    /**
+     * Called when config reloads to refresh cached values.
+     */
+    public static void reloadConfig() {
+        cachedConfig = TideConfig.values();
+    }
+
+    /**
+     * Returns the latest tide snapshot for the given level.
+     */
+    public static TideSnapshot snapshot(ServerLevel level) {
+        TideState state = TIDE_STATES.computeIfAbsent(level.dimension(), key -> new TideState());
+        return new TideSnapshot(state.normalizedHeight, state.changePerTick, cachedConfig.cycleTicks());
+    }
+
+    /**
+     * Returns the amplitude (in blocks) for the biome at the given position.
+     */
+    public static double getLocalAmplitude(ServerLevel level, BlockPos pos) {
+        Holder<Biome> biomeHolder = level.getBiome(pos);
+        if (biomeHolder.is(BiomeTags.IS_OCEAN)) {
+            return cachedConfig.oceanAmplitudeBlocks();
+        }
+        if (biomeHolder.is(BiomeTags.IS_RIVER)) {
+            return cachedConfig.riverAmplitudeBlocks();
+        }
+        return 0.0D;
+    }
+
+    @SubscribeEvent
+    public static void onServerStarting(ServerStartingEvent event) {
+        TIDE_STATES.clear();
+        cachedConfig = TideConfig.values();
+    }
+
+    @SubscribeEvent
+    public static void onServerStopping(ServerStoppingEvent event) {
+        TIDE_STATES.clear();
+    }
+
+    @SubscribeEvent
+    public static void onServerTick(ServerTickEvent.Post event) {
+        if (!event.hasTime()) {
+            return;
+        }
+        if (!cachedConfig.enabled()) {
+            return;
+        }
+
+        MinecraftServer server = event.getServer();
+        for (ServerLevel level : server.getAllLevels()) {
+            TideState state = TIDE_STATES.computeIfAbsent(level.dimension(), key -> new TideState());
+            long dayTime = level.getDayTime();
+            double newHeight = computeNormalizedHeight(dayTime, cachedConfig);
+            state.update(dayTime, newHeight);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onEntityTick(EntityTickEvent.Post event) {
+        if (!(event.getEntity() instanceof LivingEntity entity)) {
+            return;
+        }
+        if (!(entity.level() instanceof ServerLevel serverLevel)) {
+            return;
+        }
+        if (!cachedConfig.enabled() || !entity.isInWaterOrBubble()) {
+            return;
+        }
+
+        TideSnapshot snapshot = snapshot(serverLevel);
+        double amplitude = getLocalAmplitude(serverLevel, entity.blockPosition());
+        if (amplitude <= 0.0D) {
+            return;
+        }
+
+        double verticalForce = snapshot.verticalChangePerTick() * amplitude * cachedConfig.currentStrength();
+        if (Math.abs(verticalForce) < 1.0E-5) {
+            return;
+        }
+
+        Vec3 motion = entity.getDeltaMovement();
+        entity.setDeltaMovement(motion.x, motion.y + verticalForce, motion.z);
+    }
+
+    private static double computeNormalizedHeight(long dayTime, TideConfig.TideConfigValues config) {
+        long cycleTicks = Math.max(1L, config.cycleTicks());
+        long adjustedTime = (dayTime + config.phaseOffsetTicks()) % cycleTicks;
+        double phase = (adjustedTime / (double) cycleTicks) * 2.0D * PI;
+        return Math.sin(phase);
+    }
+
+    /**
+     * Lightweight state container tracked per dimension.
+     */
+    private static final class TideState {
+        private long lastUpdateTick = -1L;
+        private double normalizedHeight = 0.0D;
+        private double changePerTick = 0.0D;
+
+        void update(long worldTick, double newHeight) {
+            if (lastUpdateTick >= 0L) {
+                long delta = Math.max(1L, worldTick - lastUpdateTick);
+                changePerTick = (newHeight - normalizedHeight) / delta;
+            }
+            normalizedHeight = newHeight;
+            lastUpdateTick = worldTick;
+        }
+    }
+
+    /**
+     * Read-only tide information for consumers.
+     */
+    public record TideSnapshot(double normalizedHeight, double verticalChangePerTick, long cycleTicks) {
+        public boolean isRising() {
+            return verticalChangePerTick > 0.0D;
+        }
+
+        public String trendDescription() {
+            if (Math.abs(verticalChangePerTick) < 1.0E-5) {
+                return "slack";
+            }
+            return isRising() ? "rising" : "falling";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce configurable tide simulation for ocean and river biomes with per-dimension state tracking
- expose tide details via a new /tide command and configuration file
- register tide config reload hooks and enable light water movement for entities during tide changes

## Testing
- ./gradlew test --console=plain

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ee0c69c10832885c91beee4290c2e)