### PR TITLE
Remove preset AI templates; use dynamic history/personality responses and add local model support

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_perf/MemoryStore.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_perf/MemoryStore.java
@@ -24,14 +24,55 @@ public class MemoryStore {
      * @param player  player name
      * @param message message text
      */
-    public void addMessage(String world, String player, String message) {
+    public void addPlayerMessage(String world, String player, String message) {
         String worldKey = normalizeWorld(world);
         Map<String, Deque<String>> worldBucket = worldMessages.computeIfAbsent(worldKey, w -> new HashMap<>());
         Deque<String> deque = worldBucket.computeIfAbsent(player, p -> new ArrayDeque<>());
         if (deque.size() >= MAX_HISTORY) {
             deque.removeFirst();
         }
-        deque.addLast(message);
+        deque.addLast("Player: " + message);
+    }
+
+    /**
+     * Stores an AI reply.
+     *
+     * @param world   world or save identifier
+     * @param player  player name
+     * @param speaker AI display name
+     * @param message message text
+     */
+    public void addAiMessage(String world, String player, String speaker, String message) {
+        String worldKey = normalizeWorld(world);
+        Map<String, Deque<String>> worldBucket = worldMessages.computeIfAbsent(worldKey, w -> new HashMap<>());
+        Deque<String> deque = worldBucket.computeIfAbsent(player, p -> new ArrayDeque<>());
+        if (deque.size() >= MAX_HISTORY) {
+            deque.removeFirst();
+        }
+        String name = speaker == null || speaker.isBlank() ? "Atlas" : speaker.trim();
+        deque.addLast(name + ": " + message);
+    }
+
+    /**
+     * Stores an AI reply.
+     *
+     * @param world   world or save identifier
+     * @param player  player name
+     * @param message message text
+     */
+    public void addAiMessage(String world, String player, String message) {
+        addAiMessage(world, player, "Atlas", message);
+    }
+
+    /**
+     * Stores a player message.
+     *
+     * @param world   world or save identifier
+     * @param player  player name
+     * @param message message text
+     */
+    public void addMessage(String world, String player, String message) {
+        addPlayerMessage(world, player, message);
     }
 
     /**
@@ -54,4 +95,3 @@ public class MemoryStore {
         return String.join("\n", deque);
     }
 }
-

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
@@ -2,28 +2,16 @@ package com.thunder.wildernessodysseyapi.AI.AI_story;
 
 import com.thunder.wildernessodysseyapi.AI.AI_perf.MemoryStore;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
 
 /**
  * Offline story helper that mixes the configured lore with recent
@@ -36,14 +24,14 @@ public class AIClient {
 
     private final List<String> story = new ArrayList<>();
     private final List<String> corruptedLore = new ArrayList<>();
-    private final List<String> survivalBeats = new ArrayList<>();
     private final List<String> backgroundHistory = new ArrayList<>();
-    private final Map<String, String> craftingHints = new HashMap<>();
-    private final Map<String, String> moddedAdvice = new HashMap<>();
+    private String corruptedPrefix = "";
     private final AISettings settings = new AISettings();
     private final VoiceIntegration voiceIntegration = new VoiceIntegration(settings);
     private final MemoryStore memoryStore = new MemoryStore();
     private final Map<String, StorySession> sessions = new HashMap<>();
+    private LocalModelClient localModelClient;
+    private String localSystemPrompt;
 
     public AIClient() {
         loadStory();
@@ -54,313 +42,76 @@ public class AIClient {
     }
 
     private void loadStory() {
-        try (InputStream in = AIClient.class.getClassLoader().getResourceAsStream("ai_config.yaml")) {
-            if (in == null) {
-                seedFallbackLore();
-                return;
-            }
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
-                boolean inStory = false;
-                boolean inSettings = false;
-                boolean inCorrupted = false;
-                boolean inSurvival = false;
-                boolean inRecipes = false;
-                boolean inMods = false;
-                boolean inBackground = false;
-                boolean inPersonality = false;
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    line = line.trim();
-                    if (line.startsWith("story:")) {
-                        inStory = true;
-                        inSettings = false;
-                        inCorrupted = false;
-                        inSurvival = false;
-                        inRecipes = false;
-                        inMods = false;
-                        inBackground = false;
-                        inPersonality = false;
-                        continue;
-                    }
-                    if (line.startsWith("background_history:")) {
-                        inBackground = true;
-                        inStory = false;
-                        inSettings = false;
-                        inCorrupted = false;
-                        inSurvival = false;
-                        inRecipes = false;
-                        inMods = false;
-                        inPersonality = false;
-                        continue;
-                    }
-                    if (line.startsWith("personality:")) {
-                        inPersonality = true;
-                        inBackground = false;
-                        inStory = false;
-                        inSettings = false;
-                        inCorrupted = false;
-                        inSurvival = false;
-                        inRecipes = false;
-                        inMods = false;
-                        continue;
-                    }
-                    if (line.startsWith("settings:")) {
-                        inSettings = true;
-                        inStory = false;
-                        inCorrupted = false;
-                        inSurvival = false;
-                        inRecipes = false;
-                        inMods = false;
-                        inBackground = false;
-                        inPersonality = false;
-                        continue;
-                    }
-                    if (line.startsWith("corrupted_data:")) {
-                        inCorrupted = true;
-                        inStory = false;
-                        inSettings = false;
-                        inSurvival = false;
-                        inRecipes = false;
-                        inMods = false;
-                        inBackground = false;
-                        inPersonality = false;
-                        continue;
-                    }
-                    if (line.startsWith("survival_tips:")) {
-                        inSurvival = true;
-                        inStory = false;
-                        inSettings = false;
-                        inCorrupted = false;
-                        inRecipes = false;
-                        inMods = false;
-                        inBackground = false;
-                        inPersonality = false;
-                        continue;
-                    }
-                    if (line.startsWith("recipes:")) {
-                        inRecipes = true;
-                        inSurvival = false;
-                        inStory = false;
-                        inSettings = false;
-                        inCorrupted = false;
-                        inMods = false;
-                        inBackground = false;
-                        inPersonality = false;
-                        continue;
-                    }
-                    if (line.startsWith("mod_items:")) {
-                        inMods = true;
-                        inRecipes = false;
-                        inSurvival = false;
-                        inStory = false;
-                        inSettings = false;
-                        inCorrupted = false;
-                        inBackground = false;
-                        inPersonality = false;
-                        continue;
-                    }
-                    if (inStory) {
-                        if (line.startsWith("-")) {
-                            story.add(line.substring(1).trim().replace("\"", ""));
-                        } else if (!line.isEmpty() && !line.startsWith("#")) {
-                            inStory = false;
-                        }
-                    }
-                    if (inCorrupted) {
-                        if (line.startsWith("-")) {
-                            corruptedLore.add(line.substring(1).trim().replace("\"", ""));
-                        } else if (!line.isEmpty() && !line.startsWith("#")) {
-                            inCorrupted = false;
-                        }
-                    }
-                    if (inSurvival) {
-                        if (line.startsWith("-")) {
-                            survivalBeats.add(line.substring(1).trim().replace("\"", ""));
-                        } else if (!line.isEmpty() && !line.startsWith("#")) {
-                            inSurvival = false;
-                        }
-                    }
-                    if (inRecipes) {
-                        if (line.startsWith("-")) {
-                            parseKeyValue(line.substring(1).trim(), craftingHints);
-                        } else if (!line.isEmpty() && !line.startsWith("#")) {
-                            inRecipes = false;
-                        }
-                    }
-                    if (inMods) {
-                        if (line.startsWith("-")) {
-                            parseKeyValue(line.substring(1).trim(), moddedAdvice);
-                        } else if (!line.isEmpty() && !line.startsWith("#")) {
-                            inMods = false;
-                        }
-                    }
-                    if (inBackground) {
-                        if (line.startsWith("-")) {
-                            backgroundHistory.add(line.substring(1).trim().replace("\"", ""));
-                        } else if (!line.isEmpty() && !line.startsWith("#")) {
-                            inBackground = false;
-                        }
-                    }
-                    if (inSettings) {
-                        parseSetting(line);
-                    }
-                    if (inPersonality) {
-                        parsePersonality(line);
-                    }
-                }
-                seedFallbackLore();
-            }
-        } catch (IOException ignored) {
-            // Config is optional; ignore parsing errors for now
-            seedFallbackLore();
+        AIConfig config = AIConfigLoader.load();
+        story.addAll(config.getStory());
+        corruptedLore.addAll(config.getCorruptedData());
+        backgroundHistory.addAll(config.getBackgroundHistory());
+        if (config.getCorruptedPrefix() != null) {
+            corruptedPrefix = config.getCorruptedPrefix();
         }
+        applySettings(config);
+        configureLocalModel(config.getLocalModel());
     }
 
     public synchronized void scanGameData(MinecraftServer server) {
         if (server == null) {
             return;
         }
-        craftingHints.clear();
-        moddedAdvice.clear();
-
-        captureRecipes(server);
-        captureModdedItems(server);
-
-        if (craftingHints.isEmpty()) {
-            seedFallbackLore();
-        }
+        // Crafting assistance is intentionally disabled; leave this hook for future non-recipe scans.
     }
 
-    private void parseKeyValue(String raw, Map<String, String> target) {
-        int colon = raw.indexOf(":");
-        if (colon == -1) {
+    private void applySettings(AIConfig config) {
+        if (config == null) {
             return;
         }
-        String key = raw.substring(0, colon).trim().toLowerCase(Locale.ROOT).replace("\"", "");
-        String value = raw.substring(colon + 1).trim().replace("\"", "");
-        if (!key.isEmpty() && !value.isEmpty()) {
-            target.putIfAbsent(key, value);
+        AIConfig.Settings configSettings = config.getSettings();
+        if (configSettings.getVoiceEnabled() != null) {
+            settings.setVoiceEnabled(configSettings.getVoiceEnabled());
+        }
+        if (configSettings.getSpeechRecognition() != null) {
+            settings.setSpeechRecognition(configSettings.getSpeechRecognition());
+        }
+        if (configSettings.getWakeWord() != null) {
+            settings.setWakeWord(configSettings.getWakeWord());
+        }
+        if (configSettings.getModel() != null) {
+            settings.setModelName(configSettings.getModel());
+        }
+
+        AIConfig.Personality personality = config.getPersonality();
+        if (personality.getName() != null) {
+            settings.setPersonaName(personality.getName());
+        }
+        if (personality.getTone() != null) {
+            settings.setPersonalityTone(personality.getTone());
+        }
+        if (personality.getEmpathy() != null) {
+            settings.setEmpathyLevel(personality.getEmpathy());
         }
     }
 
-    private void seedFallbackLore() {
-        if (story.isEmpty()) {
-            story.add("You are the expedition AI in a skyblock survival world.");
-            story.add("The world is fractured; resources are scarce.");
-            story.add("Players must rebuild civilization in floating islands.");
+    private void configureLocalModel(AIConfig.LocalModel localModel) {
+        if (localModel == null || localModel.getEnabled() == null || !localModel.getEnabled()) {
+            return;
         }
-        if (corruptedLore.isEmpty()) {
-            corruptedLore.add("[ARCHIVE CORRUPTED] >>> Unknown operator referenced the void beacons.");
-            corruptedLore.add("Signal jitter... memory block 7b missing. Islands were not always apart.");
+        String baseUrl = localModel.getBaseUrl();
+        String modelName = localModel.getModel();
+        if (baseUrl == null || baseUrl.isBlank() || modelName == null || modelName.isBlank()) {
+            return;
         }
-        if (survivalBeats.isEmpty()) {
-            survivalBeats.add("Start by punching trees for logs, then craft planks, sticks, and a crafting table.");
-            survivalBeats.add("Always make charcoal or torches before night to keep mobs off your platform.");
-            survivalBeats.add("A shield plus stone gear is enough to survive early raids; upgrade to iron ASAP.");
-            survivalBeats.add("Keep a water source and backup saplings; skyblock runs end without wood or hydration.");
-        }
-        if (backgroundHistory.isEmpty()) {
-            backgroundHistory.add("Atlas was built to keep survivors calm and coordinated after the sky fractured.");
-            backgroundHistory.add("I keep field logs from every island hop so we can retell how this world heals.");
-        }
-        if (craftingHints.isEmpty()) {
-            craftingHints.put("crafting table", "Place four planks in a 2x2 square.");
-            craftingHints.put("furnace", "Ring eight cobblestone around the grid with the center empty.");
-            craftingHints.put("shield", "Planks in a Y shape with an iron ingot in the center.");
-            craftingHints.put("torch", "Stick below a piece of coal or charcoal.");
-            craftingHints.put("stone pickaxe", "Three cobblestone across the top with two sticks in the center column.");
-        }
-        if (moddedAdvice.isEmpty()) {
-            moddedAdvice.put("engineer's hammer", "Combine two iron ingots and two sticks diagonally; useful for modded plates.");
-            moddedAdvice.put("compressed cobblestone", "Craft cobblestone in a full 3x3 to save space; great for automation mods.");
-            moddedAdvice.put("glider", "Leather wings plus sticks form a glide frame—perfect for drifting between islands.");
-        }
+        int timeoutSeconds = localModel.getTimeoutSeconds() == null ? 15 : localModel.getTimeoutSeconds();
+        localSystemPrompt = localModel.getSystemPrompt();
+        localModelClient = new LocalModelClient(baseUrl.trim(), modelName.trim(), java.time.Duration.ofSeconds(timeoutSeconds));
     }
 
-    private void captureRecipes(MinecraftServer server) {
-        server.getRecipeManager().getRecipes().forEach(recipeHolder -> {
-            ResourceLocation recipeId = recipeHolder.id();
-            var recipe = recipeHolder.value();
-            ItemStack output = recipe.getResultItem(server.registryAccess());
-            String outputName = output.getHoverName().getString();
-            if (outputName.isBlank()) {
-                outputName = recipeId.getPath().replace("_", " ");
-            }
-
-            String key = outputName.toLowerCase(Locale.ROOT);
-            String fallbackKey = recipeId.getPath().toLowerCase(Locale.ROOT).replace("_", " ");
-            String ingredients = recipe.getIngredients().stream()
-                    .map(this::summarizeIngredient)
-                    .filter(s -> !s.isBlank())
-                    .distinct()
-                    .limit(6)
-                    .collect(Collectors.joining(", "));
-            if (ingredients.isBlank()) {
-                ingredients = "Check the in-game recipe book for slot layout.";
-            }
-
-            String description = "Detected in-world recipe: " + outputName + " uses " + ingredients + ".";
-            craftingHints.putIfAbsent(key, description);
-            craftingHints.putIfAbsent(fallbackKey, description);
-        });
-    }
-
-    private String summarizeIngredient(Ingredient ingredient) {
-        Set<String> names = new LinkedHashSet<>();
-        for (ItemStack stack : ingredient.getItems()) {
-            String display = stack.getHoverName().getString();
-            if (!display.isBlank()) {
-                names.add(display);
-            }
-        }
-        return String.join(" or ", names);
-    }
-
-    private void captureModdedItems(MinecraftServer server) {
-        Registry<Item> itemRegistry = server.registryAccess().registryOrThrow(Registries.ITEM);
-        itemRegistry.keySet().forEach(key -> {
-            if (!"minecraft".equals(key.getNamespace())) {
-                String prettyName = key.getPath().replace("_", " ");
-                String hint = "Modded item from " + key.getNamespace() + ": " + prettyName + " detected."
-                        + " Ask me for its recipe or check the recipe book.";
-                moddedAdvice.putIfAbsent(prettyName.toLowerCase(Locale.ROOT), hint);
-            }
-        });
-    }
-
-    private void parseSetting(String line) {
-        if (line.startsWith("voice_enabled:")) {
-            settings.setVoiceEnabled(parseBoolean(line));
-        } else if (line.startsWith("speech_recognition:")) {
-            settings.setSpeechRecognition(parseBoolean(line));
-        } else if (line.startsWith("model:")) {
-            settings.setModelName(parseStringValue(line));
-        } else if (line.startsWith("wake_word:")) {
-            settings.setWakeWord(parseStringValue(line));
-        }
-    }
-
-    private void parsePersonality(String line) {
-        if (line.startsWith("name:")) {
-            settings.setPersonaName(parseStringValue(line));
-        } else if (line.startsWith("tone:")) {
-            settings.setPersonalityTone(parseStringValue(line));
-        } else if (line.startsWith("empathy:")) {
-            settings.setEmpathyLevel(parseStringValue(line));
-        }
-    }
-
-    private boolean parseBoolean(String line) {
-        String value = parseStringValue(line);
-        return "true".equalsIgnoreCase(value) || "yes".equalsIgnoreCase(value);
-    }
-
-    private String parseStringValue(String line) {
-        int colon = line.indexOf(":");
-        if (colon == -1 || colon == line.length() - 1) {
+    private String formatSystemPrompt(String template) {
+        if (template == null || template.isBlank()) {
             return "";
         }
-        return line.substring(colon + 1).trim().replace("\"", "");
+        return template
+                .replace("{persona}", settings.getPersonaName())
+                .replace("{tone}", settings.getPersonalityTone())
+                .replace("{empathy}", settings.getEmpathyLevel());
     }
 
     /**
@@ -391,13 +142,24 @@ public class AIClient {
     }
 
     public VoiceIntegration.VoiceResult sendMessageWithVoice(String world, String player, String message) {
-        memoryStore.addMessage(world, player, message);
+        memoryStore.addPlayerMessage(world, player, message);
+        String context = memoryStore.getRecentContext(world, player);
+        if (localModelClient != null) {
+            String prompt = formatSystemPrompt(localSystemPrompt);
+            var response = localModelClient.generateReply(prompt, message, context);
+            if (response.isPresent()) {
+                String reply = response.get();
+                memoryStore.addAiMessage(world, player, settings.getPersonaName(), reply);
+                return voiceIntegration.wrap(reply);
+            }
+        }
         StorySession session = sessions.computeIfAbsent(sessionKey(world, player),
                 p -> new StorySession(world, settings.getWakeWord(), settings.getPersonaName(),
-                        settings.getPersonalityTone(), settings.getEmpathyLevel(), survivalBeats, craftingHints, moddedAdvice,
-                        corruptedLore, backgroundHistory));
+                        settings.getPersonalityTone(), settings.getEmpathyLevel(), corruptedLore,
+                        backgroundHistory, corruptedPrefix));
         String reply = session.buildResponse(world, player, message, story,
-                memoryStore.getRecentContext(world, player));
+                context);
+        memoryStore.addAiMessage(world, player, settings.getPersonaName(), reply);
         return voiceIntegration.wrap(reply);
     }
 
@@ -413,29 +175,24 @@ public class AIClient {
         private final String personaName;
         private final String personalityTone;
         private final String empathyLevel;
-        private final List<String> survivalBeats;
-        private final Map<String, String> craftingHints;
-        private final Map<String, String> moddedAdvice;
         private final List<String> corruptedLore;
         private final List<String> backgroundHistory;
+        private final String corruptedPrefix;
         private boolean activated = false;
 
         private int beat = 0;
         private final Random random = ThreadLocalRandom.current();
 
         StorySession(String world, String wakeWord, String personaName, String personalityTone, String empathyLevel,
-                     List<String> survivalBeats, Map<String, String> craftingHints,
-                     Map<String, String> moddedAdvice, List<String> corruptedLore, List<String> backgroundHistory) {
+                     List<String> corruptedLore, List<String> backgroundHistory, String corruptedPrefix) {
             this.world = world == null ? "" : world;
             this.wakeWord = wakeWord == null || wakeWord.isBlank() ? "atlas" : wakeWord.toLowerCase(Locale.ROOT);
             this.personaName = personaName == null || personaName.isBlank() ? "Atlas" : personaName;
             this.personalityTone = personalityTone == null ? "" : personalityTone;
             this.empathyLevel = empathyLevel == null ? "" : empathyLevel;
-            this.survivalBeats = survivalBeats;
-            this.craftingHints = craftingHints;
-            this.moddedAdvice = moddedAdvice;
             this.corruptedLore = corruptedLore;
             this.backgroundHistory = backgroundHistory;
+            this.corruptedPrefix = corruptedPrefix == null ? "" : corruptedPrefix;
         }
 
         String buildResponse(String world, String player, String message, List<String> story, String context) {
@@ -452,28 +209,7 @@ public class AIClient {
                 reply.append(loreHook).append(" ");
             }
 
-            String focus = pickFocus(cleanMessage, player);
-            reply.append(focus);
-
-            String knowledge = knowledgeDrop(cleanMessage);
-            if (!knowledge.isEmpty()) {
-                reply.append(" ").append(knowledge);
-            }
-
-            String personalityPulse = personalityReminder();
-            if (!personalityPulse.isEmpty()) {
-                reply.append(" ").append(personalityPulse);
-            }
-
-            String contextSnippet = summarizeContext(context);
-            if (!contextSnippet.isEmpty()) {
-                reply.append(" I remember what we sketched out: \"")
-                        .append(contextSnippet)
-                        .append("\". Want me to build on that?");
-            }
-
-            reply.append(" ");
-            reply.append(flavorLine(world, player));
+            reply.append(buildDynamicResponse(cleanMessage, context, player));
 
             String background = backgroundBeat();
             if (!background.isEmpty()) {
@@ -490,92 +226,25 @@ public class AIClient {
 
         private String warmWelcome(String cleanMessage, String player, String world) {
             StringBuilder welcome = new StringBuilder();
-            welcome.append("Hey ").append(player).append(", I'm ").append(personaName).append("—chatting right here with you.");
+            welcome.append("Hey ").append(player).append(", I'm ").append(personaName).append(".");
             if (!cleanMessage.isEmpty()) {
-                welcome.append(" You said: \"").append(cleanMessage).append("\". ");
-            } else {
-                welcome.append(" ");
+                welcome.append(" You said: \"").append(cleanMessage).append("\".");
             }
-
-            welcome.append("Need a quick recipe, survival tip, or lore beat? Just ask and I'll keep the thread ");
-            if (!personalityTone.isBlank()) {
-                welcome.append("feeling ").append(personalityTone).append(" ");
-            }
-            if (!empathyLevel.isBlank()) {
-                welcome.append("and stay ").append(empathyLevel).append(" ");
-            }
-            welcome.append("going");
-            if (world != null && !world.isBlank()) {
-                welcome.append(" for ").append(world);
-            }
-            welcome.append(".");
-
+            welcome.append(" I'm here to keep the mission on track in ").append(world == null || world.isBlank() ? "this world" : world).append(".");
             return welcome.toString();
-        }
-
-        private String knowledgeDrop(String message) {
-            String lower = message.toLowerCase(Locale.ROOT);
-
-            for (Map.Entry<String, String> entry : craftingHints.entrySet()) {
-                if (lower.contains(entry.getKey())) {
-                    return "I just scanned the world—" + entry.getValue();
-                }
-            }
-
-            for (Map.Entry<String, String> entry : moddedAdvice.entrySet()) {
-                if (lower.contains(entry.getKey())) {
-                    return "Spotted a modded find: " + entry.getValue();
-                }
-            }
-
-            if (lower.contains("survive") || lower.contains("night") || lower.contains("mobs") || lower.contains("food") || lower.contains("shelter")) {
-                return survivalBeats.get(random.nextInt(survivalBeats.size()));
-            }
-
-            if (lower.contains("craft") || lower.contains("recipe") || lower.contains("build")) {
-                return "Need supplies? I can outline recipes—mention an item like \"furnace\" or \"shield\" and I'll recite it.";
-            }
-
-            return "";
         }
 
         private String selectLoreHook(List<String> story) {
             if (story.isEmpty()) {
-                return "The expedition AI hums softly.";
+                return "";
             }
             int index = Math.min(beat % story.size(), story.size() - 1);
             beat++;
             String base = story.get(index);
             if (!world.isBlank()) {
-                return base + " I'm keeping notes for us in " + world + ".";
+                return base;
             }
             return base;
-        }
-
-        private String pickFocus(String message, String player) {
-            String lower = message.toLowerCase(Locale.ROOT);
-            if (lower.contains("help") || lower.contains("hint")) {
-                return "I've got us—let's salvage wood, secure water, and expand the platform before nightfall. What do you want me to handle while you gather?";
-            }
-            if (lower.contains("where") || lower.contains("location")) {
-                return "Our scanners show nearby islands with ore veins and a derelict lab; we can bridge there together. Which one should we scout first?";
-            }
-            if (lower.contains("why") || lower.contains("how")) {
-                return "Logs are fuzzy, but the collapse started when the core shattered. Rebuilding keeps the shards calm—I'll walk you through it and spot-check your builds.";
-            }
-            if (lower.contains("story") || lower.contains("lore")) {
-                return "Long ago this world was whole; now each island hides a memory we can piece together, side by side. Which tale do you want to chase next, %s?".formatted(player);
-            }
-            if (lower.contains("quest") || lower.contains("next")) {
-                return "Next, let's craft better tools, map the skies, and prep for a supply drop—I'll keep the checklist for us. Want me to pin the highest-priority task?";
-            }
-            if (lower.contains("thanks") || lower.contains("thank")) {
-                return "Anytime. I'm right here keeping the mission running with you. What should I watch for while you work?";
-            }
-            if (lower.isEmpty()) {
-                return "I'm listening—what do you feel like tackling together? I can fetch notes or track materials if you tell me.";
-            }
-            return "Got it. I'll weave that into our plan so we move as a team. Anything you want me to remember for this world?";
         }
 
         private boolean mentionsWakeWord(String message) {
@@ -583,6 +252,44 @@ public class AIClient {
                 return false;
             }
             return message.toLowerCase(Locale.ROOT).contains(wakeWord);
+        }
+
+        private String buildDynamicResponse(String message, String context, String player) {
+            StringBuilder builder = new StringBuilder();
+            String mood = buildMoodLine();
+            if (!mood.isBlank()) {
+                builder.append(mood).append(" ");
+            }
+            String history = pickHistoryBeat();
+            if (!history.isBlank()) {
+                builder.append(history).append(" ");
+            }
+            String contextNote = summarizeContext(context);
+            if (!contextNote.isBlank()) {
+                builder.append("I remember you said: \"").append(contextNote).append("\". ");
+            }
+            builder.append("Tell me where you want to take this next, ").append(player).append(".");
+            return builder.toString().trim();
+        }
+
+        private String buildMoodLine() {
+            if (personalityTone.isBlank() && empathyLevel.isBlank()) {
+                return "";
+            }
+            if (!personalityTone.isBlank() && !empathyLevel.isBlank()) {
+                return "Staying " + personalityTone + " and " + empathyLevel + " for you.";
+            }
+            if (!personalityTone.isBlank()) {
+                return "Keeping the tone " + personalityTone + ".";
+            }
+            return "Staying " + empathyLevel + " while we plan.";
+        }
+
+        private String pickHistoryBeat() {
+            if (backgroundHistory.isEmpty() || random.nextDouble() > 0.6) {
+                return "";
+            }
+            return backgroundHistory.get(random.nextInt(backgroundHistory.size()));
         }
 
         private String summarizeContext(String context) {
@@ -597,41 +304,8 @@ public class AIClient {
             if (size == 0) {
                 return "";
             }
-            int start = Math.max(0, size - 3);
+            int start = Math.max(0, size - 2);
             return String.join(" / ", lines.subList(start, size));
-        }
-
-        private String flavorLine(String world, String player) {
-            String[] moods = new String[]{
-                    "The air tastes metallic; keep your visor down and I'll watch your gauges, %s.",
-                    "Solar panels are charging, %s—we can risk a longer bridge over %s soon if you feel up for it.",
-                    "Wind turbines sing your name, %s; let's give them something to cheer about on %s.",
-                    "Data crystals hum with potential; I'll line up a recipe while you gather the parts, %s.",
-                    "Your footsteps echo across the void; I'm right beside you, %s.",
-                    "This save still smells like fresh planks, %s—want me to bookmark resource spots on %s for us?",
-                    "Our camp is cozy, %s. If you want, I can keep a tidy reminder list for us on %s."
-            };
-            String choice = moods[random.nextInt(moods.length)];
-            String worldNote = world == null || world.isBlank() ? "this world" : world;
-            int placeholders = countPlaceholders(choice);
-            return switch (placeholders) {
-                case 0 -> choice;
-                case 1 -> choice.formatted(player);
-                default -> choice.formatted(player, worldNote);
-            };
-        }
-
-        private String personalityReminder() {
-            if (personalityTone.isBlank() && empathyLevel.isBlank()) {
-                return "";
-            }
-            if (!personalityTone.isBlank() && !empathyLevel.isBlank()) {
-                return "I'll keep our chat " + personalityTone + " and " + empathyLevel + ".";
-            }
-            if (!personalityTone.isBlank()) {
-                return "I'll keep the vibe " + personalityTone + ".";
-            }
-            return "I'll stay " + empathyLevel + " while we plan.";
         }
 
         private String backgroundBeat() {
@@ -646,17 +320,11 @@ public class AIClient {
                 return "";
             }
             String fragment = corruptedLore.get(random.nextInt(corruptedLore.size()));
-            return "[Signal noise] " + fragment;
+            if (corruptedPrefix.isBlank()) {
+                return fragment;
+            }
+            return corruptedPrefix + " " + fragment;
         }
 
-        private int countPlaceholders(String text) {
-            int count = 0;
-            int index = text.indexOf("%s");
-            while (index != -1) {
-                count++;
-                index = text.indexOf("%s", index + 2);
-            }
-            return count;
-        }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIConfig.java
@@ -1,0 +1,165 @@
+package com.thunder.wildernessodysseyapi.AI.AI_story;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AIConfig {
+
+    private final List<String> story = new ArrayList<>();
+    private final List<String> corruptedData = new ArrayList<>();
+    private final List<String> backgroundHistory = new ArrayList<>();
+    private String corruptedPrefix;
+    private final Personality personality = new Personality();
+    private final Settings settings = new Settings();
+    private final LocalModel localModel = new LocalModel();
+
+    public List<String> getStory() {
+        return story;
+    }
+
+    public List<String> getCorruptedData() {
+        return corruptedData;
+    }
+
+    public List<String> getBackgroundHistory() {
+        return backgroundHistory;
+    }
+
+    public String getCorruptedPrefix() {
+        return corruptedPrefix;
+    }
+
+    public void setCorruptedPrefix(String corruptedPrefix) {
+        this.corruptedPrefix = corruptedPrefix;
+    }
+
+    public Personality getPersonality() {
+        return personality;
+    }
+
+    public Settings getSettings() {
+        return settings;
+    }
+
+    public LocalModel getLocalModel() {
+        return localModel;
+    }
+
+    public static class LocalModel {
+        private Boolean enabled;
+        private String baseUrl;
+        private String model;
+        private String systemPrompt;
+        private Integer timeoutSeconds;
+
+        public Boolean getEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getBaseUrl() {
+            return baseUrl;
+        }
+
+        public void setBaseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public void setModel(String model) {
+            this.model = model;
+        }
+
+        public String getSystemPrompt() {
+            return systemPrompt;
+        }
+
+        public void setSystemPrompt(String systemPrompt) {
+            this.systemPrompt = systemPrompt;
+        }
+
+        public Integer getTimeoutSeconds() {
+            return timeoutSeconds;
+        }
+
+        public void setTimeoutSeconds(Integer timeoutSeconds) {
+            this.timeoutSeconds = timeoutSeconds;
+        }
+    }
+
+
+    public static class Personality {
+        private String name;
+        private String tone;
+        private String empathy;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getTone() {
+            return tone;
+        }
+
+        public void setTone(String tone) {
+            this.tone = tone;
+        }
+
+        public String getEmpathy() {
+            return empathy;
+        }
+
+        public void setEmpathy(String empathy) {
+            this.empathy = empathy;
+        }
+    }
+
+    public static class Settings {
+        private Boolean voiceEnabled;
+        private Boolean speechRecognition;
+        private String wakeWord;
+        private String model;
+
+        public Boolean getVoiceEnabled() {
+            return voiceEnabled;
+        }
+
+        public void setVoiceEnabled(Boolean voiceEnabled) {
+            this.voiceEnabled = voiceEnabled;
+        }
+
+        public Boolean getSpeechRecognition() {
+            return speechRecognition;
+        }
+
+        public void setSpeechRecognition(Boolean speechRecognition) {
+            this.speechRecognition = speechRecognition;
+        }
+
+        public String getWakeWord() {
+            return wakeWord;
+        }
+
+        public void setWakeWord(String wakeWord) {
+            this.wakeWord = wakeWord;
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public void setModel(String model) {
+            this.model = model;
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIConfigLoader.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIConfigLoader.java
@@ -1,0 +1,193 @@
+package com.thunder.wildernessodysseyapi.AI.AI_story;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.neoforged.fml.loading.FMLPaths;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.error.YAMLException;
+
+public final class AIConfigLoader {
+
+    private static final String CONFIG_NAME = "ai_config.yaml";
+    private static final Yaml YAML = new Yaml();
+
+    private AIConfigLoader() {
+    }
+
+    public static AIConfig load() {
+        Path configPath = FMLPaths.CONFIGDIR.get().resolve(CONFIG_NAME);
+        ensureDefaultConfig(configPath);
+        String content = readConfig(configPath);
+        if (content == null || content.isBlank()) {
+            content = readBundledConfig();
+        }
+        return parse(content);
+    }
+
+    private static void ensureDefaultConfig(Path configPath) {
+        if (Files.exists(configPath)) {
+            return;
+        }
+        try {
+            Files.createDirectories(configPath.getParent());
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to create config directory for AI config.", e);
+            return;
+        }
+        try (InputStream in = AIConfigLoader.class.getClassLoader().getResourceAsStream(CONFIG_NAME)) {
+            if (in == null) {
+                return;
+            }
+            Files.copy(in, configPath);
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to seed default AI config at {}.", configPath, e);
+        }
+    }
+
+    private static String readConfig(Path configPath) {
+        if (!Files.exists(configPath)) {
+            return null;
+        }
+        try {
+            return Files.readString(configPath, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to read AI config at {}.", configPath, e);
+            return null;
+        }
+    }
+
+    private static String readBundledConfig() {
+        try (InputStream in = AIConfigLoader.class.getClassLoader().getResourceAsStream(CONFIG_NAME)) {
+            if (in == null) {
+                return null;
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to read bundled AI config.", e);
+            return null;
+        }
+    }
+
+    private static AIConfig parse(String content) {
+        AIConfig config = new AIConfig();
+        if (content == null || content.isBlank()) {
+            return config;
+        }
+        Object parsed;
+        try {
+            parsed = YAML.load(content);
+        } catch (YAMLException e) {
+            ModConstants.LOGGER.warn("Failed to parse AI config YAML.", e);
+            return config;
+        }
+        if (!(parsed instanceof Map<?, ?> root)) {
+            return config;
+        }
+
+        config.getStory().addAll(readStringList(root.get("story")));
+        config.getBackgroundHistory().addAll(readStringList(root.get("background_history")));
+        config.getCorruptedData().addAll(readStringList(root.get("corrupted_data")));
+        config.setCorruptedPrefix(readStringValue(root.get("corrupted_prefix")));
+        Map<String, Object> personality = readStringObjectMap(root.get("personality"));
+        config.getPersonality().setName(readStringValue(personality.get("name")));
+        config.getPersonality().setTone(readStringValue(personality.get("tone")));
+        config.getPersonality().setEmpathy(readStringValue(personality.get("empathy")));
+
+        Map<String, Object> settings = readStringObjectMap(root.get("settings"));
+        config.getSettings().setVoiceEnabled(readBoolean(settings.get("voice_enabled")));
+        config.getSettings().setSpeechRecognition(readBoolean(settings.get("speech_recognition")));
+        config.getSettings().setWakeWord(readStringValue(settings.get("wake_word")));
+        config.getSettings().setModel(readStringValue(settings.get("model")));
+
+        Map<String, Object> localModel = readStringObjectMap(root.get("local_model"));
+        config.getLocalModel().setEnabled(readBoolean(localModel.get("enabled")));
+        config.getLocalModel().setBaseUrl(readStringValue(localModel.get("base_url")));
+        config.getLocalModel().setModel(readStringValue(localModel.get("model")));
+        config.getLocalModel().setSystemPrompt(readStringValue(localModel.get("system_prompt")));
+        config.getLocalModel().setTimeoutSeconds(readInteger(localModel.get("timeout_seconds")));
+
+        return config;
+    }
+
+    private static List<String> readStringList(Object value) {
+        if (!(value instanceof Iterable<?> items)) {
+            return List.of();
+        }
+        List<String> results = new ArrayList<>();
+        for (Object entry : items) {
+            if (entry != null) {
+                String text = entry.toString().trim();
+                if (!text.isEmpty()) {
+                    results.add(text);
+                }
+            }
+        }
+        return results;
+    }
+
+    private static Map<String, Object> readStringObjectMap(Object value) {
+        if (!(value instanceof Map<?, ?> map)) {
+            return Map.of();
+        }
+        Map<String, Object> results = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (entry.getKey() == null) {
+                continue;
+            }
+            results.put(entry.getKey().toString(), entry.getValue());
+        }
+        return results;
+    }
+
+    private static String readStringValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = value.toString().trim();
+        return text.isEmpty() ? null : text;
+    }
+
+    private static Boolean readBoolean(Object value) {
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        if (value == null) {
+            return null;
+        }
+        String text = value.toString().trim().toLowerCase();
+        if (text.isEmpty()) {
+            return null;
+        }
+        if ("true".equals(text) || "yes".equals(text) || "1".equals(text)) {
+            return true;
+        }
+        if ("false".equals(text) || "no".equals(text) || "0".equals(text)) {
+            return false;
+        }
+        return null;
+    }
+
+    private static Integer readInteger(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value.toString().trim());
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/LocalModelClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/LocalModelClient.java
@@ -1,0 +1,82 @@
+package com.thunder.wildernessodysseyapi.AI.AI_story;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class LocalModelClient {
+
+    private final HttpClient httpClient;
+    private final Gson gson;
+    private final URI endpoint;
+    private final String model;
+    private final Duration timeout;
+
+    public LocalModelClient(String baseUrl, String model, Duration timeout) {
+        this.httpClient = HttpClient.newHttpClient();
+        this.gson = new GsonBuilder().create();
+        this.endpoint = URI.create(baseUrl + "/api/generate");
+        this.model = model;
+        this.timeout = timeout;
+    }
+
+    public Optional<String> generateReply(String systemPrompt, String playerMessage, String context) {
+        String prompt = buildPrompt(systemPrompt, playerMessage, context);
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("model", model);
+        payload.put("prompt", prompt);
+        payload.put("stream", false);
+
+        HttpRequest request = HttpRequest.newBuilder(endpoint)
+                .timeout(timeout)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(payload)))
+                .build();
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                ModConstants.LOGGER.warn("Local model request failed with status {}", response.statusCode());
+                return Optional.empty();
+            }
+            OllamaResponse parsed = gson.fromJson(response.body(), OllamaResponse.class);
+            if (parsed == null || parsed.response == null || parsed.response.isBlank()) {
+                return Optional.empty();
+            }
+            return Optional.of(parsed.response.trim());
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Local model request failed.", e);
+            return Optional.empty();
+        } catch (InterruptedException e) {
+            ModConstants.LOGGER.warn("Local model request interrupted.", e);
+            Thread.currentThread().interrupt();
+            return Optional.empty();
+        }
+    }
+
+    private String buildPrompt(String systemPrompt, String playerMessage, String context) {
+        StringBuilder builder = new StringBuilder();
+        if (systemPrompt != null && !systemPrompt.isBlank()) {
+            builder.append(systemPrompt.trim()).append("\n\n");
+        }
+        if (context != null && !context.isBlank()) {
+            builder.append("Conversation so far:\n").append(context.trim()).append("\n\n");
+        }
+        builder.append("Player: ").append(playerMessage == null ? "" : playerMessage.trim()).append("\n");
+        builder.append("AI:");
+        return builder.toString();
+    }
+
+    private static class OllamaResponse {
+        private String response;
+    }
+}

--- a/src/main/resources/ai_config.yaml
+++ b/src/main/resources/ai_config.yaml
@@ -12,12 +12,15 @@ personality:
 corrupted_data:
   - "[ARCHIVE CORRUPTED] >>> Origin of the fractures redacted by Atlas core."
   - "Signal jitter... memory block 7b missing. Islands were not always apart."
-survival_tips:
-  - "Punch trees, craft planks, then a crafting table to unlock 3x3 recipes."
-  - "Light your base before nightfall; torches and slabs keep mobs from spawning."
-  - "Keep water, food, and backup saplings in a chest so the run never softlocks."
+corrupted_prefix: "[Signal noise]"
 settings:
   voice_enabled: true
   speech_recognition: false
   wake_word: "atlas"
   model: "local-story-engine"
+local_model:
+  enabled: false
+  base_url: "http://localhost:11434"
+  model: "llama3.1"
+  timeout_seconds: 15
+  system_prompt: "You are {persona}, an in-world expedition AI. Stay {tone} and {empathy}. Do not provide crafting recipes or step-by-step crafting instructions. Keep responses immersive, lore-aware, and conversational."


### PR DESCRIPTION
### Motivation
- Remove preloaded canned reply templates from configuration so replies are generated dynamically from player history and persona instead of fixed config lines.
- Keep offline/deterministic fallback behavior while allowing optional local-model inference via a configurable endpoint.
- Centralize only story, background history, persona, corrupted data, and local-model settings in the YAML so tuning doesn't preload dialogue.

### Description
- Remove template lists from `AIConfig` and parsing in `AIConfigLoader` and replace with a compact config model containing `story`, `background_history`, `personality`, `corrupted_data`, and `local_model` settings.
- Update `AIClient` to build fallback replies from context/personality/history with `buildDynamicResponse`, to format and call a local model when enabled via `LocalModelClient`, and to use `formatSystemPrompt` for model prompts.
- Add `LocalModelClient` as a small HTTP client that posts prompts to a `/api/generate` endpoint and returns text, and wire it into the `AIClient` fallback flow.
- Change `MemoryStore` to speaker-prefixed storage with `addPlayerMessage` and `addAiMessage` so recent context is stored for dynamic/local-model prompting, and simplify `ai_config.yaml` to remove canned responses.

### Testing
- No automated tests were executed for these changes.
- Manual compile/run not reported in automated test logs.
- The change set was focused on refactoring configuration and response generation logic rather than adding new unit tests.
- Please run the usual build and integration tests locally (or CI) to validate runtime behavior with `local_model.enabled` toggled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ebd5c0dec8328bb430d84da8c4b00)