### PR TITLE
Add chunk capability for per-chunk mod state

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -9,6 +9,7 @@ import com.thunder.wildernessodysseyapi.ModPackPatches.cache.ModDataCacheCommand
 import com.thunder.wildernessodysseyapi.ModPackPatches.cache.ModDataCacheConfig;
 import com.thunder.wildernessodysseyapi.MemUtils.MemCheckCommand;
 import com.thunder.wildernessodysseyapi.MemUtils.MemoryUtils;
+import com.thunder.wildernessodysseyapi.capabilities.ChunkDataCapability;
 import com.thunder.wildernessodysseyapi.ModPackPatches.ModListTracker.commands.ModListDiffCommand;
 import com.thunder.wildernessodysseyapi.ModPackPatches.ModListTracker.commands.ModListVersionCommand;
 import com.thunder.wildernessodysseyapi.command.GlobalChatCommand;
@@ -71,6 +72,7 @@ import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
@@ -131,6 +133,7 @@ public class WildernessOdysseyAPIMainModClass {
         modEventBus.addListener(this::commonSetup);
         modEventBus.addListener(this::onConfigLoaded);
         modEventBus.addListener(this::onConfigReloaded);
+        modEventBus.addListener(this::registerCapabilities);
         ModProcessors.PROCESSORS.register(modEventBus);
         ModCreativeTabs.register(modEventBus);
 
@@ -174,6 +177,10 @@ public class WildernessOdysseyAPIMainModClass {
         LOGGER.warn("Mod Pack Version: {}", VERSION); // Logs as a warning
         LOGGER.warn("This message is for development purposes only."); // Logs as info
         dynamicModCount = ModList.get().getMods().size();
+    }
+
+    private void registerCapabilities(RegisterCapabilitiesEvent event) {
+        event.register(ChunkDataCapability.class);
     }
   
     private void addCreative(BuildCreativeModeTabContentsEvent event) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/capabilities/ChunkCapabilityHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/capabilities/ChunkCapabilityHandler.java
@@ -1,0 +1,52 @@
+package com.thunder.wildernessodysseyapi.capabilities;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.AttachCapabilitiesEvent;
+import net.neoforged.neoforge.event.level.ChunkEvent;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
+
+/**
+ * Hooks chunk events to manage the chunk capability lifecycle.
+ */
+@EventBusSubscriber(modid = MOD_ID)
+public final class ChunkCapabilityHandler {
+
+    private ChunkCapabilityHandler() {
+    }
+
+    @SubscribeEvent
+    public static void attachCapabilities(AttachCapabilitiesEvent<LevelChunk> event) {
+        LevelChunk chunk = event.getObject();
+        ChunkDataCapabilityProvider provider = new ChunkDataCapabilityProvider(chunk);
+        event.addCapability(ChunkDataCapabilityProvider.IDENTIFIER, provider);
+        event.addListener(provider::invalidate);
+    }
+
+    @SubscribeEvent
+    public static void onChunkLoad(ChunkEvent.Load event) {
+        if (!(event.getLevel() instanceof ServerLevel)) return;
+        if (!(event.getChunk() instanceof LevelChunk chunk)) return;
+
+        chunk.getCapability(ChunkDataCapabilityProvider.CHUNK_DATA_CAPABILITY).ifPresent(data -> {
+            // Clear dirty on load to avoid unnecessary saves after hydration.
+            data.clearDirty();
+        });
+    }
+
+    @SubscribeEvent
+    public static void onChunkSave(ChunkEvent.Save event) {
+        if (!(event.getChunk() instanceof LevelChunk chunk)) return;
+
+        chunk.getCapability(ChunkDataCapabilityProvider.CHUNK_DATA_CAPABILITY).ifPresent(data -> {
+            if (!data.isDirty()) {
+                return;
+            }
+            // Reset the flag post-save so we only write when necessary.
+            data.clearDirty();
+        });
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/capabilities/ChunkDataCapability.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/capabilities/ChunkDataCapability.java
@@ -1,0 +1,78 @@
+package com.thunder.wildernessodysseyapi.capabilities;
+
+import net.minecraft.nbt.CompoundTag;
+import net.neoforged.neoforge.common.util.INBTSerializable;
+
+/**
+ * Simple per-chunk data container for Wilderness Odyssey state.
+ * Uses primitive fields to keep storage shallow and efficient.
+ */
+public class ChunkDataCapability implements INBTSerializable<CompoundTag> {
+
+    private static final String VISITS_TAG = "Visits";
+    private static final String FLAGS_TAG = "Flags";
+
+    private int visitCount;
+    private short stateFlags;
+    private boolean dirty;
+    private Runnable dirtyListener = () -> {};
+
+    public void setDirtyListener(Runnable dirtyListener) {
+        this.dirtyListener = dirtyListener == null ? () -> {} : dirtyListener;
+    }
+
+    private void markDirty() {
+        dirty = true;
+        dirtyListener.run();
+    }
+
+    public int getVisitCount() {
+        return visitCount;
+    }
+
+    public void setVisitCount(int visitCount) {
+        if (this.visitCount != visitCount) {
+            this.visitCount = visitCount;
+            markDirty();
+        }
+    }
+
+    public void incrementVisits() {
+        visitCount++;
+        markDirty();
+    }
+
+    public short getStateFlags() {
+        return stateFlags;
+    }
+
+    public void setStateFlags(short stateFlags) {
+        if (this.stateFlags != stateFlags) {
+            this.stateFlags = stateFlags;
+            markDirty();
+        }
+    }
+
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    public void clearDirty() {
+        dirty = false;
+    }
+
+    @Override
+    public CompoundTag serializeNBT() {
+        CompoundTag tag = new CompoundTag();
+        tag.putInt(VISITS_TAG, visitCount);
+        tag.putShort(FLAGS_TAG, stateFlags);
+        return tag;
+    }
+
+    @Override
+    public void deserializeNBT(CompoundTag nbt) {
+        visitCount = nbt.getInt(VISITS_TAG);
+        stateFlags = nbt.getShort(FLAGS_TAG);
+        dirty = false;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/capabilities/ChunkDataCapabilityProvider.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/capabilities/ChunkDataCapabilityProvider.java
@@ -1,0 +1,50 @@
+package com.thunder.wildernessodysseyapi.capabilities;
+
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.neoforged.neoforge.capabilities.Capability;
+import net.neoforged.neoforge.capabilities.CapabilityManager;
+import net.neoforged.neoforge.capabilities.CapabilityToken;
+import net.neoforged.neoforge.capabilities.ICapabilitySerializable;
+import net.neoforged.neoforge.common.util.LazyOptional;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID;
+
+/**
+ * Provider for the chunk data capability.
+ */
+public class ChunkDataCapabilityProvider implements ICapabilitySerializable<CompoundTag> {
+
+    public static final ResourceLocation IDENTIFIER = new ResourceLocation(MOD_ID, "chunk_data");
+    public static final Capability<ChunkDataCapability> CHUNK_DATA_CAPABILITY = CapabilityManager.get(new CapabilityToken<>() {});
+
+    private final ChunkDataCapability backend = new ChunkDataCapability();
+    private final LazyOptional<ChunkDataCapability> optional = LazyOptional.of(() -> backend);
+
+    public ChunkDataCapabilityProvider(LevelChunk chunk) {
+        backend.setDirtyListener(() -> chunk.setUnsaved(true));
+    }
+
+    public void invalidate() {
+        optional.invalidate();
+    }
+
+    @Override
+    public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
+        return cap == CHUNK_DATA_CAPABILITY ? optional.cast() : LazyOptional.empty();
+    }
+
+    @Override
+    public CompoundTag serializeNBT() {
+        return backend.serializeNBT();
+    }
+
+    @Override
+    public void deserializeNBT(CompoundTag nbt) {
+        backend.deserializeNBT(nbt);
+    }
+}


### PR DESCRIPTION
## Summary
- add a chunk-scoped capability container to store mod state with shallow NBT
- register the capability during mod initialization and attach it to chunks via events
- ensure dirty tracking drives chunk save requests and clears after save to minimize writes

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949de1a84f4832880c70ff1bce4e952)