### PR TITLE
Restore schem entities for Starter Structure

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/SchematicEntityRestorer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/SchematicEntityRestorer.java
@@ -1,0 +1,116 @@
+package com.thunder.wildernessodysseyapi.WorldGen.structure;
+
+import com.mojang.datafixers.util.Pair;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.natamus.collective_common_neoforge.schematic.ParsedSchematicObject;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Backfills entity data for WorldEdit .schem files Starter Structure fails to
+ * populate when parsing schematics. Without this Create's glue/contraption
+ * entities never spawn and the starter base falls apart.
+ */
+public final class SchematicEntityRestorer {
+    private SchematicEntityRestorer() {
+    }
+
+    public static void backfillEntitiesFromSchem(ServerLevel level, Path schematicPath, boolean isNbtFormat,
+                                                 BlockPos structurePos, ParsedSchematicObject parsed) {
+        if (parsed == null || parsed.entities == null || !parsed.entities.isEmpty()) {
+            return;
+        }
+        if (isNbtFormat || schematicPath == null) {
+            return;
+        }
+
+        String fileName = schematicPath.getFileName().toString().toLowerCase(Locale.ROOT);
+        if (!fileName.endsWith(".schem")) {
+            return;
+        }
+
+        List<Pair<BlockPos, Entity>> restored = new ArrayList<>();
+        try {
+            CompoundTag root = NbtIo.readCompressed(schematicPath, NbtAccounter.unlimitedHeap());
+            if (root == null) {
+                return;
+            }
+            if (root.contains("Schematic", Tag.TAG_COMPOUND)) {
+                root = root.getCompound("Schematic");
+            }
+
+            ListTag entities = root.getList("Entities", Tag.TAG_COMPOUND);
+            if (entities.isEmpty()) {
+                return;
+            }
+
+            for (Tag entry : entities) {
+                if (!(entry instanceof CompoundTag entityTag)) {
+                    continue;
+                }
+
+                BlockPos relativePos = extractRelativePos(entityTag);
+                if (relativePos == null) {
+                    continue;
+                }
+
+                CompoundTag entityData = entityTag.contains("nbt", Tag.TAG_COMPOUND)
+                        ? entityTag.getCompound("nbt").copy()
+                        : entityTag.copy();
+                Entity entity = EntityType.create(entityData, level).orElse(null);
+                if (entity == null) {
+                    continue;
+                }
+
+                BlockPos worldPos = structurePos.offset(relativePos);
+                entity.setPos(worldPos.getX() + 0.5D, worldPos.getY(), worldPos.getZ() + 0.5D);
+                restored.add(Pair.of(worldPos, entity));
+            }
+        } catch (Exception e) {
+            ModConstants.LOGGER.warn("[Starter Structure compat] Failed to backfill entities from schem {}.", schematicPath, e);
+            return;
+        }
+
+        if (!restored.isEmpty()) {
+            parsed.entities = restored;
+            ModConstants.LOGGER.info(
+                    "[Starter Structure compat] Restored {} schematic entities from {} to preserve Create contraptions.",
+                    restored.size(), schematicPath.getFileName());
+        }
+    }
+
+    private static BlockPos extractRelativePos(CompoundTag entityTag) {
+        if (entityTag.contains("blockPos", Tag.TAG_LIST)) {
+            ListTag blockPosList = entityTag.getList("blockPos", Tag.TAG_INT);
+            if (blockPosList.size() == 3) {
+                return new BlockPos(blockPosList.getInt(0), blockPosList.getInt(1), blockPosList.getInt(2));
+            }
+        }
+
+        if (entityTag.contains("Pos", Tag.TAG_LIST)) {
+            ListTag posList = entityTag.getList("Pos", Tag.TAG_DOUBLE);
+            if (posList.size() == 3) {
+                return new BlockPos(
+                        Mth.floor(posList.getDouble(0)),
+                        Mth.floor(posList.getDouble(1)),
+                        Mth.floor(posList.getDouble(2))
+                );
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
@@ -2,15 +2,44 @@ package com.thunder.wildernessodysseyapi.mixin;
 
 import com.natamus.starterstructure_common_neoforge.util.Util;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureTerrainAdapter;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.SchematicEntityRestorer;
+import com.natamus.collective_common_neoforge.schematic.ParsedSchematicObject;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Path;
 
 @Mixin(value = Util.class, remap = false)
 public class StarterStructureUtilMixin {
+    @Inject(
+            method = "generateSchematic",
+            at = @At(
+                    value = "INVOKE_ASSIGN",
+                    target = "Lcom/natamus/collective_common_neoforge/schematic/ParseSchematicFile;getParsedSchematicObject(Ljava/io/InputStream;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;IZZ)Lcom/natamus/collective_common_neoforge/schematic/ParsedSchematicObject;"
+            ),
+            locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    private static void wildernessOdysseyApi$restoreSchemEntities(ServerLevel serverLevel,
+                                                                  CallbackInfoReturnable<BlockPos> cir,
+                                                                  java.util.List<File> listOfSchematicFiles,
+                                                                  File[] listOfFiles,
+                                                                  File schematicFile,
+                                                                  boolean automaticCenter,
+                                                                  BlockPos structurePos,
+                                                                  FileInputStream fileInputStream,
+                                                                  ParsedSchematicObject parsedSchematicObject) {
+        Path schematicPath = schematicFile.toPath();
+        SchematicEntityRestorer.backfillEntitiesFromSchem(serverLevel, schematicPath, schematicFile.getName().endsWith(".nbt"),
+                structurePos, parsedSchematicObject);
+    }
+
     @Inject(method = "generateSchematic", at = @At("RETURN"))
     private static void wildernessOdysseyApi$triggerTerrainReplacer(ServerLevel serverLevel, CallbackInfoReturnable<BlockPos> cir) {
         BlockPos structureOrigin = cir.getReturnValue();


### PR DESCRIPTION
## Summary
- add a schem entity backfill helper so Starter Structure keeps Create contraptions intact
- hook into starter structure generation to repopulate missing entities before terrain replacement runs

## Testing
- ./gradlew -x test compileJava

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69472d67f8b88328a123cae6799bb690)