### PR TITLE
Clamp blue wool leveling marker to minimum Y=64

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -41,6 +41,7 @@ public class NBTStructurePlacer {
     private static final String CREATE_ELEVATOR_PULLEY_NAME = "create:elevator_pulley";
     private static final String LEVELING_MARKER_NAME =
             BuiltInRegistries.BLOCK.getKey(Blocks.BLUE_WOOL).toString();
+    private static final int MIN_LEVELING_MARKER_Y = 64;
 
     private final ResourceLocation id;
     private TemplateData cachedData;
@@ -228,6 +229,14 @@ public class NBTStructurePlacer {
                         id, surfaceAnchorY - desiredY, maxDepth, levelingOffset);
                 desiredY = clampedY;
             }
+        }
+
+        int markerY = desiredY + levelingOffset.getY();
+        if (markerY < MIN_LEVELING_MARKER_Y) {
+            ModConstants.LOGGER.warn(
+                    "Raising structure {} so the leveling marker sits at y={} instead of y={}.",
+                    id, MIN_LEVELING_MARKER_Y, markerY);
+            desiredY = MIN_LEVELING_MARKER_Y - levelingOffset.getY();
         }
 
         BlockPos placementOrigin = new BlockPos(origin.getX(), desiredY, origin.getZ());


### PR DESCRIPTION
### Motivation
- Prevent structures from placing so that the blue wool leveling marker ends up below the intended playable surface (e.g., below bedrock/very low Y). 
- Ensure templates that use blue wool as a leveling anchor are not buried too deeply by terrain sampling and clamping logic. 

### Description
- Added a `MIN_LEVELING_MARKER_Y` constant set to `64` and applied it in `NBTStructurePlacer.resolvePlacementOrigin` to ensure the computed marker Y is not lower than 64. 
- Adjusts `desiredY` when the marker would otherwise be below `MIN_LEVELING_MARKER_Y` so the template is raised accordingly. 
- Emits a warning log when placement is raised: the message indicates the structure id and the adjusted marker Y. 

### Testing
- No automated tests were executed as part of this change. 
- The change is limited to `src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java` and compiles locally as part of the worktree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f19fa0b38832881f76db9fe6fca4f)