### PR TITLE
Preserve template entities during bunker placement

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -138,7 +138,10 @@ public class NBTStructurePlacer {
                 // Supplying the bounds up-front prevents the vanilla placer from bailing out when it cannot
                 // infer them (which resulted in the template refusing to place while terrain markers still
                 // ran).
-                .setBoundingBox(LargeStructurePlacementOptimizer.createPlacementBox(foundation.origin(), data.size()));
+                .setBoundingBox(LargeStructurePlacementOptimizer.createPlacementBox(foundation.origin(), data.size()))
+                // Preserve entities baked into the template (e.g., Create super glue and contraptions) so
+                // complex machines such as elevators remain assembled after placement.
+                .setIgnoreEntities(false);
         boolean placed = data.template().placeInWorld(level, foundation.origin(), foundation.origin(), settings, level.random, 2);
         if (!placed) {
             StructurePlacementDebugger.markFailure(attempt, "template refused placement");


### PR DESCRIPTION
## Summary
- ensure structure placements copy entities from templates so Create contraptions (like the elevator) stay intact
- document the intent with comments when building structure placement settings

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b183fffe08328947d69e1d84bf04f)