### PR TITLE
Enhance AI performance advisor with chunk streaming telemetry

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_perf/PerformanceAdvisor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_perf/PerformanceAdvisor.java
@@ -1,5 +1,8 @@
 package com.thunder.wildernessodysseyapi.AI.AI_perf;
 
+import com.thunder.wildernessodysseyapi.chunk.ChunkStreamManager;
+import com.thunder.wildernessodysseyapi.chunk.ChunkStreamStats;
+import com.thunder.wildernessodysseyapi.chunk.ChunkStreamingConfig;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Mob;
@@ -29,6 +32,9 @@ public final class PerformanceAdvisor {
         int maxLoadedChunks = 0;
         int totalLoadedChunks = 0;
 
+        ChunkStreamingConfig.ChunkConfigValues chunkConfig = ChunkStreamingConfig.values();
+        ChunkStreamStats chunkStats = ChunkStreamManager.snapshot();
+
         for (ServerLevel level : server.getAllLevels()) {
             heaviestMobCluster = Math.max(heaviestMobCluster, estimateMobCluster(level));
             int loadedChunks = level.getChunkSource().getLoadedChunksCount();
@@ -55,13 +61,7 @@ public final class PerformanceAdvisor {
                         ? "Behavior load appears nominal near observed players."
                         : "Dense mob clusters increase goal-switching costs (peak: " + heaviestMobCluster + ")."
         ));
-        subsystems.add(new PerformanceAdvisoryRequest.SubsystemLoad(
-                "chunk-processing",
-                "Chunk building or saving queues are backing up while players move.",
-                "Offer batching or prioritization guidance for chunk I/O and lighting.",
-                maxLoadedChunks,
-                "Heaviest dimension chunk load: " + maxLoadedChunks + ", total loaded across server: " + totalLoadedChunks + "."
-        ));
+        subsystems.add(buildChunkStreamingLoad(chunkConfig, chunkStats, maxLoadedChunks, totalLoadedChunks));
         subsystems.add(new PerformanceAdvisoryRequest.SubsystemLoad(
                 "world-ticking",
                 "Overall world ticking exceeded the frame budget.",
@@ -150,14 +150,128 @@ public final class PerformanceAdvisor {
             case "entity-behavior" -> load.observedValue() >= 48
                     ? "Prefer fallback/idle goals for non-aggressive mobs for the next few seconds to reduce goal churn."
                     : "No behavior adjustments required based on current samples.";
-            case "chunk-processing" -> load.observedValue() >= 800
-                    ? "Batch chunk saves in groups of 4-8 and deprioritize far-player chunks until the queue drains."
-                    : "Chunk load is moderate; keep normal batch sizes.";
+            case "chunk-processing" -> {
+                ChunkStreamingConfig.ChunkConfigValues chunkConfig = ChunkStreamingConfig.values();
+                ChunkTuningSuggestion tuning = recommendTuning(chunkConfig, saturation(load.observedValue(), 1000), ChunkStreamManager.snapshot());
+                if (!chunkConfig.enabled()) {
+                    yield "Chunk streaming is disabled; enable it or temporarily lower simulation distance to ease chunk churn.";
+                }
+                if (load.observedValue() >= 800) {
+                    yield "I/O and caches are saturated: shrink simulation distance briefly, bump maxParallelIo/ioThreads a notch, and lower the writeFlushInterval (currently "
+                            + chunkConfig.writeFlushIntervalTicks() + " ticks; try " + tuning.flushIntervalTicks() + ") until queues drain.";
+                }
+                if (load.observedValue() >= 500) {
+                    yield "Queues are warming up: keep deltaChangeBudget high (e.g., " + tuning.deltaChangeBudget()
+                            + ") and consider shorter flush intervals (" + tuning.flushIntervalTicks()
+                            + ") or extra I/O threads (" + tuning.ioThreads() + ").";
+                }
+                yield "Chunk load is within configured headroom; keep hot/warm caches at "
+                        + chunkConfig.hotCacheLimit() + "/" + chunkConfig.warmCacheLimit() + " and monitor pending saves.";
+            }
             case "world-ticking" -> load.observedValue() > DEFAULT_TICK_BUDGET_MS
                     ? "Apply short-term throttles (simulation distance -1, mob cap easing) until ticks return under budget."
                     : "Tick time within budget; no global throttle needed.";
             default -> "No recommendation available.";
         };
+    }
+
+    private static PerformanceAdvisoryRequest.SubsystemLoad buildChunkStreamingLoad(
+            ChunkStreamingConfig.ChunkConfigValues chunkConfig,
+            ChunkStreamStats chunkStats,
+            int maxLoadedChunks,
+            int totalLoadedChunks) {
+        boolean streamingEnabled = chunkConfig.enabled() && chunkStats.enabled();
+        int ioCapacity = Math.max(1, chunkConfig.ioQueueSize() * Math.max(1, chunkConfig.maxParallelIo()));
+        double hotSaturation = saturation(chunkStats.hotCached(), chunkConfig.hotCacheLimit());
+        double warmSaturation = saturation(chunkStats.warmCached(), chunkConfig.warmCacheLimit());
+        double trackedSaturation = saturation(chunkStats.trackedChunks(), chunkConfig.hotCacheLimit() + chunkConfig.warmCacheLimit());
+        double ioSaturation = saturation(chunkStats.pendingSaves() + chunkStats.inFlightIo(), ioCapacity);
+        double queueSaturation = saturation(chunkStats.ioQueueDepth(), ioCapacity);
+        double pressure = Math.max(Math.max(hotSaturation, warmSaturation), Math.max(trackedSaturation, Math.max(ioSaturation, queueSaturation)));
+        ChunkTuningSuggestion tuning = recommendTuning(chunkConfig, pressure, chunkStats);
+
+        int observed = streamingEnabled
+                ? (int) Math.round(pressure * 1000)
+                : (int) Math.round(saturation(maxLoadedChunks, chunkConfig.hotCacheLimit() + chunkConfig.warmCacheLimit()) * 500);
+
+        String evidence = streamingEnabled
+                ? String.format(
+                "Chunk streaming enabled. Hot cache %d/%d, warm cache %d/%d, tracked %d, queue %d/%d (pending %d, in-flight %d). Flush interval %d ticks, delta budget %d. Warm cache hit rate %.0f%%. Loaded chunks (vanilla): max %d, total %d.",
+                chunkStats.hotCached(),
+                chunkConfig.hotCacheLimit(),
+                chunkStats.warmCached(),
+                chunkConfig.warmCacheLimit(),
+                chunkStats.trackedChunks(),
+                chunkStats.ioQueueDepth(),
+                ioCapacity,
+                chunkStats.pendingSaves(),
+                chunkStats.inFlightIo(),
+                chunkConfig.writeFlushIntervalTicks(),
+                chunkConfig.deltaChangeBudget(),
+                chunkStats.warmCacheHitRate() * 100.0D,
+                tuning.flushIntervalTicks(),
+                tuning.maxParallelIo(),
+                tuning.ioThreads(),
+                tuning.deltaChangeBudget(),
+                maxLoadedChunks,
+                totalLoadedChunks)
+                : String.format(
+                "Chunk streaming disabled; relying on vanilla chunk I/O. Heaviest dimension load: %d, total loaded chunks: %d. Streaming config caches/queue: hot %d, warm %d, queue size %d.",
+                maxLoadedChunks,
+                totalLoadedChunks,
+                chunkConfig.hotCacheLimit(),
+                chunkConfig.warmCacheLimit(),
+                chunkConfig.ioQueueSize());
+
+        String summary = streamingEnabled
+                ? "Chunk streaming queues are approaching configured cache or I/O limits."
+                : "Chunk load is rising without chunk streaming enabled; vanilla I/O may stall.";
+        String mitigationGoal = "Offer batching, prioritization, or config tweaks that honor the chunk streaming settings.";
+
+        return new PerformanceAdvisoryRequest.SubsystemLoad(
+                "chunk-processing",
+                summary,
+                mitigationGoal,
+                observed,
+                evidence
+        );
+    }
+
+    private static double saturation(int used, int capacity) {
+        if (capacity <= 0) {
+            return 0.0D;
+        }
+        return Math.min(2.0D, used / (double) capacity);
+    }
+
+    private static ChunkTuningSuggestion recommendTuning(ChunkStreamingConfig.ChunkConfigValues config,
+                                                         double pressure,
+                                                         ChunkStreamStats stats) {
+        int currentFlush = config.writeFlushIntervalTicks();
+        int recommendedFlush = pressure >= 1.0D ? Math.max(5, currentFlush / 2) : currentFlush;
+        if (pressure >= 0.8D && recommendedFlush == currentFlush) {
+            recommendedFlush = Math.max(5, currentFlush - 5);
+        }
+
+        int recommendedParallelIo = config.maxParallelIo();
+        if (pressure >= 0.9D) {
+            recommendedParallelIo = Math.min(64, Math.max(1, config.maxParallelIo() + 1));
+        }
+
+        int recommendedIoThreads = config.ioThreads();
+        if (pressure >= 0.9D && config.ioThreads() < 32) {
+            recommendedIoThreads = Math.min(32, config.ioThreads() + 1);
+        }
+
+        int recommendedDeltaBudget = config.deltaChangeBudget();
+        if (pressure >= 0.85D && stats.warmCacheHitRate() < 0.6D) {
+            recommendedDeltaBudget = Math.max(config.deltaChangeBudget(), (int) (config.deltaChangeBudget() * 1.25));
+        }
+
+        return new ChunkTuningSuggestion(recommendedFlush, recommendedParallelIo, recommendedIoThreads, recommendedDeltaBudget);
+    }
+
+    private record ChunkTuningSuggestion(int flushIntervalTicks, int maxParallelIo, int ioThreads, int deltaChangeBudget) {
     }
 
     private static int estimateMobCluster(ServerLevel level) {


### PR DESCRIPTION
## Summary
- refine chunk-processing suggestions with live chunk tuning recommendations (flush interval, IO threads, delta budget)
- compute recommended tuning values from cache/queue pressure and include them in advisory evidence and messages

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae6e46c0883288b13d7792fae6387)