### PR TITLE
Unify starter structure schematic pipeline

### DIFF
--- a/docs/starter-structure-schematics.md
+++ b/docs/starter-structure-schematics.md
@@ -1,0 +1,25 @@
+# Starter Structure schematic pipeline
+
+Wilderness Odyssey now treats Starter Structure schematics through a single abstraction so both `.schem` and `.nbt` exports behave the same during placement.
+
+## Detection and parsing
+
+- `StarterStructureSchematic` detects formats by file extension and falls back to `ClipboardFormats.findByFile` to keep odd or renamed schematics working.
+- Footprint dimensions come from the parsed schematic when available, then from the WorldEdit clipboard, and finally from entity offsets if nothing else is present. This ensures terrain blending always has a consistent target size.
+- Entities are collected for both formats:
+  - `.schem` files still use `SchematicEntityRestorer.backfillEntitiesFromSchem` to pull Create contraptions and other missing entities from the schematic payload.
+  - `.nbt` files read the `Entities` tag directly so they populate the same `List<Pair<BlockPos, Entity>>` used for restoration.
+
+Keep entity data in every exported bunker schematic. The shared entity list is the source of truth for post-placement spawning, and it is what preserves Create contraptions even when WorldEdit is unavailable.
+
+## Placement pipeline
+
+1. Load the schematic abstraction.
+2. If `starterStructureUseWorldEdit` is enabled *and* WorldEdit is present, attempt a WorldEdit paste. Otherwise, fall back to the vanilla Starter Structure placement.
+3. Run the common post-processing steps for **both** formats and paste paths:
+   - Spawn any restored entities from the unified list.
+   - Register the hostile-spawn deny zone around the bunker.
+   - Run the terrain blender (terrain replacer toggles remain format-agnostic).
+   - When WorldEdit pasted the bunker, parsed schematic buffers are cleared so Starter Structure will not double-place it.
+
+The WorldEdit toggle now only decides how the bunker is pasted; blending, spawn-guarding, and entity restoration always run.

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSchematic.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSchematic.java
@@ -1,0 +1,278 @@
+package com.thunder.wildernessodysseyapi.WorldGen.structure;
+
+import com.mojang.datafixers.util.Pair;
+import com.natamus.collective_common_neoforge.schematic.ParsedSchematicObject;
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormats;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Captures starter structure schematic metadata from either .schem or .nbt sources so the placement
+ * pipeline can operate on a unified abstraction.
+ */
+public final class StarterStructureSchematic {
+    public enum Format {
+        SCHEM,
+        NBT,
+        UNKNOWN
+    }
+
+    private final Path path;
+    private final Format format;
+    private final ClipboardFormat clipboardFormat;
+    private final ParsedSchematicObject parsed;
+    private final StarterStructureTerrainBlender.Footprint footprint;
+    private final List<Pair<BlockPos, Entity>> entities;
+    private final boolean shouldSpawnEntities;
+
+    private StarterStructureSchematic(Path path,
+                                      Format format,
+                                      ClipboardFormat clipboardFormat,
+                                      ParsedSchematicObject parsed,
+                                      StarterStructureTerrainBlender.Footprint footprint,
+                                      List<Pair<BlockPos, Entity>> entities) {
+        this.path = path;
+        this.format = format;
+        this.clipboardFormat = clipboardFormat;
+        this.parsed = parsed;
+        this.footprint = footprint;
+        this.entities = entities == null ? List.of() : List.copyOf(entities);
+        this.shouldSpawnEntities = !this.entities.isEmpty();
+    }
+
+    public static StarterStructureSchematic capture(ServerLevel level, Path path, BlockPos structurePos,
+                                                    ParsedSchematicObject parsed) {
+        Format format = detectFormat(path);
+        ClipboardFormat clipboardFormat = detectClipboardFormat(path, format);
+        if (format == Format.UNKNOWN && clipboardFormat != null) {
+            format = inferFormatFromClipboard(clipboardFormat);
+        }
+        StarterStructureTerrainBlender.Footprint footprint = readFootprint(parsed, clipboardFormat, path);
+        List<Pair<BlockPos, Entity>> entities = readEntities(level, path, structurePos, parsed, format);
+        if (footprint == null) {
+            footprint = deriveFootprintFromEntities(entities, structurePos);
+        }
+
+        return new StarterStructureSchematic(path, format, clipboardFormat, parsed, footprint, entities);
+    }
+
+    public Path path() {
+        return path;
+    }
+
+    public Format format() {
+        return format;
+    }
+
+    public ClipboardFormat clipboardFormat() {
+        return clipboardFormat;
+    }
+
+    public ParsedSchematicObject parsed() {
+        return parsed;
+    }
+
+    public StarterStructureTerrainBlender.Footprint footprint() {
+        return footprint;
+    }
+
+    public List<Pair<BlockPos, Entity>> entities() {
+        return entities;
+    }
+
+    public boolean shouldSpawnEntities() {
+        return shouldSpawnEntities;
+    }
+
+    /**
+     * Clears parsed schematic buffers so Starter Structure does not attempt to paste a second time
+     * after WorldEdit already handled placement.
+     */
+    public void clearParsedAfterWorldEdit() {
+        if (parsed == null) {
+            return;
+        }
+        parsed.blocks = List.of();
+        parsed.blockEntityPositions = List.of();
+        parsed.entities = List.of();
+        parsed.parsedCorrectly = false;
+    }
+
+    private static Format detectFormat(Path path) {
+        if (path == null) {
+            return Format.UNKNOWN;
+        }
+
+        String fileName = path.getFileName().toString().toLowerCase(Locale.ROOT);
+        if (fileName.endsWith(".schem")) {
+            return Format.SCHEM;
+        }
+        if (fileName.endsWith(".nbt")) {
+            return Format.NBT;
+        }
+        return Format.UNKNOWN;
+    }
+
+    private static ClipboardFormat detectClipboardFormat(Path path, Format format) {
+        if (path == null) {
+            return null;
+        }
+
+        ClipboardFormat detected = ClipboardFormats.findByFile(path.toFile());
+        if (detected != null) {
+            return detected;
+        }
+
+        if (format == Format.NBT) {
+            return ClipboardFormats.findByAlias("schematic");
+        }
+
+        return null;
+    }
+
+    private static Format inferFormatFromClipboard(ClipboardFormat clipboardFormat) {
+        for (String alias : clipboardFormat.getAliases()) {
+            String lower = alias.toLowerCase(Locale.ROOT);
+            if (lower.contains("schem") || lower.contains("schematic")) {
+                return Format.SCHEM;
+            }
+            if (lower.contains("nbt")) {
+                return Format.NBT;
+            }
+        }
+        return Format.UNKNOWN;
+    }
+
+    private static StarterStructureTerrainBlender.Footprint readFootprint(ParsedSchematicObject parsed,
+                                                                          ClipboardFormat clipboardFormat,
+                                                                          Path path) {
+        StarterStructureTerrainBlender.Footprint footprint = tryReadFootprintFromParsed(parsed);
+        if (footprint != null) {
+            return footprint;
+        }
+
+        if (clipboardFormat == null || path == null || !Files.isRegularFile(path)) {
+            return null;
+        }
+
+        try (InputStream in = Files.newInputStream(path);
+             ClipboardReader reader = clipboardFormat.getReader(in)) {
+            Clipboard clipboard = reader.read();
+            BlockVector3 dimensions = clipboard.getDimensions();
+            if (dimensions.getX() > 0 && dimensions.getY() > 0 && dimensions.getZ() > 0) {
+                return new StarterStructureTerrainBlender.Footprint(
+                        dimensions.getX(),
+                        dimensions.getY(),
+                        dimensions.getZ());
+            }
+        } catch (Exception e) {
+            ModConstants.LOGGER.debug("[Starter Structure compat] Failed to read schematic dimensions from {}.", path, e);
+        }
+
+        return null;
+    }
+
+    private static StarterStructureTerrainBlender.Footprint tryReadFootprintFromParsed(ParsedSchematicObject parsed) {
+        if (parsed == null) {
+            return null;
+        }
+
+        try {
+            int width = tryReadDimension(parsed, "getWidth", "width");
+            int height = tryReadDimension(parsed, "getHeight", "height");
+            int length = tryReadDimension(parsed, "getLength", "length");
+            if (width > 0 && height > 0 && length > 0) {
+                return new StarterStructureTerrainBlender.Footprint(width, height, length);
+            }
+        } catch (Exception e) {
+            ModConstants.LOGGER.debug("[Starter Structure compat] Failed to read schematic dimensions for blending.", e);
+        }
+
+        return null;
+    }
+
+    private static int tryReadDimension(ParsedSchematicObject parsed, String getterName, String fieldName) throws Exception {
+        try {
+            java.lang.reflect.Method getter = parsed.getClass().getMethod(getterName);
+            getter.setAccessible(true);
+            Object result = getter.invoke(parsed);
+            if (result instanceof Number number) {
+                return number.intValue();
+            }
+        } catch (NoSuchMethodException ignored) {
+            // Fall back to field lookup
+        }
+
+        java.lang.reflect.Field field = parsed.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Object value = field.get(parsed);
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        return -1;
+    }
+
+    private static List<Pair<BlockPos, Entity>> readEntities(ServerLevel level, Path path, BlockPos structurePos,
+                                                             ParsedSchematicObject parsed, Format format) {
+        if (parsed != null && parsed.entities != null && !parsed.entities.isEmpty()) {
+            return List.copyOf(parsed.entities);
+        }
+
+        if (format == Format.SCHEM) {
+            return SchematicEntityRestorer.backfillEntitiesFromSchem(level, path, false, structurePos, parsed);
+        }
+
+        if (format == Format.NBT) {
+            return SchematicEntityRestorer.extractEntitiesFromNbt(level, path, structurePos);
+        }
+
+        return List.of();
+    }
+
+    private static StarterStructureTerrainBlender.Footprint deriveFootprintFromEntities(List<Pair<BlockPos, Entity>> entities, BlockPos origin) {
+        if (entities == null || entities.isEmpty() || origin == null) {
+            return null;
+        }
+
+        int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE, minZ = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE, maxY = Integer.MIN_VALUE, maxZ = Integer.MIN_VALUE;
+
+        for (Pair<BlockPos, Entity> entry : entities) {
+            if (entry == null || entry.getFirst() == null) {
+                continue;
+            }
+            BlockPos rel = entry.getFirst().subtract(origin);
+            minX = Math.min(minX, rel.getX());
+            minY = Math.min(minY, rel.getY());
+            minZ = Math.min(minZ, rel.getZ());
+            maxX = Math.max(maxX, rel.getX());
+            maxY = Math.max(maxY, rel.getY());
+            maxZ = Math.max(maxZ, rel.getZ());
+        }
+
+        if (minX == Integer.MAX_VALUE) {
+            return null;
+        }
+
+        int width = (maxX - minX) + 1;
+        int height = (maxY - minY) + 1;
+        int length = (maxZ - minZ) + 1;
+        if (width <= 0 || height <= 0 || length <= 0) {
+            return null;
+        }
+
+        return new StarterStructureTerrainBlender.Footprint(width, height, length);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSpawnGuard.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSpawnGuard.java
@@ -22,6 +22,11 @@ public final class StarterStructureSpawnGuard {
     private StarterStructureSpawnGuard() {
     }
 
+    /** Clears all tracked spawn deny zones. Primarily used by automated tests. */
+    public static void clearAll() {
+        ZONES.clear();
+    }
+
     public static void registerSpawnDenyZone(ServerLevel level, BlockPos origin) {
         if (!StructureConfig.PREVENT_STARTER_STRUCTURE_HOSTILES.get()) return;
         if (level == null || origin == null) return;

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureWorldEditPlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureWorldEditPlacer.java
@@ -12,6 +12,7 @@ import com.sk89q.worldedit.session.ClipboardHolder;
 import com.sk89q.worldedit.session.PasteBuilder;
 import com.sk89q.worldedit.world.World;
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureSchematic.Format;
 import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -32,14 +33,20 @@ public final class StarterStructureWorldEditPlacer {
      * Attempts to paste the given schematic with WorldEdit. Returns {@code true} when WorldEdit successfully
      * performs the paste, {@code false} otherwise.
      */
-    public static boolean placeWithWorldEdit(ServerLevel serverLevel, Path schematicPath, BlockPos origin, boolean isNbtFormat) {
+    public static boolean placeWithWorldEdit(ServerLevel serverLevel, StarterStructureSchematic schematic, BlockPos origin) {
         if (!StructureConfig.STARTER_STRUCTURE_USE_WORLDEDIT.get()) return false;
         if (!ModList.get().isLoaded("worldedit")) return false;
-        if (serverLevel == null || schematicPath == null || !Files.isRegularFile(schematicPath)) return false;
+        if (serverLevel == null || schematic == null) return false;
+
+        Path schematicPath = schematic.path();
+        if (schematicPath == null || !Files.isRegularFile(schematicPath)) return false;
 
         try {
-            ClipboardFormat format = ClipboardFormats.findByFile(schematicPath.toFile());
-            if (format == null && isNbtFormat) {
+            ClipboardFormat format = schematic.clipboardFormat();
+            if (format == null) {
+                format = ClipboardFormats.findByFile(schematicPath.toFile());
+            }
+            if (format == null && schematic.format() == Format.NBT) {
                 format = ClipboardFormats.findByAlias("schematic");
             }
             if (format == null) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/SpawnBunkerGameTests.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/SpawnBunkerGameTests.java
@@ -1,16 +1,46 @@
 package com.thunder.wildernessodysseyapi.gametest;
 
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormats;
+import com.sk89q.worldedit.extent.clipboard.io.ClipboardWriter;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import com.sk89q.worldedit.world.block.BlockTypes;
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.spawn.SpawnBunkerPlacer;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.SchematicEntityRestorer;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.NBTStructurePlacer;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureSchematic;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureSpawnGuard;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureTerrainBlender;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureWorldEditPlacer;
+import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.DoubleTag;
+import net.minecraft.nbt.IntTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
 import net.neoforged.neoforge.gametest.GameTestHolder;
 import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+import net.neoforged.fml.ModList;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 
 /**
  * GameTests that verify the spawn bunker can be pasted with vanilla template mechanics.
@@ -19,6 +49,7 @@ import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
 @PrefixGameTestTemplate(false)
 public class SpawnBunkerGameTests {
     private static final String BATCH = "bunker";
+    private static final String ENTITY_ID = "minecraft:armor_stand";
 
     @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
     public static void bunkerSpawnsBlocks(GameTestHelper helper) {
@@ -46,6 +77,75 @@ public class SpawnBunkerGameTests {
             helper.assertTrue(foundCryo, "No cryo tubes were found inside the pasted bunker footprint.");
             helper.succeed();
         });
+    }
+
+    @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
+    public static void nbtSchematicRestoresEntities(GameTestHelper helper) {
+        try {
+            StarterStructureSpawnGuard.clearAll();
+            Path schematicPath = createEntityNbt();
+            PlacementRun run = runPlacementPipeline(helper, schematicPath, false, true);
+
+            helper.runAtTickTime(2, () -> {
+                helper.assertTrue(hasArmorStand(helper.getLevel(), run.origin()),
+                        "Armor stand from NBT schematic was not spawned.");
+                helper.assertTrue(StarterStructureSpawnGuard.isDenied(helper.getLevel(), run.origin()),
+                        "Spawn guard zone was not registered after NBT placement.");
+                helper.assertTrue(run.schematic().footprint() != null,
+                        "Derived footprint for NBT schematic should not be null.");
+                helper.succeed();
+            });
+        } catch (Exception e) {
+            helper.fail("Failed to prepare NBT schematic for test: " + e.getMessage());
+        }
+    }
+
+    @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
+    public static void schemPlacementWithoutWorldEdit(GameTestHelper helper) {
+        try {
+            StarterStructureSpawnGuard.clearAll();
+            Path schemPath = createEntitySchem();
+            PlacementRun run = runPlacementPipeline(helper, schemPath, false, true);
+
+            helper.runAtTickTime(2, () -> {
+                helper.assertFalse(run.pastedWithWorldEdit(),
+                        "WorldEdit should be bypassed when disabled in config.");
+                helper.assertTrue(hasArmorStand(helper.getLevel(), run.origin()),
+                        "Armor stand from schem should spawn even without WorldEdit.");
+                helper.assertTrue(isBlended(helper.getLevel(), run.origin()),
+                        "Blending did not affect the surrounding terrain for schem placement.");
+                helper.succeed();
+            });
+        } catch (Exception e) {
+            helper.fail("Failed to prepare schem for test: " + e.getMessage());
+        }
+    }
+
+    @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 400)
+    public static void schemPlacementWithWorldEdit(GameTestHelper helper) {
+        if (!ModList.get().isLoaded("worldedit")) {
+            helper.succeed();
+            return;
+        }
+        try {
+            StarterStructureSpawnGuard.clearAll();
+            Path schemPath = createEntitySchem();
+            PlacementRun run = runPlacementPipeline(helper, schemPath, true, true);
+
+            helper.runAtTickTime(2, () -> {
+                helper.assertTrue(run.pastedWithWorldEdit(),
+                        "WorldEdit should paste schematics when enabled and available.");
+                helper.assertTrue(helper.getLevel().getBlockState(run.origin()).isSolid(),
+                        "WorldEdit paste did not leave any solid blocks at the origin.");
+                helper.assertTrue(hasArmorStand(helper.getLevel(), run.origin()),
+                        "Entities from schem should still be restored after WorldEdit placement.");
+                helper.assertTrue(StarterStructureSpawnGuard.isDenied(helper.getLevel(), run.origin()),
+                        "Spawn guard zone should be registered after WorldEdit placement.");
+                helper.succeed();
+            });
+        } catch (Exception e) {
+            helper.fail("Failed to prepare WorldEdit schem for test: " + e.getMessage());
+        }
     }
 
     private static NBTStructurePlacer.PlacementResult placeBunker(GameTestHelper helper) {
@@ -111,4 +211,112 @@ public class SpawnBunkerGameTests {
         }
         return false;
     }
+
+    private static PlacementRun runPlacementPipeline(GameTestHelper helper, Path path, boolean allowWorldEdit, boolean placeFallbackBlock) throws IOException {
+        ServerLevel level = helper.getLevel();
+        BlockPos origin = helper.absolutePos(BlockPos.ZERO.above(60));
+        StarterStructureSchematic schematic = StarterStructureSchematic.capture(level, path, origin, null);
+
+        boolean previousWorldEdit = StructureConfig.STARTER_STRUCTURE_USE_WORLDEDIT.get();
+        int previousCoverDepth = StructureConfig.STARTER_STRUCTURE_EXTRA_COVER_DEPTH.get();
+        StructureConfig.STARTER_STRUCTURE_USE_WORLDEDIT.set(allowWorldEdit);
+        StructureConfig.STARTER_STRUCTURE_EXTRA_COVER_DEPTH.set(0);
+
+        boolean pastedWithWorldEdit;
+        try {
+            pastedWithWorldEdit = StarterStructureWorldEditPlacer.placeWithWorldEdit(level, schematic, origin);
+            if (!pastedWithWorldEdit && placeFallbackBlock) {
+                level.setBlock(origin, Blocks.STONE.defaultBlockState(), 2);
+            }
+
+            StarterStructureSpawnGuard.registerSpawnDenyZone(level, origin);
+            StarterStructureTerrainBlender.blendPlacedStructure(level, origin, schematic.footprint());
+            SchematicEntityRestorer.spawnRestoredEntities(level, schematic.entities());
+        } finally {
+            StructureConfig.STARTER_STRUCTURE_USE_WORLDEDIT.set(previousWorldEdit);
+            StructureConfig.STARTER_STRUCTURE_EXTRA_COVER_DEPTH.set(previousCoverDepth);
+        }
+
+        return new PlacementRun(origin, schematic, pastedWithWorldEdit);
+    }
+
+    private static Path createEntityNbt() throws IOException {
+        Path path = Files.createTempFile("starter-structure-entity-", ".nbt");
+        CompoundTag root = new CompoundTag();
+        root.put("entities", buildEntityList(BlockPos.ZERO));
+        try (OutputStream out = Files.newOutputStream(path)) {
+            NbtIo.writeCompressed(root, out);
+        }
+        path.toFile().deleteOnExit();
+        return path;
+    }
+
+    private static Path createEntitySchem() throws IOException, WorldEditException {
+        ClipboardFormat format = ClipboardFormats.findByAlias("sponge");
+        if (format == null) {
+            throw new IOException("Sponge schematic format is unavailable.");
+        }
+
+        BlockArrayClipboard clipboard = new BlockArrayClipboard(new CuboidRegion(BlockVector3.ZERO, BlockVector3.ZERO));
+        clipboard.setOrigin(BlockVector3.ZERO);
+        clipboard.setBlock(BlockVector3.ZERO, BlockTypes.STONE.getDefaultState());
+
+        Path path = Files.createTempFile("starter-structure-entity-", ".schem");
+        try (OutputStream out = Files.newOutputStream(path);
+             ClipboardWriter writer = format.getWriter(out)) {
+            writer.write(clipboard);
+        }
+
+        injectEntitiesIntoSchematic(path, BlockPos.ZERO);
+        path.toFile().deleteOnExit();
+        return path;
+    }
+
+    private static void injectEntitiesIntoSchematic(Path path, BlockPos relativePos) throws IOException {
+        CompoundTag outer = NbtIo.readCompressed(path, NbtAccounter.unlimitedHeap());
+        CompoundTag target = outer.contains("Schematic", 10) ? outer.getCompound("Schematic") : outer;
+        target.put("Entities", buildEntityList(relativePos));
+        if (outer != target) {
+            outer.put("Schematic", target);
+        }
+        try (OutputStream out = Files.newOutputStream(path)) {
+            NbtIo.writeCompressed(outer, out);
+        }
+    }
+
+    private static ListTag buildEntityList(BlockPos relativePos) {
+        CompoundTag entityData = new CompoundTag();
+        entityData.putString("id", ENTITY_ID);
+
+        ListTag blockPos = new ListTag();
+        blockPos.add(IntTag.valueOf(relativePos.getX()));
+        blockPos.add(IntTag.valueOf(relativePos.getY()));
+        blockPos.add(IntTag.valueOf(relativePos.getZ()));
+
+        ListTag pos = new ListTag();
+        pos.add(DoubleTag.valueOf(relativePos.getX() + 0.5D));
+        pos.add(DoubleTag.valueOf(relativePos.getY()));
+        pos.add(DoubleTag.valueOf(relativePos.getZ() + 0.5D));
+
+        CompoundTag wrapper = new CompoundTag();
+        wrapper.put("blockPos", blockPos);
+        wrapper.put("Pos", pos);
+        wrapper.put("nbt", entityData);
+
+        ListTag entities = new ListTag();
+        entities.add(wrapper);
+        return entities;
+    }
+
+    private static boolean hasArmorStand(ServerLevel level, BlockPos origin) {
+        AABB search = new AABB(origin).inflate(2.0D);
+        return !level.getEntities(EntityType.ARMOR_STAND, search, entity -> true).isEmpty();
+    }
+
+    private static boolean isBlended(ServerLevel level, BlockPos origin) {
+        BlockPos sample = origin.offset(3, 0, 0);
+        return !level.getBlockState(sample).isAir();
+    }
+
+    private record PlacementRun(BlockPos origin, StarterStructureSchematic schematic, boolean pastedWithWorldEdit) { }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
@@ -3,13 +3,12 @@ package com.thunder.wildernessodysseyapi.mixin;
 import com.natamus.starterstructure_common_neoforge.util.Util;
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.SchematicEntityRestorer;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureSchematic;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureTerrainBlender;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureSpawnGuard;
 import com.natamus.collective_common_neoforge.schematic.ParsedSchematicObject;
-import com.mojang.datafixers.util.Pair;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.entity.Entity;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureWorldEditPlacer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -19,16 +18,10 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.nio.file.Path;
-import java.util.List;
 
 @Mixin(value = Util.class, remap = false)
 public class StarterStructureUtilMixin {
-    private static final ThreadLocal<StarterStructureTerrainBlender.Footprint> wildernessOdysseyApi$footprint = new ThreadLocal<>();
-    private static final ThreadLocal<List<Pair<BlockPos, Entity>>> wildernessOdysseyApi$restoredEntities = new ThreadLocal<>();
-    private static final ThreadLocal<Path> wildernessOdysseyApi$schematicPath = new ThreadLocal<>();
-    private static final ThreadLocal<Boolean> wildernessOdysseyApi$isNbtFormat = new ThreadLocal<>();
-    private static final ThreadLocal<ParsedSchematicObject> wildernessOdysseyApi$parsedSchematic = new ThreadLocal<>();
+    private static final ThreadLocal<StarterStructureSchematic> wildernessOdysseyApi$schematic = new ThreadLocal<>();
 
     @Inject(
             method = "generateSchematic",
@@ -47,88 +40,36 @@ public class StarterStructureUtilMixin {
                                                                     boolean automaticCenter,
                                                                     BlockPos structurePos,
                                                                     ParsedSchematicObject parsedSchematicObject,
-                                                                    FileInputStream fileInputStream) {
-        wildernessOdysseyApi$footprint.set(readFootprint(parsedSchematicObject));
-        Path schematicPath = schematicFile.toPath();
-        boolean isNbtFormat = schematicFile.getName().endsWith(".nbt");
-        List<Pair<BlockPos, Entity>> restored = SchematicEntityRestorer.backfillEntitiesFromSchem(
-                serverLevel, schematicPath, isNbtFormat, structurePos, parsedSchematicObject);
-        wildernessOdysseyApi$restoredEntities.set(restored);
-        wildernessOdysseyApi$schematicPath.set(schematicPath);
-        wildernessOdysseyApi$isNbtFormat.set(isNbtFormat);
-        wildernessOdysseyApi$parsedSchematic.set(parsedSchematicObject);
+                                                                  FileInputStream fileInputStream) {
+        StarterStructureSchematic schematic = StarterStructureSchematic.capture(
+                serverLevel, schematicFile.toPath(), structurePos, parsedSchematicObject);
+        wildernessOdysseyApi$schematic.set(schematic);
     }
 
     @Inject(method = "generateSchematic", at = @At("RETURN"))
     private static void wildernessOdysseyApi$triggerTerrainReplacer(ServerLevel serverLevel, CallbackInfoReturnable<BlockPos> cir) {
         BlockPos structureOrigin = cir.getReturnValue();
-        if (structureOrigin != null) {
-            Path schematicPath = wildernessOdysseyApi$schematicPath.get();
-            ParsedSchematicObject parsed = wildernessOdysseyApi$parsedSchematic.get();
+        StarterStructureSchematic schematic = wildernessOdysseyApi$schematic.get();
+        if (structureOrigin != null && schematic != null) {
             boolean pastedWithWorldEdit = StarterStructureWorldEditPlacer.placeWithWorldEdit(
-                    serverLevel, schematicPath, structureOrigin, Boolean.TRUE.equals(wildernessOdysseyApi$isNbtFormat.get()));
+                    serverLevel, schematic, structureOrigin);
 
             ModConstants.LOGGER.debug("[Starter Structure compat] Bypassing terrain replacer for bunker; running blending pass instead.");
             StarterStructureSpawnGuard.registerSpawnDenyZone(serverLevel, structureOrigin);
             StarterStructureTerrainBlender.blendPlacedStructure(serverLevel, structureOrigin,
-                    wildernessOdysseyApi$footprint.get());
+                    schematic.footprint());
 
-            int spawned = pastedWithWorldEdit
-                    ? 0
-                    : SchematicEntityRestorer.spawnRestoredEntities(serverLevel, wildernessOdysseyApi$restoredEntities.get());
+            int spawned = schematic.shouldSpawnEntities()
+                    ? SchematicEntityRestorer.spawnRestoredEntities(serverLevel, schematic.entities())
+                    : 0;
             if (spawned == 0) {
                 ModConstants.LOGGER.debug("[Starter Structure compat] No missing schematic entities needed spawning.");
             }
 
-            if (pastedWithWorldEdit && parsed != null) {
-                parsed.blocks = List.of();
-                parsed.blockEntityPositions = List.of();
-                parsed.entities = List.of();
-                parsed.parsedCorrectly = false;
+            if (pastedWithWorldEdit) {
+                schematic.clearParsedAfterWorldEdit();
             }
         }
-        wildernessOdysseyApi$footprint.remove();
-        wildernessOdysseyApi$restoredEntities.remove();
-        wildernessOdysseyApi$schematicPath.remove();
-        wildernessOdysseyApi$isNbtFormat.remove();
-        wildernessOdysseyApi$parsedSchematic.remove();
-    }
-
-    private static StarterStructureTerrainBlender.Footprint readFootprint(ParsedSchematicObject parsed) {
-        if (parsed == null) {
-            return null;
-        }
-        try {
-            int width = tryReadDimension(parsed, "getWidth", "width");
-            int height = tryReadDimension(parsed, "getHeight", "height");
-            int length = tryReadDimension(parsed, "getLength", "length");
-            if (width > 0 && height > 0 && length > 0) {
-                return new StarterStructureTerrainBlender.Footprint(width, height, length);
-            }
-        } catch (Exception e) {
-            ModConstants.LOGGER.debug("[Starter Structure compat] Failed to read schematic dimensions for blending.", e);
-        }
-        return null;
-    }
-
-    private static int tryReadDimension(ParsedSchematicObject parsed, String getterName, String fieldName) throws Exception {
-        try {
-            java.lang.reflect.Method getter = parsed.getClass().getMethod(getterName);
-            getter.setAccessible(true);
-            Object result = getter.invoke(parsed);
-            if (result instanceof Number number) {
-                return number.intValue();
-            }
-        } catch (NoSuchMethodException ignored) {
-            // Fall back to field lookup
-        }
-
-        java.lang.reflect.Field field = parsed.getClass().getDeclaredField(fieldName);
-        field.setAccessible(true);
-        Object value = field.get(parsed);
-        if (value instanceof Number number) {
-            return number.intValue();
-        }
-        return -1;
+        wildernessOdysseyApi$schematic.remove();
     }
 }


### PR DESCRIPTION
## Summary
- Introduced a StarterStructureSchematic abstraction to detect schematic formats, capture footprints, and unify entity extraction for both .schem and .nbt sources.
- Normalized the starter structure placement mixin so entity restoration, spawn-guarding, and terrain blending run for every format and paste path while WorldEdit usage remains a configurable paste toggle.
- Added NBT entity extraction, a spawn-guard reset helper, expanded spawn bunker GameTests for schem/nbt with and without WorldEdit, and documented the unified pipeline and entity requirements.

## Testing
- `./gradlew test --console=plain`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958a4c8267c832887780e6b763801e0)