### PR TITLE
Fix compilation issues after migration

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
@@ -54,7 +54,7 @@ public class AIClient {
     }
 
     private void loadStory() {
-        try (InputStream in = requestperfadvice.class.getClassLoader().getResourceAsStream("ai_config.yaml")) {
+        try (InputStream in = AIClient.class.getClassLoader().getResourceAsStream("ai_config.yaml")) {
             if (in == null) {
                 seedFallbackLore();
                 return;

--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -223,7 +223,6 @@ public class WildernessOdysseyAPIMainModClass {
         if (event.getConfig().getSpec() == AsyncThreadingConfig.CONFIG_SPEC) {
             AsyncTaskManager.initialize(AsyncThreadingConfig.values());
         }
-        }
         if (event.getConfig().getSpec() == StructureBlockConfig.CONFIG_SPEC) {
             StructureBlockSettings.reloadFromConfig();
         }
@@ -233,18 +232,8 @@ public class WildernessOdysseyAPIMainModClass {
     }
 
     public void onConfigReloaded(ModConfigEvent.Reloading event) {
-        if (event.getConfig().getSpec() == ModDataCacheConfig.CONFIG_SPEC) {
-            ModDataCache.initialize();
-        }
         if (event.getConfig().getSpec() == AsyncThreadingConfig.CONFIG_SPEC) {
             AsyncTaskManager.initialize(AsyncThreadingConfig.values());
-        }
-        if (event.getConfig().getSpec() == ChunkStreamingConfig.CONFIG_SPEC && chunkStorageRoot != null) {
-            ChunkStreamingConfig.ChunkConfigValues chunkConfig = ChunkStreamingConfig.values();
-            BufferPool.configure(chunkConfig);
-            IoExecutors.initialize(chunkConfig);
-            ChunkStreamManager.initialize(chunkConfig, new DiskChunkStorageAdapter(chunkStorageRoot, chunkConfig.compressionLevel(), chunkConfig.compressionCodec()));
-            ChunkDeltaTracker.configure(chunkConfig);
         }
         if (event.getConfig().getSpec() == StructureBlockConfig.CONFIG_SPEC) {
             StructureBlockSettings.reloadFromConfig();

--- a/src/main/java/com/thunder/wildernessodysseyapi/globalchat/AnalyticsSnapshot.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/globalchat/AnalyticsSnapshot.java
@@ -1,0 +1,27 @@
+package com.thunder.wildernessodysseyapi.globalchat;
+
+import java.util.List;
+
+/**
+ * Lightweight analytics payload describing current server health and players.
+ * Uses public fields for simple JSON serialization.
+ */
+public class AnalyticsSnapshot {
+    public long timestampMillis;
+    public List<PlayerStats> players;
+    public int playerCount;
+    public int maxPlayers;
+    public long usedMemoryMb;
+    public long totalMemoryMb;
+    public long peakMemoryMb;
+    public int recommendedMemoryMb;
+    public long worstTickMillis;
+    public double cpuLoad;
+    public boolean overloaded;
+    public String overloadedReason;
+
+    public static class PlayerStats {
+        public String uuid;
+        public String name;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/globalchat/AnalyticsSyncView.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/globalchat/AnalyticsSyncView.java
@@ -1,0 +1,19 @@
+package com.thunder.wildernessodysseyapi.globalchat;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Snapshot of recent analytics events to keep the relay in sync.
+ */
+public class AnalyticsSyncView {
+    public HealthStatus status = HealthStatus.HEALTHY;
+    public List<String> joinedPlayerIds = Collections.emptyList();
+    public List<String> leftPlayerIds = Collections.emptyList();
+
+    public enum HealthStatus {
+        HEALTHY,
+        DEGRADED,
+        UNHEALTHY
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/globalchat/server/GlobalChatRelayServer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/globalchat/server/GlobalChatRelayServer.java
@@ -2,6 +2,8 @@ package com.thunder.wildernessodysseyapi.globalchat.server;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.thunder.wildernessodysseyapi.globalchat.AnalyticsSnapshot;
+import com.thunder.wildernessodysseyapi.globalchat.AnalyticsSyncView;
 import com.thunder.wildernessodysseyapi.globalchat.GlobalChatPacket;
 
 import java.io.BufferedReader;

--- a/src/main/java/com/thunder/wildernessodysseyapi/io/CompressionCodec.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/io/CompressionCodec.java
@@ -1,0 +1,10 @@
+package com.thunder.wildernessodysseyapi.io;
+
+/**
+ * Supported compression backends for structure data.
+ */
+public enum CompressionCodec {
+    VANILLA_GZIP,
+    ZSTD,
+    LZ4
+}


### PR DESCRIPTION
## Summary
- fix config load/reload handlers to stop referencing removed systems
- add lightweight analytics payload definitions for the global chat relay and wire imports
- simplify NBT compression utilities with a shared compression codec enum and standard buffering

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959dfcd88488328b6182ae88563661c)