### PR TITLE
Fix chunk streaming configuration and IO handling

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamingConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamingConfig.java
@@ -124,7 +124,7 @@ public final class ChunkStreamingConfig {
                 IO_THREADS.get(),
                 IO_QUEUE_SIZE.get(),
                 BUFFER_SLICE_BYTES.get(),
-                BUFFER_SLICES_PER_THREAD.get()
+                BUFFER_SLICES_PER_THREAD.get(),
                 SKIP_WARM_CACHE_TICKING.get(),
                 FLUID_REDSTONE_THROTTLE_RADIUS.get(),
                 FLUID_REDSTONE_THROTTLE_INTERVAL.get(),
@@ -132,9 +132,9 @@ public final class ChunkStreamingConfig {
                 RANDOM_TICK_MAX_SCALE.get(),
                 MOVEMENT_SPEED_FOR_MAX_SCALE.get(),
                 RANDOM_TICK_PLAYER_BAND.get(),
-                SLICE_INTERN_LIMIT.get()
+                SLICE_INTERN_LIMIT.get(),
                 DELTA_CHANGE_BUDGET.get(),
-                LIGHT_COMPRESSION_LEVEL.get()
+                LIGHT_COMPRESSION_LEVEL.get(),
                 WRITE_FLUSH_INTERVAL_TICKS.get()
         );
     }
@@ -156,7 +156,7 @@ public final class ChunkStreamingConfig {
             int ioThreads,
             int ioQueueSize,
             int bufferSliceBytes,
-            int bufferSlicesPerThread
+            int bufferSlicesPerThread,
             boolean skipWarmCacheTicking,
             int fluidRedstoneThrottleRadius,
             int fluidRedstoneThrottleInterval,
@@ -164,10 +164,51 @@ public final class ChunkStreamingConfig {
             double randomTickMaxScale,
             double movementSpeedForMaxScale,
             int randomTickPlayerBand,
-            int sliceInternLimit
+            int sliceInternLimit,
             int deltaChangeBudget,
-            int lightCompressionLevel
+            int lightCompressionLevel,
             int writeFlushIntervalTicks
     ) {
+        public ChunkConfigValues(boolean enabled,
+                                 int hotCacheLimit,
+                                 int warmCacheLimit,
+                                 int saveDebounceTicks,
+                                 int playerTicketTtl,
+                                 int entityTicketTtl,
+                                 int redstoneTicketTtl,
+                                 int structureTicketTtl,
+                                 int maxParallelIo,
+                                 int compressionLevel) {
+            this(
+                    enabled,
+                    hotCacheLimit,
+                    warmCacheLimit,
+                    true,
+                    saveDebounceTicks,
+                    playerTicketTtl,
+                    entityTicketTtl,
+                    redstoneTicketTtl,
+                    structureTicketTtl,
+                    maxParallelIo,
+                    compressionLevel,
+                    CompressionCodec.VANILLA_GZIP,
+                    false,
+                    Math.max(2, Runtime.getRuntime().availableProcessors() / 4),
+                    128,
+                    16384,
+                    8,
+                    true,
+                    96,
+                    4,
+                    0.35D,
+                    1.25D,
+                    0.28D,
+                    128,
+                    384,
+                    256,
+                    6,
+                    20
+            );
+        }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/chunk/DiskChunkStorageAdapter.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/chunk/DiskChunkStorageAdapter.java
@@ -31,8 +31,7 @@ public class DiskChunkStorageAdapter implements ChunkStorageAdapter {
         if (!Files.exists(path)) {
             return Optional.empty();
         }
-        return Optional.of(NbtCompressionUtils.readCompressed(path, compressionCodec));
-        CompoundTag payload = NbtCompressionUtils.readCompressed(path);
+        CompoundTag payload = NbtCompressionUtils.readCompressed(path, compressionCodec);
         NbtDataCompactor.expandModPayload(payload);
         return Optional.of(payload);
     }
@@ -40,10 +39,9 @@ public class DiskChunkStorageAdapter implements ChunkStorageAdapter {
     @Override
     public void write(ChunkPos pos, CompoundTag tag) throws IOException {
         Path path = chunkPath(pos);
-        NbtCompressionUtils.writeCompressed(path, tag, compressionLevel, compressionCodec);
         CompoundTag compacted = tag.copy();
         NbtDataCompactor.compactModPayload(compacted);
-        NbtCompressionUtils.writeCompressed(path, compacted, compressionLevel);
+        NbtCompressionUtils.writeCompressed(path, compacted, compressionLevel, compressionCodec);
     }
 
     private Path chunkPath(ChunkPos pos) {


### PR DESCRIPTION
## Summary
- restore chunk streaming config construction and add legacy convenience constructor
- rebuild chunk stream manager to resolve syntax issues, improve caching stats, and align IO controller
- clean up disk chunk storage adapter compression handling

## Testing
- `./gradlew test --no-daemon` *(fails: current codebase lacks NeoForge capability APIs such as AttachCapabilitiesEvent and CapabilityManager; compile stops in capability classes)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a0d7696948328b6d5cc45a6065dd9)