### PR TITLE
Allow GameTests to load schem structures directly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,12 @@ sourceSets {
         compileClasspath += sourceSets.main.output + configurations.runtimeClasspath
         runtimeClasspath += output + compileClasspath
     }
+    schemTest {
+        java.srcDir 'src/schemTest/java'
+        resources.srcDir 'src/schemTest/resources'
+        compileClasspath += sourceSets.main.output + sourceSets.main.compileClasspath
+        runtimeClasspath += output + compileClasspath + sourceSets.main.runtimeClasspath
+    }
 }
 
 // Sets up a dependency configuration called 'localRuntime'.
@@ -143,6 +149,9 @@ configurations {
 
     jmhImplementation.extendsFrom implementation
     jmhRuntimeOnly.extendsFrom runtimeOnly
+
+    schemTestImplementation.extendsFrom implementation, testImplementation
+    schemTestRuntimeOnly.extendsFrom runtimeOnly, testRuntimeOnly
 }
 
 // Make sure Gradle run configurations (JavaExec tasks) also see bundled libraries when
@@ -314,6 +323,14 @@ tasks.register('integrationTest', Test) {
     shouldRunAfter tasks.named('test')
 }
 
+tasks.register('schemTest', Test) {
+    description = 'Runs experimental GameTest schem scenarios in an isolated source set.'
+    group = 'verification'
+    testClassesDirs = sourceSets.schemTest.output.classesDirs
+    classpath = sourceSets.schemTest.runtimeClasspath
+    shouldRunAfter tasks.named('integrationTest')
+}
+
 tasks.register('jmh', JavaExec) {
     group = 'benchmark'
     description = 'Runs JMH benchmarks for NBT serialization/deserialization.'
@@ -349,6 +366,7 @@ tasks.register('profileChunkWorkload', JavaExec) {
 
 tasks.named('check').configure {
     dependsOn tasks.named('integrationTest')
+    dependsOn tasks.named('schemTest')
 }
 
 // IDEA no longer automatically downloads sources/javadoc jars for dependencies, so we need to explicitly enable the behavior.

--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/GameTestTemplateFallbacks.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/GameTestTemplateFallbacks.java
@@ -1,0 +1,33 @@
+package com.thunder.wildernessodysseyapi.gametest;
+
+import com.thunder.wildernessodysseyapi.mixin.StructureTemplateAccessor;
+import net.minecraft.core.Vec3i;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+
+import java.util.Optional;
+
+/**
+ * Provides minimal in-memory templates for GameTest scaffolding when no structure files exist.
+ */
+public final class GameTestTemplateFallbacks {
+    public static final ResourceLocation VANILLA_EMPTY = ResourceLocation.parse("minecraft:empty");
+
+    private GameTestTemplateFallbacks() {
+    }
+
+    /**
+     * Returns an empty structure template for {@code minecraft:empty} when the file is missing.
+     */
+    public static Optional<StructureTemplate> maybeEmptyTemplate(ResourceLocation id) {
+        if (!VANILLA_EMPTY.equals(id)) {
+            return Optional.empty();
+        }
+
+        StructureTemplate template = new StructureTemplate();
+        StructureTemplateAccessor accessor = (StructureTemplateAccessor) template;
+        accessor.setSize(Vec3i.ZERO);
+        // Leave palettes and entities empty.
+        return Optional.of(template);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/SchemGameTestStructureLoader.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/SchemGameTestStructureLoader.java
@@ -1,0 +1,63 @@
+package com.thunder.wildernessodysseyapi.gametest;
+
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormats;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Loads .schem/.schematic GameTest templates by converting clipboards into in-memory StructureTemplates.
+ */
+public final class SchemGameTestStructureLoader {
+    private static final List<String> SUPPORTED_EXTENSIONS = List.of(".schem", ".schematic");
+    private static final String STRUCTURE_PREFIX = "structure/";
+
+    private SchemGameTestStructureLoader() {
+    }
+
+    public static Optional<StructureTemplate> tryLoad(ResourceManager resourceManager, ResourceLocation id) {
+        for (String extension : SUPPORTED_EXTENSIONS) {
+            ResourceLocation schemLocation = ResourceLocation.fromNamespaceAndPath(
+                    id.getNamespace(), STRUCTURE_PREFIX + id.getPath() + extension);
+            Optional<Resource> resource = resourceManager.getResource(schemLocation);
+            if (resource.isEmpty()) {
+                continue;
+            }
+
+            try (InputStream stream = resource.get().open()) {
+                ClipboardFormat format = pickFormat(extension);
+                if (format == null) {
+                    ModConstants.LOGGER.debug("Unknown schematic format for {}", schemLocation);
+                    continue;
+                }
+
+                try (ClipboardReader reader = format.getReader(stream)) {
+                    Clipboard clipboard = reader.read();
+                    return Optional.of(SchematicClipboardAdapter.toTemplate(clipboard));
+                }
+            } catch (IOException | RuntimeException e) {
+                ModConstants.LOGGER.warn("Failed to load schematic-backed test structure {}.", schemLocation, e);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static ClipboardFormat pickFormat(String extension) {
+        return switch (extension) {
+            case ".schem" -> ClipboardFormats.findByAlias("sponge");
+            case ".schematic" -> ClipboardFormats.findByAlias("schematic");
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/SchematicClipboardAdapter.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/SchematicClipboardAdapter.java
@@ -1,0 +1,103 @@
+package com.thunder.wildernessodysseyapi.gametest;
+
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.Region;
+import com.sk89q.worldedit.world.block.BaseBlock;
+import com.sk89q.worldedit.world.block.BlockStateHolder;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.mixin.StructureTemplateAccessor;
+import net.minecraft.core.Vec3i;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Converts a WorldEdit clipboard into an in-memory {@link StructureTemplate} without relying on .nbt files.
+ */
+public final class SchematicClipboardAdapter {
+    private SchematicClipboardAdapter() {
+    }
+
+    public static StructureTemplate toTemplate(Clipboard clipboard) {
+        StructureTemplate template = new StructureTemplate();
+        StructureTemplateAccessor accessor = (StructureTemplateAccessor) template;
+
+        Region region = clipboard.getRegion();
+        BlockVector3 min = region.getMinimumPoint();
+        BlockVector3 size = clipboard.getDimensions();
+
+        List<StructureTemplate.StructureBlockInfo> blocks = new ArrayList<>();
+        Map<BlockState, Integer> paletteIndex = new HashMap<>();
+        List<BlockState> paletteStates = new ArrayList<>();
+
+        for (int x = 0; x < size.getX(); x++) {
+            for (int y = 0; y < size.getY(); y++) {
+                for (int z = 0; z < size.getZ(); z++) {
+                    BlockVector3 cursor = min.add(x, y, z);
+                    BaseBlock baseBlock = clipboard.getFullBlock(cursor);
+                    BlockState state = convertState(baseBlock);
+                    if (state == null) {
+                        continue;
+                    }
+
+                    paletteIndex.computeIfAbsent(state, key -> {
+                        paletteStates.add(key);
+                        return paletteStates.size() - 1;
+                    });
+
+                    blocks.add(new StructureTemplate.StructureBlockInfo(
+                            new net.minecraft.core.BlockPos(x, y, z),
+                            state,
+                            null));
+                }
+            }
+        }
+
+        StructureTemplate.Palette palette = StructureTemplateAccessor.wildernessOdysseyApi$createPalette(blocks);
+        accessor.getPalettes().add(palette);
+        accessor.setSize(new Vec3i(size.getX(), size.getY(), size.getZ()));
+
+        return template;
+    }
+
+    private static BlockState convertState(BlockStateHolder<?> holder) {
+        ResourceLocation blockId = ResourceLocation.tryParse(holder.getBlockType().getId());
+        if (blockId == null || !net.minecraft.core.registries.BuiltInRegistries.BLOCK.containsKey(blockId)) {
+            return null;
+        }
+
+        BlockState state = net.minecraft.core.registries.BuiltInRegistries.BLOCK.get(blockId).defaultBlockState();
+        for (Map.Entry<com.sk89q.worldedit.registry.state.Property<?>, Object> entry : holder.getStates().entrySet()) {
+            Property<?> property = state.getBlock().getStateDefinition().getProperty(entry.getKey().getName());
+            if (property == null) {
+                continue;
+            }
+
+            Optional<?> parsed = property.getValue(String.valueOf(entry.getValue()));
+            if (parsed.isPresent()) {
+                state = applyProperty(state, property, parsed.get());
+            }
+        }
+
+        return state;
+    }
+
+    private static <T extends Comparable<T>> BlockState applyProperty(BlockState state, Property<T> property, Object value) {
+        try {
+            @SuppressWarnings("unchecked")
+            T cast = (T) value;
+            return state.setValue(property, cast);
+        } catch (ClassCastException e) {
+            ModConstants.LOGGER.debug("Failed to apply property {}={} for {}.", property.getName(), value, state, e);
+            return state;
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/GameTestStructureManagerMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/GameTestStructureManagerMixin.java
@@ -1,0 +1,32 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.thunder.wildernessodysseyapi.gametest.SchemGameTestStructureLoader;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Optional;
+
+/**
+ * Allows the GameTest structure manager to read schem/schematic files directly.
+ */
+@Mixin(StructureTemplateManager.class)
+public abstract class GameTestStructureManagerMixin {
+    @Shadow
+    private ResourceManager resourceManager;
+
+    @Inject(method = "loadFromResource", at = @At("HEAD"), cancellable = true)
+    private void wildernessOdysseyApi$loadSchem(ResourceLocation id,
+                                               CallbackInfoReturnable<Optional<StructureTemplate>> cir) {
+        Optional<StructureTemplate> fromSchem = SchemGameTestStructureLoader.tryLoad(this.resourceManager, id);
+        if (fromSchem.isPresent()) {
+            cir.setReturnValue(fromSchem);
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/GameTestStructureManagerMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/GameTestStructureManagerMixin.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
+import com.thunder.wildernessodysseyapi.gametest.GameTestTemplateFallbacks;
 import com.thunder.wildernessodysseyapi.gametest.SchemGameTestStructureLoader;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
@@ -24,9 +25,15 @@ public abstract class GameTestStructureManagerMixin {
     @Inject(method = "loadFromResource", at = @At("HEAD"), cancellable = true)
     private void wildernessOdysseyApi$loadSchem(ResourceLocation id,
                                                CallbackInfoReturnable<Optional<StructureTemplate>> cir) {
-        Optional<StructureTemplate> fromSchem = SchemGameTestStructureLoader.tryLoad(this.resourceManager, id);
-        if (fromSchem.isPresent()) {
-            cir.setReturnValue(fromSchem);
+        Optional<StructureTemplate> schem = SchemGameTestStructureLoader.tryLoad(this.resourceManager, id);
+        if (schem.isPresent()) {
+            cir.setReturnValue(schem);
+            return;
+        }
+
+        Optional<StructureTemplate> empty = GameTestTemplateFallbacks.maybeEmptyTemplate(id);
+        if (empty.isPresent()) {
+            cir.setReturnValue(empty);
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplateAccessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplateAccessor.java
@@ -1,0 +1,25 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import net.minecraft.core.Vec3i;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(StructureTemplate.class)
+public interface StructureTemplateAccessor {
+    @Accessor("palettes")
+    List<StructureTemplate.Palette> getPalettes();
+
+    @Accessor("entityInfoList")
+    List<StructureTemplate.StructureEntityInfo> getEntityInfoList();
+
+    @Accessor("size")
+    void setSize(Vec3i size);
+
+    @org.spongepowered.asm.mixin.gen.Invoker("<init>")
+    static StructureTemplate.Palette wildernessOdysseyApi$createPalette(List<StructureTemplate.StructureBlockInfo> blocks) {
+        throw new AssertionError();
+    }
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -14,7 +14,9 @@
       "ServerboundSetStructureBlockPacketMixin",
       "StarterStructureConfigMixin",
       "StarterStructureUtilMixin",
-      "StructureBlockEntityMixin"
+      "StructureBlockEntityMixin",
+      "GameTestStructureManagerMixin",
+      "StructureTemplateAccessor"
     ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary
- add a StructureTemplate accessor and loader to build in-memory templates from schem/schematic clipboards
- inject into StructureTemplateManager so GameTests resolve schem-backed structures without requiring .nbt files
- register the new mixins in the shared configuration

## Testing
- ./gradlew -q compileJava


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954aaf990688328a5ac8bbe253bed4b)