### PR TITLE
Refine loading stall detector with mod jar suspects

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Additional Resources:
 Community Documentation: https://docs.neoforged.net/
 NeoForged Discord: https://discord.neoforged.net/
 
+Loading Stall Detector:
+-----------------------
+If the loading screen stays up for 10+ minutes (common with 200+ mod packs), the mod now writes a snapshot to `logs/loading-stalls/`.
+Each report includes a thread dump and the active mod list so you can spot which thread/mod was executing when the hang occurred.
+Use `-Dwilderness.loadingstall.minutes=5` (for example) to lower the timeout; the suspects section lists the jar path for the top threads to speed up mod identification during loader hangs.
+
 Global Chat:
 ------------
 See `docs/global-chat-beginner.md` for a quickstart on hosting the relay, binding servers, and getting players talking.

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/LoadingStallDetector.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/LoadingStallDetector.java
@@ -1,0 +1,235 @@
+package com.thunder.wildernessodysseyapi.ModPackPatches.client;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.LoadingOverlay;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Watches the loading overlay and emits a detailed thread + mod snapshot
+ * if it stays visible for an extended period (e.g., long modpack hangs).
+ */
+@EventBusSubscriber(modid = ModConstants.MOD_ID, value = Dist.CLIENT)
+public final class LoadingStallDetector {
+    private static final Duration STALL_THRESHOLD = Duration.ofMinutes(resolveThresholdMinutes());
+    private static final Duration REMINDER_INTERVAL = Duration.ofMinutes(1);
+    private static final DateTimeFormatter TIMESTAMP = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private static long overlayStartedAt = 0L;
+    private static long lastProgressAt = 0L;
+    private static long lastReportAt = 0L;
+
+    private LoadingStallDetector() {
+    }
+
+    /**
+     * Called from the loading overlay mixin every render; marks that we are
+     * still making progress and (if first seen) arms the detector.
+     */
+    public static void recordProgress() {
+        long now = System.currentTimeMillis();
+        if (overlayStartedAt == 0L) {
+            overlayStartedAt = now;
+            ModConstants.LOGGER.info("Loading stall detector armed (loading overlay detected).");
+        }
+        lastProgressAt = now;
+    }
+
+    @SubscribeEvent
+    public static void onClientTick(ClientTickEvent.Pre event) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft == null) {
+            reset();
+            return;
+        }
+
+        boolean onLoadingOverlay = minecraft.getOverlay() instanceof LoadingOverlay;
+        long now = System.currentTimeMillis();
+
+        if (!onLoadingOverlay) {
+            if (overlayStartedAt != 0L) {
+                ModConstants.LOGGER.debug("Loading stall detector disarmed (overlay closed).");
+            }
+            reset();
+            return;
+        }
+
+        if (overlayStartedAt == 0L) {
+            overlayStartedAt = now;
+            lastProgressAt = now;
+        }
+
+        boolean pastThreshold = now - overlayStartedAt >= STALL_THRESHOLD.toMillis();
+        boolean remindIntervalElapsed = now - lastReportAt >= REMINDER_INTERVAL.toMillis();
+
+        if (pastThreshold && remindIntervalElapsed) {
+            lastReportAt = now;
+            writeStallReport(now);
+        }
+    }
+
+    private static void writeStallReport(long now) {
+        Path reportDir = Paths.get("logs", "loading-stalls");
+        String filename = "loading-stall-" + DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").format(LocalDateTime.now()) + ".log";
+        Path reportFile = reportDir.resolve(filename);
+
+        try {
+            Files.createDirectories(reportDir);
+            String report = buildReport(now);
+            Files.writeString(reportFile, report);
+            ModConstants.LOGGER.warn("Loading screen has been visible for {} minutes. Wrote stall snapshot to {}",
+                    STALL_THRESHOLD.toMinutes(), reportFile.toAbsolutePath());
+        } catch (IOException ioException) {
+            ModConstants.LOGGER.error("Failed to write loading stall report", ioException);
+        }
+    }
+
+    private static String buildReport(long now) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("=== Loading Stall Snapshot (").append(TIMESTAMP.format(LocalDateTime.now())).append(") ===\n");
+        builder.append("Overlay duration: ").append(formatDuration(now - overlayStartedAt)).append('\n');
+        builder.append("Time since last overlay render: ").append(formatDuration(now - lastProgressAt)).append('\n');
+        builder.append("Mod count: ").append(ModList.get().size()).append('\n');
+
+        appendModList(builder);
+        appendThreadDump(builder);
+
+        return builder.toString();
+    }
+
+    private static void appendModList(StringBuilder builder) {
+        List<String> mods = ModList.get().getMods().stream()
+                .map(mod -> mod.getModId() + "@" + mod.getVersion())
+                .sorted()
+                .toList();
+
+        builder.append("\n[Loaded Mods]\n");
+        mods.forEach(mod -> builder.append(" - ").append(mod).append('\n'));
+    }
+
+    private static void appendThreadDump(StringBuilder builder) {
+        builder.append("\n[Thread Dump]\n");
+        Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
+
+        appendThreadSuspects(builder, traces);
+
+        traces.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey(Comparator.comparing(Thread::getName)))
+                .forEach(entry -> {
+                    Thread thread = entry.getKey();
+                    StackTraceElement[] stack = entry.getValue();
+
+                    builder.append("\nThread: ").append(thread.getName())
+                            .append(" (id=").append(thread.getId()).append(", state=").append(thread.getState()).append(")\n");
+
+                    for (int i = 0; i < stack.length; i++) {
+                        builder.append("    at ").append(stack[i]).append('\n');
+                        if (i >= 31) {
+                            builder.append("    ... ").append(stack.length - 32).append(" more\n");
+                            break;
+                        }
+                    }
+                });
+
+        builder.append("\n");
+    }
+
+    /**
+     * Emits a lightweight suspect list before the full dump, prioritizing threads that are
+     * RUNNABLE or BLOCKED (often the ones wedging the loader).
+     */
+    private static void appendThreadSuspects(StringBuilder builder, Map<Thread, StackTraceElement[]> traces) {
+        builder.append("[Likely Culprit Threads]\n");
+        traces.entrySet().stream()
+                .sorted((a, b) -> threadPriority(b.getKey()) - threadPriority(a.getKey()))
+                .limit(6)
+                .forEach(entry -> {
+                    Thread thread = entry.getKey();
+                    StackTraceElement[] stack = entry.getValue();
+                    builder.append(" - ")
+                            .append(thread.getName())
+                            .append(" (state=")
+                            .append(thread.getState())
+                            .append(")");
+
+                    resolveJar(stack).ifPresent(jar -> builder.append(" [jar=").append(jar).append("]"));
+
+                    if (stack.length > 0) {
+                        builder.append(" at ").append(stack[0]);
+                    }
+                    builder.append('\n');
+                });
+        builder.append('\n');
+    }
+
+    private static int threadPriority(Thread thread) {
+        // Prefer threads that are RUNNABLE/BLOCKED over waiting/parked ones.
+        return switch (thread.getState()) {
+            case RUNNABLE, BLOCKED -> 3;
+            case WAITING, TIMED_WAITING -> 2;
+            default -> 1;
+        };
+    }
+
+    private static Optional<String> resolveJar(StackTraceElement[] stack) {
+        if (stack.length == 0) {
+            return Optional.empty();
+        }
+        String className = stack[0].getClassName();
+        try {
+            Class<?> cls = Class.forName(className, false, Thread.currentThread().getContextClassLoader());
+            if (cls.getProtectionDomain() != null && cls.getProtectionDomain().getCodeSource() != null) {
+                var source = cls.getProtectionDomain().getCodeSource().getLocation();
+                if (source != null) {
+                    return Optional.of(source.getPath());
+                }
+            }
+        } catch (ClassNotFoundException ignored) {
+            // Best-effort only; fall back to the raw class name if unavailable.
+        }
+        return Optional.empty();
+    }
+
+    private static String formatDuration(long millis) {
+        Duration duration = Duration.ofMillis(Math.max(millis, 0));
+        long minutes = duration.toMinutes();
+        long seconds = duration.minusMinutes(minutes).toSeconds();
+        long ms = duration.minusMinutes(minutes).minusSeconds(seconds).toMillis();
+        return String.format("%02dm %02ds %03dms", minutes, seconds, ms);
+    }
+
+    private static long resolveThresholdMinutes() {
+        String override = System.getProperty("wilderness.loadingstall.minutes", "").trim();
+        if (override.isEmpty()) {
+            return 10L;
+        }
+        try {
+            long minutes = Long.parseLong(override);
+            return minutes > 0 ? minutes : 10L;
+        } catch (NumberFormatException ignored) {
+            return 10L;
+        }
+    }
+
+    private static void reset() {
+        overlayStartedAt = 0L;
+        lastProgressAt = 0L;
+        lastReportAt = 0L;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/LoadingOverlayMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/LoadingOverlayMixin.java
@@ -1,6 +1,7 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.ModPackPatches.client.LoadingStallDetector;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.LoadingOverlay;
@@ -23,6 +24,7 @@ public class LoadingOverlayMixin {
         if (minecraft == null) {
             return;
         }
+        LoadingStallDetector.recordProgress();
 
         int screenWidth = minecraft.getWindow().getGuiScaledWidth();
         int screenHeight = minecraft.getWindow().getGuiScaledHeight();


### PR DESCRIPTION
## Summary
- allow configuring the stall timeout via system property and emit a “likely culprits” section when the loading screen hangs
- include best-effort jar paths for busy/blocking threads to highlight the mod behind the stall
- document the configurable timeout and jar suspect output for faster modpack triage

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e0fdc479483288347b8bcb87b1db5)