### PR TITLE
Fix starter structure entity capture timing

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
@@ -32,7 +32,8 @@ public class StarterStructureUtilMixin {
             method = "generateSchematic",
             at = @At(
                     value = "INVOKE_ASSIGN",
-                    target = "Lcom/natamus/collective_common_neoforge/schematic/ParseSchematicFile;getParsedSchematicObject(Ljava/io/InputStream;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;IZZ)Lcom/natamus/collective_common_neoforge/schematic/ParsedSchematicObject;"
+                    target = "Lcom/natamus/collective_common_neoforge/schematic/ParseSchematicFile;getParsedSchematicObject(Ljava/io/InputStream;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;IZZ)Lcom/natamus/collective_common_neoforge/schematic/ParsedSchematicObject;",
+                    shift = At.Shift.AFTER
             ),
             locals = LocalCapture.CAPTURE_FAILHARD
     )


### PR DESCRIPTION
## Summary
- shift the starter structure schematic mixin to run after parsing so parsed data is available
- ensure backfilled entity restoration runs for the bunker schematic to keep Create contraptions intact

## Testing
- ./gradlew --no-daemon build -x test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f12c984c08328821c8180e52a192c)