### PR TITLE
Allow bunker template air blocks to clear space

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java
@@ -3,15 +3,13 @@ package com.thunder.wildernessodysseyapi.WorldGen.processor;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 /**
- * Prevents the bunker template from clearing anything other than dirt when placing air inside the structure.
+ * Ensures air blocks from the bunker template are placed so the interior stays clear.
  */
 public class BunkerPlacementProcessor extends StructureProcessor {
     public static final MapCodec<BunkerPlacementProcessor> CODEC = MapCodec.unit(BunkerPlacementProcessor::new);
@@ -28,16 +26,6 @@ public class BunkerPlacementProcessor extends StructureProcessor {
                                                              StructureTemplate.StructureBlockInfo raw,
                                                              StructureTemplate.StructureBlockInfo placed,
                                                              StructurePlaceSettings settings) {
-        BlockState state = placed.state();
-        if (!state.isAir()) {
-            return placed;
-        }
-
-        BlockState existing = level.getBlockState(placed.pos());
-        if (existing.is(Blocks.DIRT)) {
-            return placed;
-        }
-
-        return null;
+        return placed;
     }
 }


### PR DESCRIPTION
### Motivation
- The bunker template should preserve interior emptiness by allowing template air to replace existing blocks during placement. 
- The previous processor prevented template air from clearing anything except dirt, which left unwanted blocks inside the bunker footprint. 

### Description
- Simplified `BunkerPlacementProcessor.processBlock` to always return the `placed` block info so template air is applied. 
- Updated the class Javadoc to reflect the new behavior. 
- Removed now-unused imports for `Blocks` and `BlockState` from `BunkerPlacementProcessor`. 
- Change affects `src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java`. 

### Testing
- No automated tests were executed as part of this change. 
- The change is limited to processor logic and compiles with the updated imports. 
- Manual or integration testing is recommended to verify bunker interiors are cleared as expected after placement. 
- No existing automated test failures were observed prior to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe6d814b08328ad9eaf8f94ec7ec8)