### PR TITLE
Restrict cryo spawn configuration to overworld

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/spawn/WorldSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/spawn/WorldSpawnHandler.java
@@ -2,6 +2,7 @@ package com.thunder.wildernessodysseyapi.WorldGen.spawn;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.level.LevelEvent;
@@ -31,6 +32,10 @@ public class WorldSpawnHandler {
     }
 
     private static void configureWorldSpawn(ServerLevel world) {
+        if (!world.dimension().equals(Level.OVERWORLD)) {
+            return;
+        }
+
         CryoSpawnData data = CryoSpawnData.get(world);
         List<BlockPos> spawnBlockPositions = new ArrayList<>(data.getPositions());
 


### PR DESCRIPTION
## Summary
- avoid configuring cryo spawn positions outside the overworld by skipping other dimensions

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69472ce79df8832880647bdf8991b54f)