### PR TITLE
Handle Create elevator pulleys without strict class check

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -40,8 +40,6 @@ public class NBTStructurePlacer {
     private static final String TERRAIN_REPLACER_NAME = "wildernessodysseyapi:terrain_replacer";
     private static final String CRYO_TUBE_NAME = "wildernessodysseyapi:cryo_tube";
     private static final String CREATE_ELEVATOR_PULLEY_NAME = "create:elevator_pulley";
-    private static final String CREATE_ELEVATOR_PULLEY_CLASS =
-            "com.simibubi.create.content.contraptions.elevator.ElevatorPulleyBlockEntity";
     private static final String LEVELING_MARKER_NAME =
             BuiltInRegistries.BLOCK.getKey(Blocks.BLUE_WOOL).toString();
 
@@ -453,7 +451,7 @@ public class NBTStructurePlacer {
         for (BlockPos offset : pulleyOffsets) {
             BlockPos worldPos = origin.offset(offset);
             BlockEntity blockEntity = level.getBlockEntity(worldPos);
-            if (blockEntity == null || !CREATE_ELEVATOR_PULLEY_CLASS.equals(blockEntity.getClass().getName())) {
+            if (blockEntity == null) {
                 continue;
             }
             try {
@@ -461,6 +459,8 @@ public class NBTStructurePlacer {
                 clicked.setAccessible(true);
                 clicked.invoke(blockEntity);
                 level.scheduleTick(worldPos, blockEntity.getBlockState().getBlock(), 1);
+            } catch (NoSuchMethodException e) {
+                ModConstants.LOGGER.warn("Create elevator pulley at {} for {} exposes no activation hook; skipping.", worldPos, id);
             } catch (Exception e) {
                 ModConstants.LOGGER.warn("Failed to prime Create elevator pulley at {} for {}.", worldPos, id, e);
             }


### PR DESCRIPTION
### Motivation
- The structure placer failed to prime Create elevator pulleys when the block entity class name didn't match an exact string, causing pulleys/elevator contraptions not to activate after placement.
- The intent is to activate any Create pulley that exposes the expected activation hook instead of relying on a fragile class-name check.

### Description
- Removed the hard dependency on the `CREATE_ELEVATOR_PULLEY_CLASS` name and instead attempt to reflectively invoke the `clicked` method on the block entity found at pulley positions in `NBTStructurePlacer.java`.
- Added handling for `NoSuchMethodException` and a clear log warning when a pulley block entity does not expose the `clicked` activation hook, while preserving the existing exception catch for invocation failures.
- Keeps the `create` mod presence and pulley offset checks before attempting activation and still schedules a block tick after invoking the hook.

### Testing
- No automated tests were run against this change.
- The change was applied and committed locally (`git commit` successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c84482bc88328a0016dd050d7f81c)