### PR TITLE
Improve chunk IO backpressure and async resiliency

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryTracker.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/MemUtils/MemoryTracker.java
@@ -23,9 +23,7 @@ public class MemoryTracker {
     public static void onServerTick(ServerTickEvent.Post event) {
         if (++tickCounter >= SAMPLE_INTERVAL) {
             tickCounter = 0;
-            if (++tickCounter % SAMPLE_INTERVAL == 0) {
-                MemoryUtils.recordPeakUsage();
-            }
+            MemoryUtils.recordPeakUsage();
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/async/AsyncTaskStats.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/async/AsyncTaskStats.java
@@ -11,5 +11,6 @@ public record AsyncTaskStats(
         int queuedWorkerTasks,
         int mainThreadBacklog,
         int appliedLastTick,
-        int rejectedTasks
+        int rejectedTasks,
+        int callerRunsEvents
 ) { }

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/AsyncStatsCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/AsyncStatsCommand.java
@@ -35,6 +35,7 @@ public final class AsyncStatsCommand {
         source.sendSuccess(() -> Component.literal(" - Main-thread backlog: " + stats.mainThreadBacklog()), false);
         source.sendSuccess(() -> Component.literal(" - Applied last tick: " + stats.appliedLastTick()), false);
         source.sendSuccess(() -> Component.literal(" - Rejected tasks: " + stats.rejectedTasks()), false);
+        source.sendSuccess(() -> Component.literal(" - Caller-runs (backpressure): " + stats.callerRunsEvents()), false);
         return 1;
     }
 }


### PR DESCRIPTION
## Summary
- add chunk load backpressure with queued requests instead of dropping when exceeding max parallel IO
- fix memory sampling cadence and expose caller-runs backpressure metrics in async stats
- harden global chat connectivity with timeouts and exponential reconnect backoff

## Testing
- ./gradlew test --no-daemon

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee62a27008328935e931e13460c76)