### PR TITLE
Bundle SnakeYAML into mod jar to fix runtime NoClassDefFoundError

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,6 +198,7 @@ dependencies {
     bundledLibs 'com.squareup.okio:okio:3.9.0'
     bundledLibs 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
     bundledLibs 'com.github.luben:zstd-jni:1.5.7-6'
+    bundledLibs 'org.yaml:snakeyaml:2.2'
 
     testImplementation platform("org.junit:junit-bom:${junitVersion}")
     testImplementation 'org.junit.jupiter:junit-jupiter'


### PR DESCRIPTION
### Motivation
- The server crashed at startup with `java.lang.NoClassDefFoundError: org/yaml/snakeyaml/error/YAMLException` when `AIClient.loadStory` attempted to load YAML.
- `snakeyaml` was declared as an `implementation` dependency but was not being bundled into the mod jar runtime classpath, causing missing-class errors under the secure classloader.

### Description
- Added a bundled dependency entry for SnakeYAML in `build.gradle` by adding `bundledLibs 'org.yaml:snakeyaml:2.2'` so the library is included inside the final mod jar.
- The change ensures the runtime classpath provided to the mod includes SnakeYAML to prevent `NoClassDefFoundError` in environments that isolate mod classloaders.

### Testing
- No automated tests were run for this change.
- (Manual testing recommended: run the dev server or build the mod and verify the previous crash no longer occurs.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695edf18f15883289eaa2abc1aac1c2e)