### PR TITLE
Add c structure tag for impact site

### DIFF
--- a/src/main/resources/data/c/tags/worldgen/structure/impact_site.json
+++ b/src/main/resources/data/c/tags/worldgen/structure/impact_site.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "wildernessodysseyapi:impact_zone"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a c:impact_site worldgen structure tag
- register the impact zone structure in the shared tag for compatibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694adb6bf840832895b21fd96b178444)