### PR TITLE
Fix LevelChunk mixin shadow target

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/LevelChunkMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/LevelChunkMixin.java
@@ -4,6 +4,7 @@ import com.thunder.wildernessodysseyapi.chunk.ChunkTickThrottler;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,18 +14,18 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LevelChunk.class)
 public abstract class LevelChunkMixin {
-    @Shadow
-    public abstract ChunkPos getPos();
+    @Shadow @Final
+    private ChunkPos chunkPos;
 
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
     private void wildernessodysseyapi$skipWarmCached(ServerLevel level, int randomTickSpeed, CallbackInfo ci) {
-        if (ChunkTickThrottler.shouldSkipWarmTicking(getPos())) {
+        if (ChunkTickThrottler.shouldSkipWarmTicking(this.chunkPos)) {
             ci.cancel();
         }
     }
 
     @ModifyVariable(method = "tick", at = @At("HEAD"), argsOnly = true)
     private int wildernessodysseyapi$scaleRandomTicks(int randomTickSpeed, ServerLevel level) {
-        return ChunkTickThrottler.scaleRandomTickDensity(level, getPos(), randomTickSpeed);
+        return ChunkTickThrottler.scaleRandomTickDensity(level, this.chunkPos, randomTickSpeed);
     }
 }


### PR DESCRIPTION
## Summary
- restore build.gradle to the previous mixin compiler setup
- update LevelChunk mixin to shadow the chunk position field instead of a missing getter

## Testing
- ./gradlew compileJava -x test *(cancelled manually to avoid lengthy artifact regeneration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad8f2afd48328a899c9dd2854f3f8)