### PR TITLE
Fix Create schematic cannon placement

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureCreateCannonPlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureCreateCannonPlacer.java
@@ -5,10 +5,12 @@ import com.simibubi.create.foundation.utility.CreatePaths;
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
@@ -49,12 +51,16 @@ public final class StarterStructureCreateCannonPlacer {
             Files.copy(schematicPath, cannonPath, StandardCopyOption.REPLACE_EXISTING);
 
             ItemStack blueprint = SchematicItem.create(serverLevel, fileName, OWNER_NAMESPACE);
-            CompoundTag tag = blueprint.getOrCreateTag();
+            CustomData customData = blueprint.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY);
+            CompoundTag tag = customData.copyTag();
+            if (tag == null) {
+                tag = new CompoundTag();
+            }
             tag.putBoolean("Deployed", true);
             tag.put("Anchor", NbtUtils.writeBlockPos(origin));
             tag.putString("Rotation", Rotation.NONE.name());
             tag.putString("Mirror", Mirror.NONE.name());
-            blueprint.setTag(tag);
+            blueprint.set(DataComponents.CUSTOM_DATA, CustomData.of(tag));
 
             StructureTemplate template = SchematicItem.loadSchematic(serverLevel, blueprint);
             StructurePlaceSettings settings = SchematicItem.getSettings(blueprint, true);

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSchematic.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSchematic.java
@@ -1,0 +1,32 @@
+package com.thunder.wildernessodysseyapi.WorldGen.structure;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
+/**
+ * Simple abstraction around starter structure schematics so Create, WorldEdit, and vanilla
+ * placement logic can share the same metadata.
+ */
+public record StarterStructureSchematic(Path path) {
+
+    /** Returns {@code true} when the schematic file exists on disk. */
+    public boolean exists() {
+        return path != null && Files.isRegularFile(path);
+    }
+
+    /** Returns the schematic file name, or an empty string when the path is missing. */
+    public String fileName() {
+        return path == null ? "" : path.getFileName().toString();
+    }
+
+    /** Returns the lowercase extension (including the leading dot) or an empty string. */
+    public String extension() {
+        if (path == null) {
+            return "";
+        }
+        String name = path.getFileName().toString();
+        int dot = name.lastIndexOf('.');
+        return dot >= 0 ? name.substring(dot).toLowerCase(Locale.ROOT) : "";
+    }
+}


### PR DESCRIPTION
## Summary
- add a StarterStructureSchematic wrapper so Create/WorldEdit/vanilla placement can share schematic metadata
- update Create schematic cannon placement to use 1.21 custom data components instead of legacy item tags

## Testing
- ./gradlew test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ed442b888328b04273fdf7b187f0)