### PR TITLE
Limit bunker terrain replacement to grass

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -326,6 +326,13 @@ public class NBTStructurePlacer {
                 continue;
             }
             BlockPos worldPos = origin.offset(offset);
+            BlockState existing = level.getBlockState(worldPos);
+            if (existing.isAir()) {
+                continue;
+            }
+            if (forceDirtLayer && !existing.is(Blocks.GRASS_BLOCK)) {
+                continue;
+            }
             BlockState replacement = forceDirtLayer
                     ? Blocks.DIRT.defaultBlockState()
                     : plan.samples().get(i);


### PR DESCRIPTION
### Motivation

- Prevent terrain replacer from writing blocks into the bunker interior and accidentally filling non-terrain air space. 
- Restrict the forced-dirt layer applied for the `bunker` template to only convert surface grass so we don't overwrite non-grass surfaces. 

### Description

- Modified `NBTStructurePlacer.applyTerrainReplacement` to skip replacement when the existing world block at the target `worldPos` is air. 
- When `forceDirtLayer` is true (bunker leveling case), only perform the replacement if the existing block is `Blocks.GRASS_BLOCK`. 
- Kept the normal terrain-replacer path intact so sampled replacements from `plan.samples()` are still used for non-forced cases. 
- Change implemented in `src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java`.

### Testing

- No automated tests were run for this change. 
- No continuous integration or unit tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696052b676008328849138bd998426ec)