### PR TITLE
Add world-scoped chunk cache path and improve streaming coalescing

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -61,6 +61,7 @@ import com.thunder.wildernessodysseyapi.WorldGen.util.DeferredTaskScheduler;
 import com.thunder.wildernessodysseyapi.chunk.ChunkStreamManager;
 import com.thunder.wildernessodysseyapi.chunk.ChunkStreamingConfig;
 import com.thunder.wildernessodysseyapi.chunk.ChunkTickThrottler;
+import com.thunder.wildernessodysseyapi.chunk.ChunkStoragePaths;
 import com.thunder.wildernessodysseyapi.chunk.DiskChunkStorageAdapter;
 import com.thunder.wildernessodysseyapi.io.BufferPool;
 import com.thunder.wildernessodysseyapi.io.IoExecutors;
@@ -196,7 +197,7 @@ public class WildernessOdysseyAPIMainModClass {
         ChunkStreamingConfig.ChunkConfigValues chunkConfig = ChunkStreamingConfig.values();
         BufferPool.configure(chunkConfig);
         IoExecutors.initialize(chunkConfig);
-        chunkStorageRoot = event.getServer().getFile("config/" + CONFIG_FOLDER + "chunk-cache");
+        chunkStorageRoot = ChunkStoragePaths.resolveCacheRoot(event.getServer(), chunkConfig);
         ChunkStreamManager.initialize(chunkConfig, new DiskChunkStorageAdapter(chunkStorageRoot, chunkConfig.compressionLevel(), chunkConfig.compressionCodec()));
         ChunkDeltaTracker.configure(chunkConfig);
         globalChatManager.initialize(event.getServer(), event.getServer().getFile("config"));

--- a/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStoragePaths.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStoragePaths.java
@@ -18,8 +18,9 @@ public final class ChunkStoragePaths {
             folderName = "chunk-cache";
         }
         if (config.storeCacheInWorldConfig()) {
-            return server.getWorldPath(LevelResource.SERVERCONFIG).resolve(folderName);
+            Path worldConfig = server.getWorldPath(LevelResource.ROOT).resolve("serverconfig");
+            return worldConfig.resolve(folderName);
         }
-        return server.getFile("config/" + com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID + "/" + folderName).toPath();
+        return server.getFile("config/" + com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID + "/" + folderName);
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStoragePaths.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStoragePaths.java
@@ -1,0 +1,25 @@
+package com.thunder.wildernessodysseyapi.chunk;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.storage.LevelResource;
+
+import java.nio.file.Path;
+
+/**
+ * Resolves per-world or global chunk cache paths.
+ */
+public final class ChunkStoragePaths {
+    private ChunkStoragePaths() {
+    }
+
+    public static Path resolveCacheRoot(MinecraftServer server, ChunkStreamingConfig.ChunkConfigValues config) {
+        String folderName = config.cacheFolderName();
+        if (folderName == null || folderName.isBlank()) {
+            folderName = "chunk-cache";
+        }
+        if (config.storeCacheInWorldConfig()) {
+            return server.getWorldPath(LevelResource.SERVERCONFIG).resolve(folderName);
+        }
+        return server.getFile("config/" + com.thunder.wildernessodysseyapi.Core.ModConstants.MOD_ID + "/" + folderName).toPath();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamManager.java
@@ -452,6 +452,10 @@ public final class ChunkStreamManager {
 
         CompletableFuture<Optional<CompoundTag>> loadChunk(ChunkPos pos, ResourceKey<Level> requestedDimension) {
             ChunkStreamingConfig.ChunkConfigValues values = configSupplier.get();
+            CompletableFuture<Optional<CompoundTag>> inFlight = loadTasks.get(pos);
+            if (inFlight != null) {
+                return inFlight;
+            }
             LoadRequest request = new LoadRequest(
                     pos,
                     requestedDimension != null ? requestedDimension : dimension,
@@ -481,6 +485,9 @@ public final class ChunkStreamManager {
         }
 
         void enqueueSave(ChunkPos pos, CompoundTag payload, DirtySegmentSet dirtySegments, long gameTime, ResourceKey<Level> requestedDimension) {
+            if (!dirtySegments.hasEntries()) {
+                return;
+            }
             pendingSaves.merge(
                     pos,
                     new PendingSave(payload, dirtySegments, gameTime + configSupplier.get().saveDebounceTicks(),

--- a/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamingConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamingConfig.java
@@ -37,6 +37,10 @@ public final class ChunkStreamingConfig {
     public static final ModConfigSpec.IntValue DELTA_CHANGE_BUDGET;
     public static final ModConfigSpec.IntValue LIGHT_COMPRESSION_LEVEL;
     public static final ModConfigSpec.IntValue WRITE_FLUSH_INTERVAL_TICKS;
+    public static final ModConfigSpec.ConfigValue<String> CACHE_FOLDER_NAME;
+    public static final ModConfigSpec.BooleanValue STORE_CACHE_IN_WORLD_CONFIG;
+    public static final ModConfigSpec.ConfigValue<String> CACHE_FOLDER_NAME;
+    public static final ModConfigSpec.BooleanValue STORE_CACHE_IN_WORLD_CONFIG;
 
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 
@@ -98,6 +102,10 @@ public final class ChunkStreamingConfig {
                 .defineInRange("lightCompressionLevel", 6, 1, 9);
         WRITE_FLUSH_INTERVAL_TICKS = BUILDER.comment("Interval (in ticks) to batch dirty chunk writes using the scheduled flush task.")
                 .defineInRange("writeFlushIntervalTicks", 20, 1, 200);
+        CACHE_FOLDER_NAME = BUILDER.comment("Folder name used for chunk cache storage.")
+                .define("cacheFolderName", "chunk-cache");
+        STORE_CACHE_IN_WORLD_CONFIG = BUILDER.comment("If true, chunk cache data is stored under the world-specific config folder instead of the global config directory.")
+                .define("storeCacheInWorldConfig", true);
         BUILDER.pop();
 
         CONFIG_SPEC = BUILDER.build();
@@ -136,7 +144,9 @@ public final class ChunkStreamingConfig {
                     SLICE_INTERN_LIMIT.get(),
                     DELTA_CHANGE_BUDGET.get(),
                     LIGHT_COMPRESSION_LEVEL.get(),
-                    WRITE_FLUSH_INTERVAL_TICKS.get()
+                    WRITE_FLUSH_INTERVAL_TICKS.get(),
+                    CACHE_FOLDER_NAME.get(),
+                    STORE_CACHE_IN_WORLD_CONFIG.get()
             );
         } catch (IllegalStateException ex) {
             return defaultValues();
@@ -175,7 +185,9 @@ public final class ChunkStreamingConfig {
                 SLICE_INTERN_LIMIT.getDefault(),
                 DELTA_CHANGE_BUDGET.getDefault(),
                 LIGHT_COMPRESSION_LEVEL.getDefault(),
-                WRITE_FLUSH_INTERVAL_TICKS.getDefault()
+                WRITE_FLUSH_INTERVAL_TICKS.getDefault(),
+                CACHE_FOLDER_NAME.getDefault(),
+                STORE_CACHE_IN_WORLD_CONFIG.getDefault()
         );
     }
 
@@ -207,7 +219,9 @@ public final class ChunkStreamingConfig {
             int sliceInternLimit,
             int deltaChangeBudget,
             int lightCompressionLevel,
-            int writeFlushIntervalTicks
+            int writeFlushIntervalTicks,
+            String cacheFolderName,
+            boolean storeCacheInWorldConfig
     ) {
         public ChunkConfigValues(boolean enabled,
                                  int hotCacheLimit,
@@ -247,7 +261,9 @@ public final class ChunkStreamingConfig {
                     384,
                     256,
                     6,
-                    20
+                    20,
+                    "chunk-cache",
+                    true
             );
         }
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamingConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/chunk/ChunkStreamingConfig.java
@@ -39,8 +39,6 @@ public final class ChunkStreamingConfig {
     public static final ModConfigSpec.IntValue WRITE_FLUSH_INTERVAL_TICKS;
     public static final ModConfigSpec.ConfigValue<String> CACHE_FOLDER_NAME;
     public static final ModConfigSpec.BooleanValue STORE_CACHE_IN_WORLD_CONFIG;
-    public static final ModConfigSpec.ConfigValue<String> CACHE_FOLDER_NAME;
-    public static final ModConfigSpec.BooleanValue STORE_CACHE_IN_WORLD_CONFIG;
 
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/chunk/DiskChunkStorageAdapter.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/chunk/DiskChunkStorageAdapter.java
@@ -39,6 +39,7 @@ public class DiskChunkStorageAdapter implements ChunkStorageAdapter {
     @Override
     public void write(ChunkPos pos, CompoundTag tag) throws IOException {
         Path path = chunkPath(pos);
+        Files.createDirectories(path.getParent());
         CompoundTag compacted = tag.copy();
         NbtDataCompactor.compactModPayload(compacted);
         NbtCompressionUtils.writeCompressed(path, compacted, compressionLevel, compressionCodec);


### PR DESCRIPTION
## Summary
- add config options for cache folder name and storing chunk cache under per-world config directories, plus resolver helper
- ensure chunk cache directory is created before writes and reuse in-flight chunk loads while skipping no-op saves
- wire server startup to resolve the cache root via the new helper for world-scoped storage

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694efecffa9483288c0c6009c0e15951)