### PR TITLE
Queue Atlas replies, remove echoed input, and disable stub voice output

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIChatListener.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIChatListener.java
@@ -50,10 +50,7 @@ public class AIChatListener {
         VoiceIntegration.VoiceResult reply = CLIENT.sendMessageWithVoice(worldKey,
                 player.getName().getString(), message);
 
-        player.sendSystemMessage(Component.literal("[Atlas] " + reply.text()));
-        if (reply.voiceQueued() && reply.voiceLine() != null && !reply.voiceLine().isBlank()) {
-            player.sendSystemMessage(Component.literal("[Atlas Voice] " + reply.voiceLine()));
-        }
+        player.getServer().execute(() -> player.sendSystemMessage(Component.literal("[Atlas] " + reply.text())));
     }
 
     @SubscribeEvent

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
@@ -227,9 +227,6 @@ public class AIClient {
         private String warmWelcome(String cleanMessage, String player, String world) {
             StringBuilder welcome = new StringBuilder();
             welcome.append("Hey ").append(player).append(", I'm ").append(personaName).append(".");
-            if (!cleanMessage.isEmpty()) {
-                welcome.append(" You said: \"").append(cleanMessage).append("\".");
-            }
             welcome.append(" I'm here to keep the mission on track in ").append(world == null || world.isBlank() ? "this world" : world).append(".");
             return welcome.toString();
         }

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/VoiceIntegration.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/VoiceIntegration.java
@@ -15,10 +15,6 @@ public class VoiceIntegration {
     }
 
     public VoiceResult wrap(String text) {
-        if (!settings.isVoiceEnabled()) {
-            return new VoiceResult(text, null, false, settings.isSpeechRecognition());
-        }
-        String voice = "Atlas (voice): " + text;
-        return new VoiceResult(text, voice, true, settings.isSpeechRecognition());
+        return new VoiceResult(text, null, false, settings.isSpeechRecognition());
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure Atlas chat replies appear after the player's message in chat by sending them on the server queue. 
- Prevent Atlas from repeating the player's input back to them in the welcome message. 
- Stop emitting the offline stub voice text into chat so voice output is not duplicated. 
- Align behavior with an actual TTS/ASR pipeline by disabling the placeholder voice-line emission.

### Description
- Send Atlas replies via `player.getServer().execute(...)` in `AIChatListener` so messages are queued on the server thread. 
- Remove the `You said: ...` echo from the `warmWelcome` method in `AIClient`. 
- Modify `VoiceIntegration.wrap` to always return no `voiceLine` and `voiceQueued = false`, preserving `speechInputAllowed` from settings. 
- As a result, the code no longer sends `[Atlas Voice]` chat lines to the player.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f1a6ecce883288e0fba8b23a28a3a)