### PR TITLE
Compact custom NBT payloads and prune mod tracking history

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ModListTracker/ModTracker.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ModListTracker/ModTracker.java
@@ -7,6 +7,7 @@ import net.neoforged.fml.loading.moddiscovery.ModInfo;
 import com.google.gson.Gson;
 import java.io.*;
 import java.nio.file.*;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -18,6 +19,10 @@ import java.util.stream.Collectors;
 public class ModTracker {
     private static final Path TRACKING_FILE = Paths.get("config", "mods-tracking.json");
     private static final Path LOG_FILE = Paths.get("logs", "mod-changes.log");
+
+    private static final int MAX_HISTORY_VERSIONS = 32;
+    private static final long HISTORY_RETENTION_DAYS = 90;
+    private static final long MAX_LOG_FILE_BYTES = 512 * 1024; // 512KB
 
     private static final List<String> addedMods = new ArrayList<>();
     private static final List<String> removedMods = new ArrayList<>();
@@ -70,6 +75,8 @@ public class ModTracker {
         if (history == null) {
             history = new ModTrackingHistory();
         }
+        history.versionTimestamps.put(com.thunder.wildernessodysseyapi.Core.ModConstants.VERSION, System.currentTimeMillis());
+        pruneHistory(history);
         history.lastVersion = com.thunder.wildernessodysseyapi.Core.ModConstants.VERSION;
         history.versions.put(com.thunder.wildernessodysseyapi.Core.ModConstants.VERSION, currentMods);
         saveHistory(history);
@@ -111,7 +118,11 @@ public class ModTracker {
         }
         try (Reader reader = Files.newBufferedReader(TRACKING_FILE)) {
             LOGGER.debug("Loading mod tracking history from {}", TRACKING_FILE);
-            return new Gson().fromJson(reader, ModTrackingHistory.class);
+            ModTrackingHistory history = new Gson().fromJson(reader, ModTrackingHistory.class);
+            if (history != null && history.versionTimestamps == null) {
+                history.versionTimestamps = new HashMap<>();
+            }
+            return history;
         } catch (IOException e) {
             LOGGER.error("Failed to load mod tracking history", e);
             return null;
@@ -124,6 +135,39 @@ public class ModTracker {
             new Gson().toJson(history, writer);
         } catch (IOException e) {
             LOGGER.error("Failed to save mod tracking history", e);
+        }
+    }
+
+    private static void pruneHistory(ModTrackingHistory history) {
+        if (history == null || history.versions == null) {
+            return;
+        }
+        history.versionTimestamps = history.versionTimestamps == null ? new HashMap<>() : history.versionTimestamps;
+        long cutoff = System.currentTimeMillis() - Duration.ofDays(HISTORY_RETENTION_DAYS).toMillis();
+        List<String> sorted = history.versionTimestamps.entrySet().stream()
+                .sorted(java.util.Map.Entry.<String, Long>comparingByValue(java.util.Comparator.nullsLast(Long::compare)).reversed())
+                .map(java.util.Map.Entry::getKey)
+                .toList();
+
+        Set<String> toRetain = new java.util.LinkedHashSet<>();
+        for (String version : sorted) {
+            Long timestamp = history.versionTimestamps.get(version);
+            if (timestamp != null && timestamp < cutoff) {
+                continue;
+            }
+            toRetain.add(version);
+            if (toRetain.size() >= MAX_HISTORY_VERSIONS) {
+                break;
+            }
+        }
+        if (toRetain.isEmpty() && !sorted.isEmpty()) {
+            toRetain.add(sorted.get(0));
+        }
+
+        history.versions.keySet().removeIf(version -> !toRetain.contains(version));
+        history.versionTimestamps.keySet().removeIf(version -> !toRetain.contains(version));
+        if (history.lastVersion != null && !toRetain.contains(history.lastVersion)) {
+            history.lastVersion = toRetain.isEmpty() ? null : toRetain.iterator().next();
         }
     }
 
@@ -156,13 +200,41 @@ public class ModTracker {
             Files.createDirectories(LOG_FILE.getParent());
             LOGGER.debug("Writing mod change log to {}", LOG_FILE);
             Files.write(LOG_FILE, logMessage.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+            pruneLogFile();
         } catch (IOException e) {
             LOGGER.error("Failed to write mod change log", e);
+        }
+    }
+
+    private static void pruneLogFile() {
+        try {
+            if (!Files.exists(LOG_FILE)) {
+                return;
+            }
+            long size = Files.size(LOG_FILE);
+            if (size <= MAX_LOG_FILE_BYTES) {
+                return;
+            }
+            java.util.List<String> lines = Files.readAllLines(LOG_FILE);
+            int keepFrom = lines.size();
+            int running = 0;
+            for (int i = lines.size() - 1; i >= 0; i--) {
+                running += lines.get(i).getBytes().length + System.lineSeparator().getBytes().length;
+                if (running > MAX_LOG_FILE_BYTES) {
+                    break;
+                }
+                keepFrom = i;
+            }
+            Files.write(LOG_FILE, lines.subList(keepFrom, lines.size()));
+            LOGGER.debug("Pruned mod change log to {} entries ({} bytes).", lines.size() - keepFrom, MAX_LOG_FILE_BYTES);
+        } catch (IOException e) {
+            LOGGER.debug("Failed to prune mod change log", e);
         }
     }
 
     private static class ModTrackingHistory {
         String lastVersion;
         Map<String, Map<String, String>> versions = new HashMap<>();
+        Map<String, Long> versionTimestamps = new HashMap<>();
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/chunk/DiskChunkStorageAdapter.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/chunk/DiskChunkStorageAdapter.java
@@ -1,6 +1,7 @@
 package com.thunder.wildernessodysseyapi.chunk;
 
 import com.thunder.wildernessodysseyapi.util.NbtCompressionUtils;
+import com.thunder.wildernessodysseyapi.util.NbtDataCompactor;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.ChunkPos;
 
@@ -27,13 +28,17 @@ public class DiskChunkStorageAdapter implements ChunkStorageAdapter {
         if (!Files.exists(path)) {
             return Optional.empty();
         }
-        return Optional.of(NbtCompressionUtils.readCompressed(path));
+        CompoundTag payload = NbtCompressionUtils.readCompressed(path);
+        NbtDataCompactor.expandModPayload(payload);
+        return Optional.of(payload);
     }
 
     @Override
     public void write(ChunkPos pos, CompoundTag tag) throws IOException {
         Path path = chunkPath(pos);
-        NbtCompressionUtils.writeCompressed(path, tag, compressionLevel);
+        CompoundTag compacted = tag.copy();
+        NbtDataCompactor.compactModPayload(compacted);
+        NbtCompressionUtils.writeCompressed(path, compacted, compressionLevel);
     }
 
     private Path chunkPath(ChunkPos pos) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/util/NbtDataCompactor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/util/NbtDataCompactor.java
@@ -1,0 +1,426 @@
+package com.thunder.wildernessodysseyapi.util;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.nbt.ByteArrayTag;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.IntArrayTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.ResourceLocation;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterInputStream;
+
+/**
+ * Compacts mod-owned NBT payloads before they are written to disk and restores them
+ * after reads. This keeps the on-disk format small without changing how callers
+ * interact with the in-memory data.
+ */
+public final class NbtDataCompactor {
+
+    private static final String MOD_DATA_KEY = ModConstants.MOD_ID;
+    private static final String RESOURCE_TABLE_KEY = "_wo_rl_table";
+    private static final String RESOURCE_REF_KEY = "_wo_rl_ref";
+    private static final String FLATTENED_KEY = "_wo_flattened";
+    private static final String FLATTENED_PATH_KEY = "path";
+    private static final String FLATTENED_COMPRESSION_KEY = "compression";
+    private static final String FLATTENED_PAYLOAD_KEY = "payload";
+    private static final String COMPRESSION_DEFLATE = "deflate";
+    private static final String BLOB_WRAPPER_TYPE = "_wo_compression";
+    private static final String BLOB_DATA_KEY = "_wo_data";
+    private static final String BLOB_ORIGINAL_SIZE_KEY = "_wo_size";
+    private static final String BLOB_ORIGINAL_TYPE_KEY = "_wo_type";
+
+    private static final int RESOURCE_LENGTH_THRESHOLD = 64;
+    private static final int MAX_HISTORY_ENTRIES = 64;
+    private static final long HISTORY_RETENTION_MS = TimeUnit.DAYS.toMillis(45);
+    private static final int MAX_FLATTEN_DEPTH = 6;
+    private static final int BLOB_COMPRESSION_THRESHOLD = 2048;
+
+    private static final DateTimeFormatter LOG_TIMESTAMP = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private NbtDataCompactor() {
+    }
+
+    /**
+     * Applies size-saving transforms to mod-owned payloads prior to writing them to disk.
+     */
+    public static void compactModPayload(CompoundTag root) {
+        if (root == null || !root.contains(MOD_DATA_KEY, Tag.TAG_COMPOUND)) {
+            return;
+        }
+        CompoundTag modData = root.getCompound(MOD_DATA_KEY);
+
+        pruneHistories(modData);
+
+        List<String> rlTable = new ArrayList<>();
+        encodeResourceLocations(modData, rlTable);
+        if (!rlTable.isEmpty()) {
+            ListTag tableTag = new ListTag();
+            rlTable.forEach(id -> tableTag.add(StringTag.valueOf(id)));
+            modData.put(RESOURCE_TABLE_KEY, tableTag);
+        }
+
+        ListTag flattened = new ListTag();
+        flatten(modData, "", 0, flattened);
+        if (!flattened.isEmpty()) {
+            modData.put(FLATTENED_KEY, flattened);
+        }
+
+        compressLargeBlobs(modData);
+        root.put(MOD_DATA_KEY, modData);
+    }
+
+    /**
+     * Restores any compacted data back to its expanded form after reading from disk.
+     */
+    public static void expandModPayload(CompoundTag root) {
+        if (root == null || !root.contains(MOD_DATA_KEY, Tag.TAG_COMPOUND)) {
+            return;
+        }
+        CompoundTag modData = root.getCompound(MOD_DATA_KEY);
+
+        decodeFlattened(modData);
+        decompressBlobs(modData);
+        decodeResourceLocations(modData);
+
+        root.put(MOD_DATA_KEY, modData);
+    }
+
+    private static void pruneHistories(CompoundTag tag) {
+        for (String key : new HashSet<>(tag.getAllKeys())) {
+            Tag child = tag.get(key);
+            if (child instanceof CompoundTag compound) {
+                pruneHistories(compound);
+            } else if (child instanceof ListTag list
+                    && list.getElementType() == Tag.TAG_STRING
+                    && isHistoryKey(key)) {
+                List<String> trimmed = filterHistory(list);
+                ListTag replacement = new ListTag();
+                trimmed.forEach(entry -> replacement.add(StringTag.valueOf(entry)));
+                tag.put(key, replacement);
+            }
+        }
+    }
+
+    private static boolean isHistoryKey(String key) {
+        String lower = key.toLowerCase(Locale.ROOT);
+        return lower.contains("history") || lower.contains("log");
+    }
+
+    private static List<String> filterHistory(ListTag list) {
+        List<String> entries = new ArrayList<>();
+        long cutoff = System.currentTimeMillis() - HISTORY_RETENTION_MS;
+        for (Tag element : list) {
+            String value = element.getAsString();
+            long timestamp = extractTimestamp(value);
+            if (timestamp > 0 && timestamp < cutoff) {
+                continue;
+            }
+            entries.add(value);
+        }
+        int start = Math.max(0, entries.size() - MAX_HISTORY_ENTRIES);
+        return entries.subList(start, entries.size());
+    }
+
+    private static long extractTimestamp(String value) {
+        try {
+            if (value.length() >= 19 && Character.isDigit(value.charAt(0))) {
+                LocalDateTime parsed = LocalDateTime.parse(value.substring(0, 19), LOG_TIMESTAMP);
+                return parsed.toInstant(ZoneOffset.UTC).toEpochMilli();
+            }
+        } catch (Exception ignored) {
+        }
+        return -1;
+    }
+
+    private static void encodeResourceLocations(CompoundTag tag, List<String> rlTable) {
+        for (String key : new HashSet<>(tag.getAllKeys())) {
+            Tag child = tag.get(key);
+            if (child instanceof CompoundTag compound) {
+                encodeResourceLocations(compound, rlTable);
+            } else if (child instanceof ListTag list && list.getElementType() == Tag.TAG_COMPOUND) {
+                for (Tag element : list) {
+                    if (element instanceof CompoundTag compoundElement) {
+                        encodeResourceLocations(compoundElement, rlTable);
+                    }
+                }
+            } else if (child instanceof StringTag stringTag) {
+                String value = stringTag.getAsString();
+                if (value.length() < RESOURCE_LENGTH_THRESHOLD) {
+                    continue;
+                }
+                ResourceLocation rl = ResourceLocation.tryParse(value);
+                if (rl == null) {
+                    continue;
+                }
+                int idx = rlTable.indexOf(rl.toString());
+                if (idx == -1) {
+                    rlTable.add(rl.toString());
+                    idx = rlTable.size() - 1;
+                }
+                CompoundTag ref = new CompoundTag();
+                ref.putInt(RESOURCE_REF_KEY, idx);
+                tag.put(key, ref);
+            }
+        }
+    }
+
+    private static void decodeResourceLocations(CompoundTag tag) {
+        if (!tag.contains(RESOURCE_TABLE_KEY, Tag.TAG_LIST)) {
+            return;
+        }
+        ListTag tableTag = tag.getList(RESOURCE_TABLE_KEY, Tag.TAG_STRING);
+        List<String> table = new ArrayList<>(tableTag.size());
+        tableTag.forEach(entry -> table.add(entry.getAsString()));
+
+        decodeResourceLocationsRecursive(tag, table);
+        tag.remove(RESOURCE_TABLE_KEY);
+    }
+
+    private static void decodeResourceLocationsRecursive(CompoundTag tag, List<String> table) {
+        for (String key : new HashSet<>(tag.getAllKeys())) {
+            Tag child = tag.get(key);
+            if (child instanceof CompoundTag compound) {
+                if (compound.contains(RESOURCE_REF_KEY, Tag.TAG_INT)) {
+                    int idx = compound.getInt(RESOURCE_REF_KEY);
+                    if (idx >= 0 && idx < table.size()) {
+                        tag.putString(key, table.get(idx));
+                    } else {
+                        tag.remove(key);
+                    }
+                    continue;
+                }
+                decodeResourceLocationsRecursive(compound, table);
+            } else if (child instanceof ListTag list && list.getElementType() == Tag.TAG_COMPOUND) {
+                for (Tag element : list) {
+                    if (element instanceof CompoundTag compoundElement) {
+                        decodeResourceLocationsRecursive(compoundElement, table);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void flatten(CompoundTag tag, String path, int depth, ListTag sink) {
+        for (String key : new HashSet<>(tag.getAllKeys())) {
+            Tag child = tag.get(key);
+            if (!(child instanceof CompoundTag compound)) {
+                continue;
+            }
+            String childPath = path.isEmpty() ? key : path + "." + key;
+            if (depth >= MAX_FLATTEN_DEPTH) {
+                byte[] payload = serializeCompound(compound);
+                if (payload.length == 0) {
+                    continue;
+                }
+                CompoundTag flattened = new CompoundTag();
+                flattened.putString(FLATTENED_PATH_KEY, childPath);
+                flattened.putString(FLATTENED_COMPRESSION_KEY, COMPRESSION_DEFLATE);
+                flattened.putByteArray(FLATTENED_PAYLOAD_KEY, payload);
+                sink.add(flattened);
+                tag.remove(key);
+            } else {
+                flatten(compound, childPath, depth + 1, sink);
+            }
+        }
+    }
+
+    private static void decodeFlattened(CompoundTag tag) {
+        if (!tag.contains(FLATTENED_KEY, Tag.TAG_LIST)) {
+            return;
+        }
+        ListTag flattened = tag.getList(FLATTENED_KEY, Tag.TAG_COMPOUND);
+        for (Tag element : flattened) {
+            if (!(element instanceof CompoundTag entry)) {
+                continue;
+            }
+            String path = entry.getString(FLATTENED_PATH_KEY);
+            byte[] payload = entry.getByteArray(FLATTENED_PAYLOAD_KEY);
+            String compression = entry.getString(FLATTENED_COMPRESSION_KEY);
+            try {
+                CompoundTag restored = deserializeCompound(payload, compression);
+                if (restored != null) {
+                    insertAtPath(tag, path, restored);
+                }
+            } catch (IOException e) {
+                ModConstants.LOGGER.debug("Failed to restore flattened tag {}.", path, e);
+            }
+        }
+        tag.remove(FLATTENED_KEY);
+    }
+
+    private static void insertAtPath(CompoundTag root, String path, CompoundTag payload) {
+        String[] parts = path.split("\\.");
+        CompoundTag current = root;
+        for (int i = 0; i < parts.length - 1; i++) {
+            String segment = parts[i];
+            CompoundTag next = current.contains(segment, Tag.TAG_COMPOUND)
+                    ? current.getCompound(segment)
+                    : new CompoundTag();
+            current.put(segment, next);
+            current = next;
+        }
+        current.put(parts[parts.length - 1], payload);
+    }
+
+    private static byte[] serializeCompound(CompoundTag compound) {
+        try (ByteArrayOutputStream raw = new ByteArrayOutputStream();
+             DeflaterOutputStream deflater = new DeflaterOutputStream(raw);
+             DataOutputStream data = new DataOutputStream(deflater)) {
+            NbtIo.write(compound, data);
+            deflater.finish();
+            return raw.toByteArray();
+        } catch (IOException e) {
+            ModConstants.LOGGER.debug("Failed to serialize nested compound for compaction.", e);
+            return new byte[0];
+        }
+    }
+
+    private static CompoundTag deserializeCompound(byte[] payload, String compression) throws IOException {
+        try (ByteArrayInputStream raw = new ByteArrayInputStream(payload);
+             InputStreamWrapper wrapper = new InputStreamWrapper(raw, compression);
+             DataInputStream data = new DataInputStream(wrapper.stream())) {
+            return NbtIo.read(data);
+        }
+    }
+
+    private static void compressLargeBlobs(CompoundTag tag) {
+        for (String key : new HashSet<>(tag.getAllKeys())) {
+            Tag child = tag.get(key);
+            if (child instanceof CompoundTag compound) {
+                compressLargeBlobs(compound);
+            } else if (child instanceof ByteArrayTag bytes && bytes.size() >= BLOB_COMPRESSION_THRESHOLD) {
+                tag.put(key, wrapCompressed(bytes.getAsByteArray(), Tag.TAG_BYTE_ARRAY));
+            } else if (child instanceof IntArrayTag ints && ints.getAsIntArray().length * Integer.BYTES >= BLOB_COMPRESSION_THRESHOLD) {
+                tag.put(key, wrapCompressed(toByteArray(ints.getAsIntArray()), Tag.TAG_INT_ARRAY));
+            }
+        }
+    }
+
+    private static void decompressBlobs(CompoundTag tag) {
+        for (String key : new HashSet<>(tag.getAllKeys())) {
+            Tag child = tag.get(key);
+            if (child instanceof CompoundTag compound) {
+                if (isCompressedBlob(compound)) {
+                    Tag restored = unwrapCompressed(compound);
+                    if (restored != null) {
+                        tag.put(key, restored);
+                        continue;
+                    }
+                }
+                decompressBlobs(compound);
+            }
+        }
+    }
+
+    private static boolean isCompressedBlob(CompoundTag tag) {
+        return tag.contains(BLOB_WRAPPER_TYPE, Tag.TAG_STRING) && tag.contains(BLOB_DATA_KEY, Tag.TAG_BYTE_ARRAY);
+    }
+
+    private static CompoundTag wrapCompressed(byte[] data, byte originalType) {
+        CompoundTag wrapper = new CompoundTag();
+        wrapper.putString(BLOB_WRAPPER_TYPE, COMPRESSION_DEFLATE);
+        wrapper.putInt(BLOB_ORIGINAL_SIZE_KEY, data.length);
+        wrapper.putByte(BLOB_ORIGINAL_TYPE_KEY, originalType);
+        wrapper.putByteArray(BLOB_DATA_KEY, compressBytes(data));
+        return wrapper;
+    }
+
+    private static Tag unwrapCompressed(CompoundTag wrapper) {
+        String compression = wrapper.getString(BLOB_WRAPPER_TYPE);
+        byte[] compressed = wrapper.getByteArray(BLOB_DATA_KEY);
+        byte originalType = wrapper.getByte(BLOB_ORIGINAL_TYPE_KEY);
+        try {
+            byte[] restored = decompressBytes(compressed, compression);
+            return switch (originalType) {
+                case Tag.TAG_BYTE_ARRAY -> new ByteArrayTag(restored);
+                case Tag.TAG_INT_ARRAY -> new IntArrayTag(toIntArray(restored));
+                default -> null;
+            };
+        } catch (IOException e) {
+            ModConstants.LOGGER.debug("Failed to decompress custom blob.", e);
+            return null;
+        }
+    }
+
+    private static byte[] compressBytes(byte[] data) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+             DeflaterOutputStream deflater = new DeflaterOutputStream(out)) {
+            deflater.write(data);
+            deflater.finish();
+            return out.toByteArray();
+        } catch (IOException e) {
+            ModConstants.LOGGER.debug("Failed to compress blob.", e);
+            return data;
+        }
+    }
+
+    private static byte[] decompressBytes(byte[] data, String compression) throws IOException {
+        ByteArrayInputStream raw = new ByteArrayInputStream(data);
+        try (InputStreamWrapper wrapper = new InputStreamWrapper(raw, compression);
+             DataInputStream in = new DataInputStream(wrapper.stream())) {
+            return in.readAllBytes();
+        }
+    }
+
+    private static byte[] toByteArray(int[] ints) {
+        ByteBuffer buffer = ByteBuffer.allocate(ints.length * Integer.BYTES).order(ByteOrder.BIG_ENDIAN);
+        for (int value : ints) {
+            buffer.putInt(value);
+        }
+        return buffer.array();
+    }
+
+    private static int[] toIntArray(byte[] data) {
+        ByteBuffer buffer = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN);
+        int[] ints = new int[buffer.remaining() / Integer.BYTES];
+        for (int i = 0; i < ints.length; i++) {
+            ints[i] = buffer.getInt();
+        }
+        return ints;
+    }
+
+    /**
+     * Simple wrapper to defer inflater allocation until needed and still participate in
+     * try-with-resources cleanup.
+     */
+    private static final class InputStreamWrapper implements AutoCloseable {
+        private final ByteArrayInputStream raw;
+        private final InflaterInputStream inflater;
+
+        private InputStreamWrapper(ByteArrayInputStream raw, String compression) {
+            this.raw = raw;
+            this.inflater = COMPRESSION_DEFLATE.equals(compression) ? new InflaterInputStream(raw) : null;
+        }
+
+        public java.io.InputStream stream() {
+            return inflater != null ? inflater : raw;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (inflater != null) {
+                inflater.close();
+            }
+            raw.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an NBT compactor that encodes long resource identifiers, flattens deep custom data, compresses large blobs, and trims oversized histories before writing payloads
- run the compactor during chunk storage reads/writes so compacted on-disk data is transparently expanded in memory
- cap mod tracking history and log files by age and size using recorded timestamps to prevent unbounded growth

## Testing
- ./gradlew test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949de2332ac83289a3c0f2f23c6912c)