### PR TITLE
Handle chunk streaming config defaults in tests

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/async/AsyncThreadingConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/async/AsyncThreadingConfig.java
@@ -43,13 +43,31 @@ public final class AsyncThreadingConfig {
     }
 
     public static AsyncConfigValues values() {
+        try {
+            return new AsyncConfigValues(
+                    ENABLED.get(),
+                    MAX_THREADS.get(),
+                    QUEUE_SIZE.get(),
+                    APPLY_PER_TICK.get(),
+                    TASK_TIMEOUT_MS.get(),
+                    DEBUG_LOGGING.get()
+            );
+        } catch (IllegalStateException ex) {
+            return defaultValues();
+        }
+    }
+
+    /**
+     * Returns configuration defaults without requiring the config file to be loaded.
+     */
+    public static AsyncConfigValues defaultValues() {
         return new AsyncConfigValues(
-                ENABLED.get(),
-                MAX_THREADS.get(),
-                QUEUE_SIZE.get(),
-                APPLY_PER_TICK.get(),
-                TASK_TIMEOUT_MS.get(),
-                DEBUG_LOGGING.get()
+                ENABLED.getDefault(),
+                MAX_THREADS.getDefault(),
+                QUEUE_SIZE.getDefault(),
+                APPLY_PER_TICK.getDefault(),
+                TASK_TIMEOUT_MS.getDefault(),
+                DEBUG_LOGGING.getDefault()
         );
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamManager.java
@@ -241,6 +241,9 @@ public final class ChunkStreamManager {
     private static void expireTickets(long gameTime) {
         List<ChunkPos> expired = new ArrayList<>();
         STATE.forEach((pos, entry) -> {
+            if (entry.tickets.isEmpty()) {
+                return;
+            }
             entry.tickets.entrySet().removeIf(ticket -> {
                 boolean isExpired = ticket.getValue().isExpired(gameTime);
                 if (isExpired && ModConstants.LOGGER.isTraceEnabled()) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamingConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamingConfig.java
@@ -107,35 +107,75 @@ public final class ChunkStreamingConfig {
     }
 
     public static ChunkConfigValues values() {
+        try {
+            return new ChunkConfigValues(
+                    ENABLED.get(),
+                    HOT_CACHE_LIMIT.get(),
+                    WARM_CACHE_LIMIT.get(),
+                    SPLIT_WARM_CACHE.get(),
+                    SAVE_DEBOUNCE_TICKS.get(),
+                    PLAYER_TICKET_TTL.get(),
+                    ENTITY_TICKET_TTL.get(),
+                    REDSTONE_TICKET_TTL.get(),
+                    STRUCTURE_TICKET_TTL.get(),
+                    MAX_PARALLEL_IO.get(),
+                    COMPRESSION_LEVEL.get(),
+                    COMPRESSION_CODEC.get(),
+                    PER_DIMENSION_EXECUTORS.get(),
+                    IO_THREADS.get(),
+                    IO_QUEUE_SIZE.get(),
+                    BUFFER_SLICE_BYTES.get(),
+                    BUFFER_SLICES_PER_THREAD.get(),
+                    SKIP_WARM_CACHE_TICKING.get(),
+                    FLUID_REDSTONE_THROTTLE_RADIUS.get(),
+                    FLUID_REDSTONE_THROTTLE_INTERVAL.get(),
+                    RANDOM_TICK_MIN_SCALE.get(),
+                    RANDOM_TICK_MAX_SCALE.get(),
+                    MOVEMENT_SPEED_FOR_MAX_SCALE.get(),
+                    RANDOM_TICK_PLAYER_BAND.get(),
+                    SLICE_INTERN_LIMIT.get(),
+                    DELTA_CHANGE_BUDGET.get(),
+                    LIGHT_COMPRESSION_LEVEL.get(),
+                    WRITE_FLUSH_INTERVAL_TICKS.get()
+            );
+        } catch (IllegalStateException ex) {
+            return defaultValues();
+        }
+    }
+
+    /**
+     * Returns configuration defaults without requiring the config file to be loaded.
+     */
+    public static ChunkConfigValues defaultValues() {
         return new ChunkConfigValues(
-                ENABLED.get(),
-                HOT_CACHE_LIMIT.get(),
-                WARM_CACHE_LIMIT.get(),
-                SPLIT_WARM_CACHE.get(),
-                SAVE_DEBOUNCE_TICKS.get(),
-                PLAYER_TICKET_TTL.get(),
-                ENTITY_TICKET_TTL.get(),
-                REDSTONE_TICKET_TTL.get(),
-                STRUCTURE_TICKET_TTL.get(),
-                MAX_PARALLEL_IO.get(),
-                COMPRESSION_LEVEL.get(),
-                COMPRESSION_CODEC.get(),
-                PER_DIMENSION_EXECUTORS.get(),
-                IO_THREADS.get(),
-                IO_QUEUE_SIZE.get(),
-                BUFFER_SLICE_BYTES.get(),
-                BUFFER_SLICES_PER_THREAD.get(),
-                SKIP_WARM_CACHE_TICKING.get(),
-                FLUID_REDSTONE_THROTTLE_RADIUS.get(),
-                FLUID_REDSTONE_THROTTLE_INTERVAL.get(),
-                RANDOM_TICK_MIN_SCALE.get(),
-                RANDOM_TICK_MAX_SCALE.get(),
-                MOVEMENT_SPEED_FOR_MAX_SCALE.get(),
-                RANDOM_TICK_PLAYER_BAND.get(),
-                SLICE_INTERN_LIMIT.get(),
-                DELTA_CHANGE_BUDGET.get(),
-                LIGHT_COMPRESSION_LEVEL.get(),
-                WRITE_FLUSH_INTERVAL_TICKS.get()
+                ENABLED.getDefault(),
+                HOT_CACHE_LIMIT.getDefault(),
+                WARM_CACHE_LIMIT.getDefault(),
+                SPLIT_WARM_CACHE.getDefault(),
+                SAVE_DEBOUNCE_TICKS.getDefault(),
+                PLAYER_TICKET_TTL.getDefault(),
+                ENTITY_TICKET_TTL.getDefault(),
+                REDSTONE_TICKET_TTL.getDefault(),
+                STRUCTURE_TICKET_TTL.getDefault(),
+                MAX_PARALLEL_IO.getDefault(),
+                COMPRESSION_LEVEL.getDefault(),
+                COMPRESSION_CODEC.getDefault(),
+                PER_DIMENSION_EXECUTORS.getDefault(),
+                IO_THREADS.getDefault(),
+                IO_QUEUE_SIZE.getDefault(),
+                BUFFER_SLICE_BYTES.getDefault(),
+                BUFFER_SLICES_PER_THREAD.getDefault(),
+                SKIP_WARM_CACHE_TICKING.getDefault(),
+                FLUID_REDSTONE_THROTTLE_RADIUS.getDefault(),
+                FLUID_REDSTONE_THROTTLE_INTERVAL.getDefault(),
+                RANDOM_TICK_MIN_SCALE.getDefault(),
+                RANDOM_TICK_MAX_SCALE.getDefault(),
+                MOVEMENT_SPEED_FOR_MAX_SCALE.getDefault(),
+                RANDOM_TICK_PLAYER_BAND.getDefault(),
+                SLICE_INTERN_LIMIT.getDefault(),
+                DELTA_CHANGE_BUDGET.getDefault(),
+                LIGHT_COMPRESSION_LEVEL.getDefault(),
+                WRITE_FLUSH_INTERVAL_TICKS.getDefault()
         );
     }
 


### PR DESCRIPTION
## Summary
- allow async threading config values to fall back to defaults when configs are not loaded
- add default accessors for chunk streaming config values and fall back when configs are unavailable
- avoid expiring unticketed chunks so pending saves can flush before integration loads

## Testing
- ./gradlew integrationTest --tests "com.thunder.wildernessodysseyapi.chunk.ChunkStreamingIntegrationTest.bulkSaveAndLoadStayWithinLatencyBudget"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac10184588328983d7cf9c002f329)