### PR TITLE
Only replace dirt for bunker air

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java
@@ -11,7 +11,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProc
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 /**
- * Prevents the bunker template from clearing non-dirt blocks when placing air inside the structure.
+ * Prevents the bunker template from clearing anything other than dirt when placing air inside the structure.
  */
 public class BunkerPlacementProcessor extends StructureProcessor {
     public static final MapCodec<BunkerPlacementProcessor> CODEC = MapCodec.unit(BunkerPlacementProcessor::new);
@@ -34,7 +34,7 @@ public class BunkerPlacementProcessor extends StructureProcessor {
         }
 
         BlockState existing = level.getBlockState(placed.pos());
-        if (existing.isAir() || existing.is(Blocks.DIRT)) {
+        if (existing.is(Blocks.DIRT)) {
             return placed;
         }
 


### PR DESCRIPTION
### Motivation
- Restrict bunker template air blocks so they only replace dirt and do not propagate through existing empty space.
- Prevent template air from allowing placement to pass through or cancel when the target location is already empty.
- Avoid clearing or modifying non-dirt blocks during bunker placement.

### Description
- Changed the check in `BunkerPlacementProcessor.processBlock` to only allow placement when the existing block `is(Blocks.DIRT)`.
- Removed the `existing.isAir()` branch so template air no longer passes through existing air blocks.
- Updated the class comment to clarify that only dirt will be cleared by bunker air placement.
- Modified `src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3a00b21483288fc30254a1d76f5a)