### PR TITLE
Restrict bunker terrain replacement to surface marker layer

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -330,12 +330,16 @@ public class NBTStructurePlacer {
             if (existing.isAir()) {
                 continue;
             }
-            if (forceDirtLayer && !existing.is(Blocks.GRASS_BLOCK)) {
+            if (forceDirtLayer) {
+                SurfaceSample sample = TerrainReplacerEngine.sampleSurface(level, worldPos);
+                if (sample.y() != worldPos.getY()) {
+                    continue;
+                }
+                level.setBlock(worldPos, Blocks.DIRT.defaultBlockState(), 2);
+                applied++;
                 continue;
             }
-            BlockState replacement = forceDirtLayer
-                    ? Blocks.DIRT.defaultBlockState()
-                    : plan.samples().get(i);
+            BlockState replacement = plan.samples().get(i);
             level.setBlock(worldPos, replacement, 2);
             applied++;
         }


### PR DESCRIPTION
### Motivation
- Prevent terrain replacer markers from overwriting blocks inside the spawn bunker by restricting replacement to the marker's surface layer. 
- Ensure sampled terrain (or forced dirt) is only applied where the template's leveling marker actually sits at the sampled surface height. 

### Description
- Update `NBTStructurePlacer.applyTerrainReplacement` to, when `shouldForceDirtLayer` is true, call `TerrainReplacerEngine.sampleSurface` for each candidate and only place `Blocks.DIRT` if `sample.y() == worldPos.getY()`.
- Preserve the original sampled-replacement behavior for non-bunker cases by applying `plan.samples()` for normal offsets.
- Removes the previous heuristic that checked `existing.is(Blocks.GRASS_BLOCK)` and replaces it with a direct surface-height check to avoid interior fills.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69606c1a01788328bf6ef12db529a862)