### PR TITLE
Align bunker placement to surface, deny spawns in placement bounds, and clear grass in footprint

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -196,13 +196,14 @@ public class NBTStructurePlacer {
         }
 
         SurfaceSample sample = TerrainReplacerEngine.sampleSurface(level, origin.offset(levelingOffset.getX(), 0, levelingOffset.getZ()));
-        int desiredY = sample.y() - levelingOffset.getY();
+        int surfaceAnchorY = sample.y() + 1;
+        int desiredY = surfaceAnchorY - levelingOffset.getY();
         int maxDepth = StructureConfig.MAX_LEVELING_DEPTH.get();
         if (maxDepth >= 0) {
-            int clampedY = Math.max(desiredY, sample.y() - maxDepth);
+            int clampedY = Math.max(desiredY, surfaceAnchorY - maxDepth);
             if (clampedY != desiredY) {
                 ModConstants.LOGGER.warn("Clamping leveling depth for structure {}. Desired bury depth {} exceeds limit {} at marker {}.",
-                        id, sample.y() - desiredY, maxDepth, levelingOffset);
+                        id, surfaceAnchorY - desiredY, maxDepth, levelingOffset);
                 desiredY = clampedY;
             }
         }

--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/SpawnBunkerGameTests.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/SpawnBunkerGameTests.java
@@ -60,7 +60,7 @@ public class SpawnBunkerGameTests {
         }
 
         BlockPos guardCenter = BlockPos.containing(result.bounds().getCenter());
-        StarterStructureSpawnGuard.registerSpawnDenyZone(helper.getLevel(), guardCenter);
+        StarterStructureSpawnGuard.registerSpawnDenyZone(helper.getLevel(), result.bounds());
 
         helper.runAtTickTime(2, () -> {
             helper.assertTrue(StarterStructureSpawnGuard.isDenied(helper.getLevel(), guardCenter),


### PR DESCRIPTION
### Motivation
- Prevent the spawn bunker from being buried below ground by anchoring leveling to the sampled surface rather than the raw marker Y. 
- Ensure hostile mobs do not spawn anywhere inside the actual placed structure footprint. 
- Remove grass/plant blocks inside the bunker footprint so the structure can be placed cleanly against terrain. 
- Update game tests to exercise the new bounds-based spawn guard registration.

### Description
- Adjust `NBTStructurePlacer.resolvePlacementOrigin` to compute the placement Y using a surface anchor (`surfaceAnchorY = sample.y() + 1`) and clamp bury depth against `StructureConfig.MAX_LEVELING_DEPTH`. 
- Replace the radius-based spawn-deny API with an AABB-backed guard by adding `registerSpawnDenyZone(ServerLevel, AABB)` and storing `SpawnDenyZone` entries using `AABB` bounds, and update debug logging accordingly. 
- Call the new bounds-based guard from `SpawnBunkerPlacer` using `result.bounds()` and add `clearGrassInBounds` which iterates the placement `AABB` and replaces grass/plant blocks with air. 
- Update the `SpawnBunkerGameTests` to register the spawn deny zone with the placement bounds instead of a single center position.

### Testing
- No automated tests were executed as part of this change. 
- The `SpawnBunkerGameTests` were updated to use the new bounds-based API but were not run here. 
- The project compiles locally in CI (not executed in this PR). 
- Developer manual validation recommended to run the gametests and a full build (`./gradlew build`) to confirm behavior in-game.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ecaa94dd48328ab89bafc7692f16e)