### PR TITLE
Fix Starter Structure mixin targets

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureConfigMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureConfigMixin.java
@@ -1,39 +1,32 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
+import com.natamus.starterstructure_common_neoforge.config.ConfigHandler;
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.lang.reflect.Field;
-
 /**
  * Forces Starter Structure to keep entity spawning enabled so tile-entity-powered
  * machines inside the bunker are not stripped when the schematic is placed.
  */
-@Mixin(targets = "com.natamus.starterstructure.config.ConfigHandler", remap = false)
+@Mixin(value = ConfigHandler.class, remap = false)
 public class StarterStructureConfigMixin {
     private static boolean loggedOnce = false;
 
     @Inject(method = "initConfig", at = @At("TAIL"))
     private static void wildernessOdysseyApi$ensureEntitiesEnabled(CallbackInfo ci) {
-        try {
-            Class<?> clazz = Class.forName("com.natamus.starterstructure.config.ConfigHandler");
-            Field spawnEntities = clazz.getDeclaredField("spawnNonSignEntitiesFromSupportedSchematics");
-            boolean current = spawnEntities.getBoolean(null);
-            if (!current) {
-                spawnEntities.setBoolean(null, true);
-                if (!loggedOnce) {
-                    ModConstants.LOGGER.info("[Starter Structure compat] Forced entity spawning on for schematics to preserve bunker machines.");
-                    loggedOnce = true;
-                }
-            }
-        } catch (Throwable throwable) {
+        boolean current = ConfigHandler.spawnNonSignEntitiesFromSupportedSchematics;
+        if (!current) {
+            ConfigHandler.spawnNonSignEntitiesFromSupportedSchematics = true;
             if (!loggedOnce) {
-                ModConstants.LOGGER.warn("[Starter Structure compat] Unable to enforce entity spawning; bunker machines may be missing. {}", throwable.toString());
+                ModConstants.LOGGER.info("[Starter Structure compat] Forced entity spawning on for schematics to preserve bunker machines.");
                 loggedOnce = true;
             }
+        } else if (!loggedOnce) {
+            ModConstants.LOGGER.debug("[Starter Structure compat] Entity spawning already enabled for schematics.");
+            loggedOnce = true;
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
+import com.natamus.starterstructure_common_neoforge.util.Util;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureTerrainAdapter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -8,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(targets = "com.natamus.starterstructure.util.Util", remap = false)
+@Mixin(value = Util.class, remap = false)
 public class StarterStructureUtilMixin {
     @Inject(method = "generateSchematic", at = @At("RETURN"))
     private static void wildernessOdysseyApi$triggerTerrainReplacer(ServerLevel serverLevel, CallbackInfoReturnable<BlockPos> cir) {


### PR DESCRIPTION
## Summary
- retarget Starter Structure mixins to the NeoForge common Starter Structure classes so compatibility hooks run
- simplify the entity-spawn enforcement logic with direct ConfigHandler access and clearer logging

## Testing
- ./gradlew build -x test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946da3faea483288dba8d00cce3f073)