### PR TITLE
Feather terrain auto-blend around structures

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/configurable/StructureConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/configurable/StructureConfig.java
@@ -21,6 +21,12 @@ public class StructureConfig {
     public static final ModConfigSpec.BooleanValue ENABLE_TERRAIN_REPLACER;
     /** Warn when terrain replacer usage exceeds this fraction of the template volume */
     public static final ModConfigSpec.DoubleValue TERRAIN_REPLACER_WARNING_THRESHOLD;
+    /** Fill gaps below structures even when no terrain markers are present. */
+    public static final ModConfigSpec.BooleanValue ENABLE_AUTO_TERRAIN_BLEND;
+    /** Maximum height (in blocks) to fill when auto-blending under structures. */
+    public static final ModConfigSpec.IntValue AUTO_TERRAIN_BLEND_MAX_DEPTH;
+    /** Horizontal radius (in blocks) to feather terrain around placed structures. */
+    public static final ModConfigSpec.IntValue AUTO_TERRAIN_BLEND_RADIUS;
     /** Maximum depth (blocks) the leveling marker may sit below the sampled surface; -1 disables clamping */
     public static final ModConfigSpec.IntValue MAX_LEVELING_DEPTH;
     /** Prevent hostile mob spawns inside the starter bunker immediately after placement */
@@ -59,6 +65,18 @@ public class StructureConfig {
                                 + " Helps catch mistakenly-exported templates that would be overwritten by terrain."
                 )
                 .defineInRange("terrainReplacerWarningThreshold", 0.35D, 0.0D, 1.0D);
+        ENABLE_AUTO_TERRAIN_BLEND = BUILDER.comment(
+                        "If true, structure placement will attempt to blend terrain even when no terrain marker blocks exist."
+                )
+                .define("enableAutoTerrainBlend", true);
+        AUTO_TERRAIN_BLEND_MAX_DEPTH = BUILDER.comment(
+                        "Maximum number of blocks to fill upward from the surface when auto-blending structures."
+                )
+                .defineInRange("autoTerrainBlendMaxDepth", 6, 1, 64);
+        AUTO_TERRAIN_BLEND_RADIUS = BUILDER.comment(
+                        "Horizontal radius to feather terrain around structures when auto-blending is enabled."
+                )
+                .defineInRange("autoTerrainBlendRadius", 2, 0, 8);
         MAX_LEVELING_DEPTH = BUILDER.comment(
                         "Maximum number of blocks the leveling marker may be placed below the sampled surface."
                                 + " Prevents tall templates from being buried when the blue wool marker sits high above the"

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/TerrainSurveyProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/TerrainSurveyProcessor.java
@@ -46,7 +46,8 @@ public class TerrainSurveyProcessor extends StructureProcessor {
         }
 
         if (state.is(TerrainReplacerBlock.TERRAIN_REPLACER.get())) {
-            BlockState sampled = TerrainReplacerEngine.sampleSurfaceBlock(level, placed.pos());
+            var material = TerrainReplacerEngine.sampleSurfaceMaterial(level, placed.pos());
+            BlockState sampled = TerrainReplacerEngine.chooseReplacement(material, placed.pos().getY());
             return new StructureTemplate.StructureBlockInfo(placed.pos(), sampled, placed.nbt());
         }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -192,6 +192,14 @@ public class NBTStructurePlacer {
 
         int replaced = applyTerrainReplacement(level, foundation.origin(), data.terrainOffsets(),
                 replacementPlan, data.levelingOffset());
+        int autoBlended = 0;
+        if (replaced == 0
+                && data.terrainOffsets().isEmpty()
+                && StructureConfig.ENABLE_AUTO_TERRAIN_BLEND.get()) {
+            int maxDepth = StructureConfig.AUTO_TERRAIN_BLEND_MAX_DEPTH.get();
+            int radius = StructureConfig.AUTO_TERRAIN_BLEND_RADIUS.get();
+            autoBlended = TerrainReplacerEngine.applyAutoBlend(level, placementBox, maxDepth, radius);
+        }
 
         if (data.levelingOffset() != null && foundation.levelingReplacement() != null) {
             BlockPos markerWorldPos = foundation.origin().offset(data.levelingOffset());
@@ -213,7 +221,8 @@ public class NBTStructurePlacer {
                 .toList();
 
         StructurePlacementDebugger.markSuccess(attempt,
-                "placed with %s terrain samples and %s cryo tubes".formatted(replaced, cryoPositions.size()));
+                "placed with %s terrain samples, %s auto-blended blocks, and %s cryo tubes"
+                        .formatted(replaced, autoBlended, cryoPositions.size()));
 
         return new PlacementResult(foundation.origin(), bounds, cryoPositions, List.copyOf(chunkSlices));
     }


### PR DESCRIPTION
### Motivation
- Improve visual blending of placed structures into surrounding terrain for templates that lack terrain markers (including modded templates). 
- Allow server operators to tune how far the auto-blend should feather outward so edges transition more naturally without changing the structure itself. 
- Preserve the chosen topsoil/filler sampling behavior while extending blending to nearby columns outside the exact template footprint. 

### Description
- Add a new config `AUTO_TERRAIN_BLEND_RADIUS` (`autoTerrainBlendRadius`) to `StructureConfig` to control the horizontal feather radius for auto-blending. 
- Extend `TerrainReplacerEngine` with `sampleSurfaceMaterial`, `chooseReplacement`, and an updated `applyAutoBlend(ServerLevel, BoundingBox, int, int)` that expands blending to an outer bounds and resolves nearest footprint columns via `resolveBaseY`/`expandBounds`. 
- Update `TerrainSurveyProcessor` to sample `SurfaceMaterial` and use `chooseReplacement`, and thread the new radius through `NBTStructurePlacer` to call the updated `applyAutoBlend`, while also reporting the auto-blended block count in placement logs. 

### Testing
- No automated tests were run for these changes. 
- The changes were compiled and committed in the working tree as part of the PR creation workflow (no runtime or unit tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69605819f5088328b5e209ab65b6f080)