### PR TITLE
Align integration test classpath with main NeoForge deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,8 +116,8 @@ sourceSets {
     integrationTest {
         java.srcDir 'src/integrationTest/java'
         resources.srcDir 'src/integrationTest/resources'
-        compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
-        runtimeClasspath += output + compileClasspath
+        compileClasspath += sourceSets.main.output + sourceSets.main.compileClasspath
+        runtimeClasspath += output + compileClasspath + sourceSets.main.runtimeClasspath
     }
     jmh {
         java.srcDir 'src/jmh/java'
@@ -142,8 +142,8 @@ configurations {
     // Libraries that must be bundled directly into the mod jar so they are available at runtime.
     bundledLibs
 
-    integrationTestImplementation.extendsFrom testImplementation
-    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+    integrationTestImplementation.extendsFrom implementation, testImplementation
+    integrationTestRuntimeOnly.extendsFrom runtimeOnly, testRuntimeOnly
 
     jmhImplementation.extendsFrom implementation
     jmhRuntimeOnly.extendsFrom runtimeOnly


### PR DESCRIPTION
## Summary
- extend integration test configurations from the main implementation/runtime buckets to pick up the NeoForge dev bundle
- align integration test source set classpaths with the main compile/runtime classpaths

## Testing
- ./gradlew integrationTest (fails: ChunkStreamingIntegrationTest > bulkSaveAndLoadStayWithinLatencyBudget())

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694abb8244c883288d1e9e7ffb60c25d)