### PR TITLE
Handle tide config before load

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/tide/TideConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/tide/TideConfig.java
@@ -58,6 +58,20 @@ public final class TideConfig {
     }
 
     /**
+     * Returns configuration defaults without requiring the config file to be loaded.
+     */
+    public static TideConfigValues defaultValues() {
+        return new TideConfigValues(
+                ENABLED.getDefault(),
+                CYCLE_MINUTES.getDefault(),
+                OCEAN_AMPLITUDE_BLOCKS.getDefault(),
+                RIVER_AMPLITUDE_BLOCKS.getDefault(),
+                PHASE_OFFSET_MINUTES.getDefault(),
+                CURRENT_STRENGTH.getDefault()
+        );
+    }
+
+    /**
      * Convenience record used to avoid repeated config lookups every tick.
      */
     public record TideConfigValues(


### PR DESCRIPTION
## Summary
- add default tide config values that do not require the config file to be loaded
- guard tide manager config caching with a safe fallback and warning log

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946023e3de08328b0c1fc99c64873b1)