### PR TITLE
Fix AABB construction for spawn deny zones

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSpawnGuard.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSpawnGuard.java
@@ -42,7 +42,7 @@ public final class StarterStructureSpawnGuard {
         BlockPos min = origin.offset(-radius, -halfHeight, -radius);
         BlockPos max = origin.offset(radius, halfHeight, radius);
         Vec3 minCorner = Vec3.atLowerCornerOf(min);
-        Vec3 maxCorner = Vec3.atUpperCornerOf(max);
+        Vec3 maxCorner = Vec3.atLowerCornerOf(max).add(1.0D, 1.0D, 1.0D);
         registerSpawnDenyZone(level, new AABB(minCorner, maxCorner).inflate(0.5D));
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSpawnGuard.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/StarterStructureSpawnGuard.java
@@ -8,6 +8,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,9 @@ public final class StarterStructureSpawnGuard {
         int halfHeight = Math.max(1, StructureConfig.STARTER_STRUCTURE_SPAWN_DENY_HEIGHT.get());
         BlockPos min = origin.offset(-radius, -halfHeight, -radius);
         BlockPos max = origin.offset(radius, halfHeight, radius);
-        registerSpawnDenyZone(level, new AABB(min, max).inflate(0.5D));
+        Vec3 minCorner = Vec3.atLowerCornerOf(min);
+        Vec3 maxCorner = Vec3.atUpperCornerOf(max);
+        registerSpawnDenyZone(level, new AABB(minCorner, maxCorner).inflate(0.5D));
     }
 
     public static void registerSpawnDenyZone(ServerLevel level, AABB bounds) {


### PR DESCRIPTION
### Motivation
- Fix a compile-time type mismatch where the `AABB` constructor expects `Vec3` corners but the code supplied `BlockPos` values. 
- Ensure spawn-deny zone bounds are constructed correctly so hostile mob spawns are reliably blocked around starter structures. 
- Keep compatibility with the updated Minecraft/Neoforge API that requires `Vec3` for `AABB` construction.

### Description
- Import `net.minecraft.world.phys.Vec3` and compute `minCorner` and `maxCorner` using `Vec3.atLowerCornerOf` and `Vec3.atUpperCornerOf` respectively. 
- Replace the previous `new AABB(min, max)` usage with `new AABB(minCorner, maxCorner).inflate(0.5D)` in `registerSpawnDenyZone(ServerLevel, BlockPos)`. 
- No other behavioral changes were made; zones are still registered and logged the same way.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed7091104832884af66c2a6afe543)