### PR TITLE
Fix StarterStructure mixin local capture order

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
@@ -33,8 +33,8 @@ public class StarterStructureUtilMixin {
                                                                   File schematicFile,
                                                                   boolean automaticCenter,
                                                                   BlockPos structurePos,
-                                                                  FileInputStream fileInputStream,
-                                                                  ParsedSchematicObject parsedSchematicObject) {
+                                                                  ParsedSchematicObject parsedSchematicObject,
+                                                                  FileInputStream fileInputStream) {
         Path schematicPath = schematicFile.toPath();
         SchematicEntityRestorer.backfillEntitiesFromSchem(serverLevel, schematicPath, schematicFile.getName().endsWith(".nbt"),
                 structurePos, parsedSchematicObject);


### PR DESCRIPTION
## Summary
- reorder captured local variables in StarterStructureUtilMixin to match the new variable layout
- prevent mixin injection failure during Starter Structure mod loading

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69473d7b9bf48328a57fb8a8398d2eb7)