### PR TITLE
Add schematic fallback support for GameTest templates

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/GameTestSchematicTemplateLoader.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/GameTestSchematicTemplateLoader.java
@@ -1,0 +1,135 @@
+package com.thunder.wildernessodysseyapi.gametest;
+
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormats;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.mixin.StructureTemplateAccessor;
+import com.thunder.wildernessodysseyapi.mixin.StructureTemplateManagerAccessor;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Vec3i;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.Palette;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.StructureBlockInfo;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Loads GameTest structure templates from WorldEdit schematic formats so tests can reuse the same
+ * schematics without duplicating NBT templates.
+ */
+public final class GameTestSchematicTemplateLoader {
+    private static final List<String> STRUCTURE_FOLDERS = List.of("structure", "structures");
+    private static final List<String> SUPPORTED_EXTENSIONS = List.of(".schem", ".schematic");
+
+    private GameTestSchematicTemplateLoader() {
+    }
+
+    /**
+     * Attempts to load the requested GameTest template from a WorldEdit schematic. When a schematic is
+     * found and parsed, the resulting {@link StructureTemplate} is written into the template manager's cache.
+     *
+     * @return a populated structure template, or {@code null} when no schematic could be resolved
+     */
+    public static @Nullable StructureTemplate loadFromSchematic(StructureTemplateManager manager, ResourceLocation id) {
+        ResourceManager resourceManager = ((StructureTemplateManagerAccessor) manager).getResourceManager();
+        if (resourceManager == null) {
+            return null;
+        }
+
+        byte[] schematicBytes = readSchematicBytes(resourceManager, id);
+        if (schematicBytes == null) {
+            return null;
+        }
+
+        ClipboardFormat format = ClipboardFormats.findByInputStream(() -> new ByteArrayInputStream(schematicBytes));
+        if (format == null) {
+            ModConstants.LOGGER.warn("[GameTest schematics] Could not detect schematic format for {} ({} bytes).", id, schematicBytes.length);
+            return null;
+        }
+
+        try (ClipboardReader reader = format.getReader(new ByteArrayInputStream(schematicBytes))) {
+            Clipboard clipboard = reader.read();
+            StructureTemplate template = manager.getOrCreate(id);
+            writeClipboardToTemplate(template, clipboard);
+            return template;
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("[GameTest schematics] Failed to read schematic for {}.", id, e);
+            return null;
+        }
+    }
+
+    private static @Nullable byte[] readSchematicBytes(ResourceManager resourceManager, ResourceLocation id) {
+        for (String folder : STRUCTURE_FOLDERS) {
+            for (String extension : SUPPORTED_EXTENSIONS) {
+                ResourceLocation schematicLocation = ResourceLocation.fromNamespaceAndPath(
+                        id.getNamespace(), folder + "/" + id.getPath() + extension);
+                Optional<Resource> resource = resourceManager.getResource(schematicLocation);
+                if (resource.isEmpty()) {
+                    continue;
+                }
+
+                try (InputStream in = resource.get().open()) {
+                    return in.readAllBytes();
+                } catch (IOException e) {
+                    ModConstants.LOGGER.warn("[GameTest schematics] Unable to read schematic resource {}.", schematicLocation, e);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static void writeClipboardToTemplate(StructureTemplate template, Clipboard clipboard) {
+        BlockVector3 min = clipboard.getMinimumPoint();
+        BlockVector3 dimensions = clipboard.getDimensions();
+        int sizeX = dimensions.getX();
+        int sizeY = dimensions.getY();
+        int sizeZ = dimensions.getZ();
+
+        List<StructureBlockInfo> blocks = new ArrayList<>();
+        for (int x = 0; x < sizeX; x++) {
+            for (int y = 0; y < sizeY; y++) {
+                for (int z = 0; z < sizeZ; z++) {
+                    BlockVector3 cursor = BlockVector3.at(min.getX() + x, min.getY() + y, min.getZ() + z);
+                    BaseBlock baseBlock = clipboard.getFullBlock(cursor);
+                    if (baseBlock == null) {
+                        continue;
+                    }
+
+                    BlockState blockState = com.sk89q.worldedit.neoforge.NeoForgeAdapter.adapt(baseBlock.toImmutableState());
+                    if (blockState.isAir()) {
+                        continue;
+                    }
+
+                    BlockPos relativePos = new BlockPos(x, y, z);
+                    // Block entity data is intentionally omitted for GameTests; WorldEdit will paste the full
+                    // schematic during the test run itself.
+                    blocks.add(new StructureBlockInfo(relativePos, blockState, (CompoundTag) null));
+                }
+            }
+        }
+
+        StructureTemplateAccessor accessor = (StructureTemplateAccessor) template;
+        accessor.setSize(new Vec3i(sizeX, sizeY, sizeZ));
+        List<Palette> palettes = accessor.getPalettes();
+        palettes.clear();
+        palettes.add(com.thunder.wildernessodysseyapi.mixin.StructureTemplatePaletteInvoker.wildernessodysseyapi$newPalette(blocks));
+        accessor.getEntityInfoList().clear();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplateAccessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplateAccessor.java
@@ -1,0 +1,22 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import net.minecraft.core.Vec3i;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.Palette;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.StructureEntityInfo;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(StructureTemplate.class)
+public interface StructureTemplateAccessor {
+    @Accessor("palettes")
+    List<Palette> getPalettes();
+
+    @Accessor("entityInfoList")
+    List<StructureEntityInfo> getEntityInfoList();
+
+    @Accessor("size")
+    void setSize(Vec3i size);
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplateManagerAccessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplateManagerAccessor.java
@@ -1,0 +1,12 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(StructureTemplateManager.class)
+public interface StructureTemplateManagerAccessor {
+    @Accessor("resourceManager")
+    ResourceManager getResourceManager();
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplatePaletteInvoker.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplatePaletteInvoker.java
@@ -1,0 +1,16 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.StructureBlockInfo;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.List;
+
+@Mixin(StructureTemplate.Palette.class)
+public interface StructureTemplatePaletteInvoker {
+    @Invoker("<init>")
+    static StructureTemplate.Palette wildernessodysseyapi$newPalette(List<StructureBlockInfo> blocks) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureUtilsMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureUtilsMixin.java
@@ -1,0 +1,48 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.gametest.GameTestSchematicTemplateLoader;
+import net.minecraft.gametest.framework.GameTestInfo;
+import net.minecraft.gametest.framework.StructureUtils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+@Mixin(StructureUtils.class)
+public abstract class StructureUtilsMixin {
+    @Redirect(
+            method = "prepareTestStructure",
+            at = @At(value = "INVOKE", target = "Ljava/util/Optional;orElseThrow(Ljava/util/function/Supplier;)Ljava/lang/Object;")
+    )
+    private static Object wildernessodysseyapi$loadSchematicWhenMissing(
+            Optional<StructureTemplate> template,
+            Supplier<? extends RuntimeException> missingSupplier,
+            GameTestInfo info,
+            BlockPos origin,
+            Rotation rotation,
+            ServerLevel level
+    ) {
+        if (template.isPresent()) {
+            return template.get();
+        }
+
+        ResourceLocation structureId = ResourceLocation.parse(info.getStructureName());
+        StructureTemplateManager manager = level.getStructureManager();
+        StructureTemplate schematicTemplate = GameTestSchematicTemplateLoader.loadFromSchematic(manager, structureId);
+        if (schematicTemplate != null) {
+            ModConstants.LOGGER.info("[GameTest schematics] Loaded schematic-backed template for {}.", structureId);
+            return schematicTemplate;
+        }
+
+        throw missingSupplier.get();
+    }
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -8,14 +8,18 @@
       "BlockEntityMixin",
       "CampfireBlockMixin",
       "DayNightCycleMixin",
-      "EntityAccessor",
-      "ServerLevelMixin",
-      "ForwardExtentCopyMixin",
-      "ServerboundSetStructureBlockPacketMixin",
-      "StarterStructureConfigMixin",
-      "StarterStructureUtilMixin",
-      "StructureBlockEntityMixin"
-    ],
+    "EntityAccessor",
+    "ServerLevelMixin",
+    "ForwardExtentCopyMixin",
+    "ServerboundSetStructureBlockPacketMixin",
+    "StarterStructureConfigMixin",
+    "StarterStructureUtilMixin",
+    "StructureBlockEntityMixin",
+    "StructureTemplateAccessor",
+    "StructureTemplateManagerAccessor",
+    "StructureTemplatePaletteInvoker",
+    "StructureUtilsMixin"
+  ],
   "injectors": {
     "defaultRequire": 1
   },


### PR DESCRIPTION
## Summary
- add a GameTest schematic loader that converts WorldEdit schematics into StructureTemplates
- intercept GameTest structure preparation to fall back to schematic-backed templates and access underlying template internals through mixin accessors
- register the new mixins in the configuration

## Testing
- ./gradlew test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954761ef0e88328bacb785a9ad8e1cf)