### PR TITLE
Use schem-driven GameTests and CI workflow updates

### DIFF
--- a/.github/workflows/gametest.yml
+++ b/.github/workflows/gametest.yml
@@ -1,0 +1,31 @@
+name: Game Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  rungametestserver:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Cache Gradle packages
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: wrapper
+
+      - name: Run GameTests
+        run: ./gradlew rungametestserver --stacktrace

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -24,14 +24,20 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2025.3
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
         with:
           # When pr-mode is set to true, Qodana analyzes only the files that have been changed
-          pr-mode: false
+          pr-mode: ${{ github.event_name == 'pull_request' }}
           use-caches: true
+          cache-default-branch: main
           post-pr-comment: true
           use-annotations: true
           # Upload Qodana results (SARIF, other artifacts, logs) as an artifact to the job

--- a/build.gradle
+++ b/build.gradle
@@ -50,13 +50,13 @@ neoForge {
             client()
 
             // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
-            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            systemProperty 'neoforge.enabledGameTestNamespaces', "${project.mod_id},minecraft"
         }
 
         server {
             server()
             programArgument '--nogui'
-            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            systemProperty 'neoforge.enabledGameTestNamespaces', "${project.mod_id},minecraft"
         }
 
         // This run config launches GameTestServer and runs all registered gametests, then exits.
@@ -64,7 +64,7 @@ neoForge {
         // The gametest system is also enabled by default for other run configs under the /test commands.
         gameTestServer {
             type = "gameTestServer"
-            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            systemProperty 'neoforge.enabledGameTestNamespaces', "${project.mod_id},minecraft"
         }
 
         data {

--- a/build.gradle
+++ b/build.gradle
@@ -50,13 +50,13 @@ neoForge {
             client()
 
             // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
-            systemProperty 'neoforge.enabledGameTestNamespaces', "${project.mod_id},minecraft"
+            // Keep default (all) so both mod and vanilla GameTests register in dev.
         }
 
         server {
             server()
             programArgument '--nogui'
-            systemProperty 'neoforge.enabledGameTestNamespaces', "${project.mod_id},minecraft"
+            // Keep default (all) so both mod and vanilla GameTests register in dev.
         }
 
         // This run config launches GameTestServer and runs all registered gametests, then exits.
@@ -64,7 +64,8 @@ neoForge {
         // The gametest system is also enabled by default for other run configs under the /test commands.
         gameTestServer {
             type = "gameTestServer"
-            systemProperty 'neoforge.enabledGameTestNamespaces', "${project.mod_id},minecraft"
+            // Empty = all namespaces; avoids filtering away tests during CI.
+            systemProperty 'neoforge.enabledGameTestNamespaces', ""
         }
 
         data {

--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/StarterStructureGameTests.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/StarterStructureGameTests.java
@@ -38,7 +38,7 @@ public class StarterStructureGameTests {
     private static final String WORLD_EDIT_MOD_ID = "worldedit";
     private static final String CREATE_MOD_ID = "create";
 
-    @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
+    @GameTest(namespace = ModConstants.MOD_ID, templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
     public void bunkerSpawnsBlocks(GameTestHelper helper) {
         PlacementContext context = pasteBunker(helper);
         if (context == null) {
@@ -52,7 +52,7 @@ public class StarterStructureGameTests {
         });
     }
 
-    @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
+    @GameTest(namespace = ModConstants.MOD_ID, templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
     public void bunkerRetainsCreateMachines(GameTestHelper helper) {
         if (!ModList.get().isLoaded(CREATE_MOD_ID)) {
             helper.fail("Create mod is not loaded; cannot verify Create machines.");

--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/StarterStructureGameTests.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/StarterStructureGameTests.java
@@ -38,7 +38,7 @@ public class StarterStructureGameTests {
     private static final String WORLD_EDIT_MOD_ID = "worldedit";
     private static final String CREATE_MOD_ID = "create";
 
-    @GameTest(namespace = ModConstants.MOD_ID, templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
+    @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
     public void bunkerSpawnsBlocks(GameTestHelper helper) {
         PlacementContext context = pasteBunker(helper);
         if (context == null) {
@@ -52,7 +52,7 @@ public class StarterStructureGameTests {
         });
     }
 
-    @GameTest(namespace = ModConstants.MOD_ID, templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
+    @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
     public void bunkerRetainsCreateMachines(GameTestHelper helper) {
         if (!ModList.get().isLoaded(CREATE_MOD_ID)) {
             helper.fail("Create mod is not loaded; cannot verify Create machines.");

--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/StarterStructureGameTests.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/StarterStructureGameTests.java
@@ -38,7 +38,7 @@ public class StarterStructureGameTests {
     private static final String WORLD_EDIT_MOD_ID = "worldedit";
     private static final String CREATE_MOD_ID = "create";
 
-    @GameTest(templateNamespace = ModConstants.MOD_ID, template = "empty", batch = BATCH, timeoutTicks = 400)
+    @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
     public void bunkerSpawnsBlocks(GameTestHelper helper) {
         PlacementContext context = pasteBunker(helper);
         if (context == null) {
@@ -52,7 +52,7 @@ public class StarterStructureGameTests {
         });
     }
 
-    @GameTest(templateNamespace = ModConstants.MOD_ID, template = "empty", batch = BATCH, timeoutTicks = 400)
+    @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
     public void bunkerRetainsCreateMachines(GameTestHelper helper) {
         if (!ModList.get().isLoaded(CREATE_MOD_ID)) {
             helper.fail("Create mod is not loaded; cannot verify Create machines.");

--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/StarterStructureGameTests.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/StarterStructureGameTests.java
@@ -39,7 +39,7 @@ public class StarterStructureGameTests {
     private static final String CREATE_MOD_ID = "create";
 
     @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
-    public void bunkerSpawnsBlocks(GameTestHelper helper) {
+    public static void bunkerSpawnsBlocks(GameTestHelper helper) {
         PlacementContext context = pasteBunker(helper);
         if (context == null) {
             return; // pasteBunker already reported failure
@@ -53,7 +53,7 @@ public class StarterStructureGameTests {
     }
 
     @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
-    public void bunkerRetainsCreateMachines(GameTestHelper helper) {
+    public static void bunkerRetainsCreateMachines(GameTestHelper helper) {
         if (!ModList.get().isLoaded(CREATE_MOD_ID)) {
             helper.fail("Create mod is not loaded; cannot verify Create machines.");
             return;


### PR DESCRIPTION
## Summary
- keep GameTests powered by the bunker schem while using the vanilla `minecraft:empty` template to avoid bundled structure files
- add a GitHub Actions workflow to run the GameTest server via Gradle
- update the Qodana workflow with Java 21 setup and PR-aware configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69541c5c5c9083289af79a1193be2512)