### PR TITLE
Gate AI chat responses on holding red wool

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIChatListener.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIChatListener.java
@@ -2,6 +2,8 @@ package com.thunder.wildernessodysseyapi.AI.AI_story;
 
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.event.ServerChatEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
@@ -28,6 +30,9 @@ public class AIChatListener {
         if (message.isEmpty()) {
             return;
         }
+        if (!isHoldingActivationItem(player)) {
+            return;
+        }
 
         String wakeWord = CLIENT.getWakeWord();
         boolean mentionsWakeWord = message.toLowerCase(Locale.ROOT).contains(wakeWord);
@@ -46,6 +51,9 @@ public class AIChatListener {
                 player.getName().getString(), message);
 
         player.sendSystemMessage(Component.literal("[Atlas] " + reply.text()));
+        if (reply.voiceQueued() && reply.voiceLine() != null && !reply.voiceLine().isBlank()) {
+            player.sendSystemMessage(Component.literal("[Atlas Voice] " + reply.voiceLine()));
+        }
     }
 
     @SubscribeEvent
@@ -70,5 +78,13 @@ public class AIChatListener {
                 || lower.contains("should i")
                 || lower.contains("what")
                 || lower.contains("how");
+    }
+
+    private static boolean isHoldingActivationItem(ServerPlayer player) {
+        return isRedWool(player.getMainHandItem()) || isRedWool(player.getOffhandItem());
+    }
+
+    private static boolean isRedWool(ItemStack stack) {
+        return !stack.isEmpty() && stack.is(Items.RED_WOOL);
     }
 }


### PR DESCRIPTION
### Motivation
- Limit when the in-game assistant (Atlas) responds by requiring a player-held activation item so conversations are intentional and local-only.
- Provide a visible fallback for voice output by emitting the generated voice line to chat when voice is queued.
- Reflect the goal of an offline-friendly AI activation mechanism that can be triggered by in-game item interactions.

### Description
- Added imports for `ItemStack` and `Items` and new helpers `isHoldingActivationItem` and `isRedWool` in `AIChatListener.java`.
- Early-return from `onChat` unless the player is holding red wool in either hand to gate AI replies.
- When `VoiceResult.voiceQueued()` is true, emit the voice line as a secondary chat message via `player.sendSystemMessage`.
- Changes are contained in `src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIChatListener.java`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695de314be088328a22b11ca5f825ab6)