### PR TITLE
Fix LevelChunk mixin chunk position shadow failure

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/LevelChunkMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/LevelChunkMixin.java
@@ -4,7 +4,6 @@ import com.thunder.wildernessodysseyapi.chunk.ChunkTickThrottler;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -14,18 +13,18 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LevelChunk.class)
 public abstract class LevelChunkMixin {
-    @Shadow @Final
-    private ChunkPos chunkPos;
+    @Shadow
+    public abstract ChunkPos getPos();
 
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
     private void wildernessodysseyapi$skipWarmCached(ServerLevel level, int randomTickSpeed, CallbackInfo ci) {
-        if (ChunkTickThrottler.shouldSkipWarmTicking(this.chunkPos)) {
+        if (ChunkTickThrottler.shouldSkipWarmTicking(this.getPos())) {
             ci.cancel();
         }
     }
 
     @ModifyVariable(method = "tick", at = @At("HEAD"), argsOnly = true)
     private int wildernessodysseyapi$scaleRandomTicks(int randomTickSpeed, ServerLevel level) {
-        return ChunkTickThrottler.scaleRandomTickDensity(level, this.chunkPos, randomTickSpeed);
+        return ChunkTickThrottler.scaleRandomTickDensity(level, this.getPos(), randomTickSpeed);
     }
 }


### PR DESCRIPTION
## Summary
- replace the chunkPos field shadow in LevelChunkMixin with a getPos accessor
- update warm tick skip and random tick scaling to use the accessor, avoiding missing field errors

## Testing
- ./gradlew compileJava

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae1cf9788832889b4cb4cacd61b58)