### PR TITLE
Add Create schematic cannon fallback for starter bunker

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureCreateCannonPlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureCreateCannonPlacer.java
@@ -1,0 +1,75 @@
+package com.thunder.wildernessodysseyapi.WorldGen.structure;
+
+import com.simibubi.create.content.schematics.SchematicItem;
+import com.simibubi.create.foundation.utility.CreatePaths;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import net.minecraft.world.phys.Vec3i;
+import net.neoforged.fml.ModList;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * Attempts to place starter structures using Create's schematic cannon pipeline before falling back to
+ * WorldEdit or vanilla template placement.
+ */
+public final class StarterStructureCreateCannonPlacer {
+    private static final String OWNER_NAMESPACE = "wildernessodysseyapi";
+
+    private StarterStructureCreateCannonPlacer() {
+    }
+
+    /**
+     * Attempts to paste the given schematic using Create's schematic cannon format. Returns {@code true}
+     * when Create is present and the placement succeeds.
+     */
+    public static boolean placeWithSchematicannon(ServerLevel serverLevel, StarterStructureSchematic schematic, BlockPos origin) {
+        if (!ModList.get().isLoaded("create")) return false;
+        if (serverLevel == null || schematic == null || origin == null) return false;
+
+        Path schematicPath = schematic.path();
+        if (schematicPath == null || !Files.isRegularFile(schematicPath)) return false;
+
+        String fileName = schematicPath.getFileName().toString();
+        Path cannonDir = CreatePaths.UPLOADED_SCHEMATICS_DIR.resolve(OWNER_NAMESPACE);
+        try {
+            Files.createDirectories(cannonDir);
+            Path cannonPath = cannonDir.resolve(fileName);
+            Files.copy(schematicPath, cannonPath, StandardCopyOption.REPLACE_EXISTING);
+
+            ItemStack blueprint = SchematicItem.create(serverLevel, fileName, OWNER_NAMESPACE);
+            CompoundTag tag = blueprint.getOrCreateTag();
+            tag.putBoolean("Deployed", true);
+            tag.put("Anchor", NbtUtils.writeBlockPos(origin));
+            tag.putString("Rotation", Rotation.NONE.name());
+            tag.putString("Mirror", Mirror.NONE.name());
+            blueprint.setTag(tag);
+
+            StructureTemplate template = SchematicItem.loadSchematic(serverLevel, blueprint);
+            StructurePlaceSettings settings = SchematicItem.getSettings(blueprint, true);
+            Vec3i size = template.getSize();
+            if (size.getX() == 0 || size.getY() == 0 || size.getZ() == 0) {
+                ModConstants.LOGGER.debug("[Starter Structure compat] Skipping Create schematic cannon placement for {} because the template is empty.", schematicPath);
+                return false;
+            }
+            template.placeInWorld(serverLevel, origin, origin, settings, serverLevel.random, Block.UPDATE_CLIENTS);
+
+            ModConstants.LOGGER.info("[Starter Structure compat] Pasted starter bunker with Create schematic cannon at {}.", origin);
+            return true;
+        } catch (Exception e) {
+            ModConstants.LOGGER.warn("[Starter Structure compat] Create schematic cannon placement failed for {}.", schematicPath, e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StarterStructureUtilMixin.java
@@ -10,6 +10,7 @@ import com.natamus.collective_common_neoforge.schematic.ParsedSchematicObject;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureWorldEditPlacer;
+import com.thunder.wildernessodysseyapi.WorldGen.structure.StarterStructureCreateCannonPlacer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -51,7 +52,9 @@ public class StarterStructureUtilMixin {
         BlockPos structureOrigin = cir.getReturnValue();
         StarterStructureSchematic schematic = wildernessOdysseyApi$schematic.get();
         if (structureOrigin != null && schematic != null) {
-            boolean pastedWithWorldEdit = StarterStructureWorldEditPlacer.placeWithWorldEdit(
+            boolean pastedWithCreate = StarterStructureCreateCannonPlacer.placeWithSchematicannon(
+                    serverLevel, schematic, structureOrigin);
+            boolean pastedWithWorldEdit = pastedWithCreate ? false : StarterStructureWorldEditPlacer.placeWithWorldEdit(
                     serverLevel, schematic, structureOrigin);
 
             ModConstants.LOGGER.debug("[Starter Structure compat] Bypassing terrain replacer for bunker; running blending pass instead.");
@@ -66,7 +69,7 @@ public class StarterStructureUtilMixin {
                 ModConstants.LOGGER.debug("[Starter Structure compat] No missing schematic entities needed spawning.");
             }
 
-            if (pastedWithWorldEdit) {
+            if (pastedWithCreate || pastedWithWorldEdit) {
                 schematic.clearParsedAfterWorldEdit();
             }
         }


### PR DESCRIPTION
## Summary
- add a Create schematic cannon placement path for the starter bunker before falling back to WorldEdit or vanilla handling
- try Create first, then WorldEdit schem placement, and only rely on the original .nbt flow if those paths fail
- reuse starter schematic metadata to copy the file into Create's uploads, build a deployed blueprint at spawn, and skip empty templates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598d6666448328b391f91be311e2be)