### PR TITLE
Adjust bunker placement rules

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java
@@ -1,0 +1,43 @@
+package com.thunder.wildernessodysseyapi.WorldGen.processor;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+
+/**
+ * Prevents the bunker template from clearing non-dirt blocks when placing air inside the structure.
+ */
+public class BunkerPlacementProcessor extends StructureProcessor {
+    public static final MapCodec<BunkerPlacementProcessor> CODEC = MapCodec.unit(BunkerPlacementProcessor::new);
+
+    @Override
+    protected StructureProcessorType<?> getType() {
+        return ModProcessors.BUNKER_PLACEMENT.get();
+    }
+
+    @Override
+    public StructureTemplate.StructureBlockInfo processBlock(LevelReader level,
+                                                             BlockPos pos,
+                                                             BlockPos pivot,
+                                                             StructureTemplate.StructureBlockInfo raw,
+                                                             StructureTemplate.StructureBlockInfo placed,
+                                                             StructurePlaceSettings settings) {
+        BlockState state = placed.state();
+        if (!state.isAir()) {
+            return placed;
+        }
+
+        BlockState existing = level.getBlockState(placed.pos());
+        if (existing.isAir() || existing.is(Blocks.DIRT)) {
+            return placed;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/ModProcessors.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/ModProcessors.java
@@ -19,6 +19,11 @@ public final class ModProcessors {
      */
     public static final DeferredHolder<StructureProcessorType<?>, StructureProcessorType<TerrainSurveyProcessor>> TERRAIN_SURVEY =
             PROCESSORS.register("terrain_survey", () -> () -> TerrainSurveyProcessor.CODEC);
+    /**
+     * Processor that prevents bunker placement from clearing non-dirt blocks when air is placed.
+     */
+    public static final DeferredHolder<StructureProcessorType<?>, StructureProcessorType<BunkerPlacementProcessor>> BUNKER_PLACEMENT =
+            PROCESSORS.register("bunker_placement", () -> () -> BunkerPlacementProcessor.CODEC);
 
     private ModProcessors() {
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -18,6 +18,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.StructureBlockInfo;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
@@ -45,6 +46,7 @@ public class NBTStructurePlacer {
     private static final int MAX_LEVELING_MARKER_Y = 65;
 
     private final ResourceLocation id;
+    private final List<StructureProcessor> extraProcessors;
     private TemplateData cachedData;
 
     public NBTStructurePlacer(String namespace, String path) {
@@ -52,7 +54,12 @@ public class NBTStructurePlacer {
     }
 
     public NBTStructurePlacer(ResourceLocation id) {
+        this(id, List.of());
+    }
+
+    public NBTStructurePlacer(ResourceLocation id, List<StructureProcessor> extraProcessors) {
         this.id = id;
+        this.extraProcessors = List.copyOf(extraProcessors);
     }
 
     /**
@@ -174,6 +181,9 @@ public class NBTStructurePlacer {
                 // Preserve entities baked into the template (e.g., Create super glue and contraptions) so
                 // complex machines such as elevators remain assembled after placement.
                 .setIgnoreEntities(false);
+        for (StructureProcessor processor : extraProcessors) {
+            settings.addProcessor(processor);
+        }
         boolean placed = data.template().placeInWorld(level, foundation.origin(), foundation.origin(), settings, level.random, 2);
         if (!placed) {
             StructurePlacementDebugger.markFailure(attempt, "template refused placement");


### PR DESCRIPTION
### Motivation
- Prevent structure placement from destroying non-dirt blocks inside the starter bunker so only dirt and air may be overwritten during placement.
- Ensure the starter bunker is never anchored in ocean biomes by preferring a nearby land biome for spawn placement.
- Provide a mechanism to attach placement-specific processors to vanilla template placements for targeted behavior.

### Description
- Add `BunkerPlacementProcessor` which skips applying template air where the existing block is neither air nor `Blocks.DIRT`.
- Register a `bunker_placement` processor in `ModProcessors` and pass an instance to the bunker placer via a new `NBTStructurePlacer` constructor that accepts `extraProcessors`.
- Update `NBTStructurePlacer` to accept and add `StructureProcessor`s to `StructurePlaceSettings` so processors are applied during `placeInWorld`.
- Change `SpawnBunkerPlacer` to search for a land anchor within `LAND_SEARCH_RADIUS` using `LAND_SEARCH_STEP` grid steps and tighten `sealRoofAndDrainWater` to only replace `air` or `dirt` when capping.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f23b3ade883288b4425d26b57971c)