### PR TITLE
Add hostile spawn guard for starter bunkers and improve compat

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/configurable/StructureConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/configurable/StructureConfig.java
@@ -25,12 +25,18 @@ public class StructureConfig {
     public static final ModConfigSpec.IntValue MAX_LEVELING_DEPTH;
     /** Enable post-processing for Starter Structure bunkers using terrain replacer markers */
     public static final ModConfigSpec.BooleanValue ENABLE_STARTER_STRUCTURE_TERRAIN_REPLACER;
+    /** Prevent hostile mob spawns inside the starter bunker immediately after placement */
+    public static final ModConfigSpec.BooleanValue PREVENT_STARTER_STRUCTURE_HOSTILES;
     /** Horizontal search radius around the spawn bunker for terrain replacer markers */
     public static final ModConfigSpec.IntValue STARTER_STRUCTURE_SCAN_RADIUS;
     /** Vertical search range above and below the bunker origin for replacer markers */
     public static final ModConfigSpec.IntValue STARTER_STRUCTURE_SCAN_HEIGHT;
     /** Delay (ticks) after the starter structure is scheduled before applying the terrain replacer */
     public static final ModConfigSpec.IntValue STARTER_STRUCTURE_DELAY_TICKS;
+    /** Horizontal radius where hostile mobs may not spawn around the placed starter bunker */
+    public static final ModConfigSpec.IntValue STARTER_STRUCTURE_SPAWN_DENY_RADIUS;
+    /** Vertical half-height where hostile mobs may not spawn around the placed starter bunker */
+    public static final ModConfigSpec.IntValue STARTER_STRUCTURE_SPAWN_DENY_HEIGHT;
 
     private static final HashMap<String, BooleanValue> STRUCTURES = new HashMap<>();
     private static final HashMap<String, BooleanValue> POIS = new HashMap<>();
@@ -72,6 +78,10 @@ public class StructureConfig {
                                 + " will have those markers swapped for sampled surface blocks after generation."
                 )
                 .define("starterStructureTerrainReplacer", true);
+        PREVENT_STARTER_STRUCTURE_HOSTILES = BUILDER.comment(
+                        "When true, hostile mob spawns inside the starter bunker will be blocked after placement."
+                )
+                .define("starterStructurePreventHostiles", true);
         STARTER_STRUCTURE_SCAN_RADIUS = BUILDER.comment(
                         "Horizontal radius (in blocks) to scan around the starter bunker for terrain replacer markers."
                 )
@@ -85,6 +95,14 @@ public class StructureConfig {
                                 + " Gives the placer time to finish setting blocks."
                 )
                 .defineInRange("starterStructureDelayTicks", 10, 1, 200);
+        STARTER_STRUCTURE_SPAWN_DENY_RADIUS = BUILDER.comment(
+                        "Horizontal radius (in blocks) around the starter bunker where hostile mob spawns are denied."
+                )
+                .defineInRange("starterStructureSpawnDenyRadius", 24, 1, 128);
+        STARTER_STRUCTURE_SPAWN_DENY_HEIGHT = BUILDER.comment(
+                        "Vertical half-height (in blocks up and down) where hostile mob spawns are denied around the starter bunker."
+                )
+                .defineInRange("starterStructureSpawnDenyHeight", 12, 1, 128);
         BUILDER.pop();
 
         registerAll();

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSpawnEvents.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSpawnEvents.java
@@ -1,0 +1,42 @@
+package com.thunder.wildernessodysseyapi.WorldGen.structure;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.MobCategory;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.living.LivingSpawnEvent;
+
+/**
+ * Denies hostile mob spawns inside the starter bunker immediately after placement.
+ */
+@EventBusSubscriber(modid = ModConstants.MOD_ID)
+public final class StarterStructureSpawnEvents {
+    private StarterStructureSpawnEvents() {
+    }
+
+    @SubscribeEvent
+    public static void denyHostiles(LivingSpawnEvent.CheckSpawn event) {
+        if (!StructureConfig.PREVENT_STARTER_STRUCTURE_HOSTILES.get()) {
+            return;
+        }
+        if (!(event.getLevel() instanceof ServerLevel level)) {
+            return;
+        }
+        if (!(event.getEntity() instanceof Mob mob)) {
+            return;
+        }
+        if (mob.getType().getCategory() != MobCategory.MONSTER) {
+            return;
+        }
+
+        BlockPos pos = BlockPos.containing(event.getX(), event.getY(), event.getZ());
+        if (StarterStructureSpawnGuard.isDenied(level, pos)) {
+            event.setResult(Event.Result.DENY);
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSpawnGuard.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSpawnGuard.java
@@ -1,0 +1,69 @@
+package com.thunder.wildernessodysseyapi.WorldGen.structure;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.server.level.ServerLevel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Tracks recently placed starter bunkers and denies hostile mob spawns inside them.
+ */
+public final class StarterStructureSpawnGuard {
+    private static final Map<ResourceKey<Level>, List<SpawnDenyZone>> ZONES = new ConcurrentHashMap<>();
+
+    private StarterStructureSpawnGuard() {
+    }
+
+    public static void registerSpawnDenyZone(ServerLevel level, BlockPos origin) {
+        if (!StructureConfig.PREVENT_STARTER_STRUCTURE_HOSTILES.get()) {
+            return;
+        }
+        if (level == null || origin == null) {
+            return;
+        }
+
+        int radius = Math.max(1, StructureConfig.STARTER_STRUCTURE_SPAWN_DENY_RADIUS.get());
+        int halfHeight = Math.max(1, StructureConfig.STARTER_STRUCTURE_SPAWN_DENY_HEIGHT.get());
+
+        SpawnDenyZone zone = new SpawnDenyZone(origin.immutable(), radius, halfHeight);
+        ZONES.computeIfAbsent(level.dimension(), key -> new CopyOnWriteArrayList<>()).add(zone);
+
+        if (StructureConfig.DEBUG_LOG_PLACEMENTS.get()) {
+            ModConstants.LOGGER.debug(
+                    "[Starter Structure compat] Blocking hostile spawns within {}x{}x{} around bunker at {} in {}.",
+                    radius * 2 + 1, halfHeight * 2 + 1, radius * 2 + 1, origin, level.dimension().location());
+        }
+    }
+
+    public static boolean isDenied(LevelAccessor level, BlockPos pos) {
+        List<SpawnDenyZone> zones = ZONES.get(level.dimension());
+        if (zones == null || zones.isEmpty()) {
+            return false;
+        }
+
+        for (SpawnDenyZone zone : zones) {
+            if (zone.contains(pos)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private record SpawnDenyZone(BlockPos center, int radius, int halfHeight) {
+        boolean contains(BlockPos pos) {
+            int dx = Math.abs(pos.getX() - center.getX());
+            int dz = Math.abs(pos.getZ() - center.getZ());
+            int dy = Math.abs(pos.getY() - center.getY());
+            return dx <= radius && dz <= radius && dy <= halfHeight;
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
@@ -3,6 +3,7 @@ package com.thunder.wildernessodysseyapi.mixin;
 import com.natamus.starterstructure_common_neoforge.util.Util;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureTerrainAdapter;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.SchematicEntityRestorer;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureSpawnGuard;
 import com.natamus.collective_common_neoforge.schematic.ParsedSchematicObject;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -45,6 +46,7 @@ public class StarterStructureUtilMixin {
         BlockPos structureOrigin = cir.getReturnValue();
         if (structureOrigin != null) {
             StarterStructureTerrainAdapter.scheduleTerrainReplacement(serverLevel, structureOrigin);
+            StarterStructureSpawnGuard.registerSpawnDenyZone(serverLevel, structureOrigin);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add configuration to block hostile mob spawns around Starter Structure bunkers and apply the guard when schematics are placed
- enforce the spawn deny zone during mob spawn checks so bunkers stay clear while retaining Create/WorldEdit entity support

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b18e921dc8328967467be9cc3765d)