### PR TITLE
Add emissive layer support to cryo tubes

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Client/CryoTubeRenderSetup.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Client/CryoTubeRenderSetup.java
@@ -28,9 +28,15 @@ public class CryoTubeRenderSetup {
      */
     @SubscribeEvent
     public static void onClientSetup(FMLClientSetupEvent event) {
+        // Allow both cutout and translucent layers. The base tube renders on
+        // cutout to avoid z-fighting when tubes touch, while the emissive
+        // overlay (texture slot #1 in the model) uses the translucent sheet so
+        // it can glow without being affected by lightmaps.
         event.enqueueWork(() ->
-                ItemBlockRenderTypes.setRenderLayer(CryoTubeBlock.CRYO_TUBE.get(), RenderType.translucent())
+                ItemBlockRenderTypes.setRenderLayer(
+                        CryoTubeBlock.CRYO_TUBE.get(),
+                        renderType -> renderType == RenderType.cutout() || renderType == RenderType.translucent()
+                )
         );
     }
 }
-


### PR DESCRIPTION
## Summary
- register cryo tubes for both cutout and translucent render layers
- enable emissive overlay rendering while keeping the base model on cutout to avoid z-fighting between adjacent tubes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac796f1c483288933d9d4804f188f)