### PR TITLE
Fix starter structure entity restoration and terrain adapter gating

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/SchematicEntityRestorer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/SchematicEntityRestorer.java
@@ -30,7 +30,10 @@ public final class SchematicEntityRestorer {
 
     public static void backfillEntitiesFromSchem(ServerLevel level, Path schematicPath, boolean isNbtFormat,
                                                  BlockPos structurePos, ParsedSchematicObject parsed) {
-        if (parsed == null || parsed.entities == null || !parsed.entities.isEmpty()) {
+        if (parsed == null) {
+            return;
+        }
+        if (parsed.entities != null && !parsed.entities.isEmpty()) {
             return;
         }
         if (isNbtFormat || schematicPath == null) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureTerrainAdapter.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureTerrainAdapter.java
@@ -24,9 +24,6 @@ public final class StarterStructureTerrainAdapter {
      * Schedule post-processing for the starter structure to replace marker blocks with sampled terrain.
      */
     public static void scheduleTerrainReplacement(ServerLevel level, BlockPos structureOrigin) {
-        if (!StructureConfig.ENABLE_TERRAIN_REPLACER.get()) {
-            return;
-        }
         if (!StructureConfig.ENABLE_STARTER_STRUCTURE_TERRAIN_REPLACER.get()) {
             return;
         }


### PR DESCRIPTION
## Summary
- allow schematic entity restoration even when the parsed object did not pre-populate the entity list
- let the starter structure terrain replacer run when its feature is enabled regardless of the global terrain replacer toggle

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69482e4c985c8328950d48573355df68)