### PR TITLE
Fix palette accessor mixin for structure templates

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/SchematicClipboardAdapter.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/SchematicClipboardAdapter.java
@@ -7,6 +7,7 @@ import com.sk89q.worldedit.world.block.BaseBlock;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import com.thunder.wildernessodysseyapi.mixin.StructureTemplateAccessor;
+import com.thunder.wildernessodysseyapi.mixin.StructureTemplatePaletteAccessor;
 import net.minecraft.core.Vec3i;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.state.BlockState;
@@ -141,7 +142,7 @@ public final class SchematicClipboardAdapter {
 
     private static StructureTemplate.Palette createPalette(List<StructureTemplate.StructureBlockInfo> blocks) {
         try {
-            return StructureTemplateAccessor.wildernessOdysseyApi$createPalette(blocks);
+            return StructureTemplatePaletteAccessor.wildernessOdysseyApi$createPalette(blocks);
         } catch (Throwable ignored) {
             // Mixin not applied in test environments; fall back to reflective construction.
         }

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplateAccessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplateAccessor.java
@@ -17,9 +17,4 @@ public interface StructureTemplateAccessor {
 
     @Accessor("size")
     void setSize(Vec3i size);
-
-    @org.spongepowered.asm.mixin.gen.Invoker("<init>")
-    static StructureTemplate.Palette wildernessOdysseyApi$createPalette(List<StructureTemplate.StructureBlockInfo> blocks) {
-        throw new AssertionError();
-    }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplatePaletteAccessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureTemplatePaletteAccessor.java
@@ -1,0 +1,15 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.List;
+
+@Mixin(StructureTemplate.Palette.class)
+public interface StructureTemplatePaletteAccessor {
+    @Invoker("<init>")
+    static StructureTemplate.Palette wildernessOdysseyApi$createPalette(List<StructureTemplate.StructureBlockInfo> blocks) {
+        throw new AssertionError();
+    }
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -16,7 +16,8 @@
       "StarterStructureUtilMixin",
       "StructureBlockEntityMixin",
       "GameTestStructureManagerMixin",
-      "StructureTemplateAccessor"
+      "StructureTemplateAccessor",
+      "StructureTemplatePaletteAccessor"
     ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Summary
- add a dedicated mixin targeting StructureTemplate.Palette to expose its constructor
- remove the incorrect palette constructor invoker from StructureTemplateAccessor and register the new mixin
- update schematic clipboard adapter to use the palette mixin while keeping reflective fallback

## Testing
- ./gradlew test --no-daemon

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955c5fbae98832885e5a1c1e4ef5582)