### PR TITLE
Optimize NBT resource encoding and chunk slice allocation

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/LargeStructurePlacementOptimizer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/LargeStructurePlacementOptimizer.java
@@ -107,12 +107,16 @@ public final class LargeStructurePlacementOptimizer {
             return Collections.emptyList();
         }
 
-        List<AABB> slices = new ArrayList<>();
         BlockPos max = origin.offset(size.getX() - 1, size.getY() - 1, size.getZ() - 1);
         int minChunkX = Math.floorDiv(origin.getX(), CHUNK_SIZE);
         int maxChunkX = Math.floorDiv(max.getX(), CHUNK_SIZE);
         int minChunkZ = Math.floorDiv(origin.getZ(), CHUNK_SIZE);
         int maxChunkZ = Math.floorDiv(max.getZ(), CHUNK_SIZE);
+        int chunkXCount = maxChunkX - minChunkX + 1;
+        int chunkZCount = maxChunkZ - minChunkZ + 1;
+        long estimatedSlices = (long) chunkXCount * chunkZCount;
+        int initialCapacity = (int) Math.min(Integer.MAX_VALUE, Math.max(0L, estimatedSlices));
+        List<AABB> slices = new ArrayList<>(initialCapacity);
 
         for (int chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
             int chunkMinX = chunkX * CHUNK_SIZE;


### PR DESCRIPTION
### Motivation
- Reduce CPU overhead when compacting NBT payloads by avoiding repeated linear scans for ResourceLocation indexes. 
- Reduce temporary allocations and resizing when computing chunk-aligned slices for very large structure placements. 
- Improve performance and memory behavior in hot code paths related to world generation and disk I/O. 

### Description
- Updated `NbtDataCompactor.encodeResourceLocations` to accept a `Map<String,Integer>` (`rlIndex`) and use it to index resource strings, replacing `List.indexOf` linear lookups. 
- Added `HashMap`/`Map` imports and thread-local index propagation so recursive calls reuse the same lookup cache. 
- Pre-compute chunk counts in `LargeStructurePlacementOptimizer.computeChunkSlices` and initialize the `ArrayList` with `initialCapacity` to avoid repeated resizes. 
- Small API/signature change: `encodeResourceLocations` now takes `(CompoundTag, List<String>, Map<String,Integer>)` and related call sites updated accordingly. 

### Testing
- No automated tests were executed as part of this change. 
- Compilation and runtime verification were not performed by CI in this rollout. 
- Recommend running `./gradlew build` and project test suites (`junit` / integration tests) to validate behavior. 
- Recommend running relevant large-structure placement and NBT compaction benchmarks in a dev environment to measure impact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695de6941b408328b2a22d9b44a5b937)