### PR TITLE
Queue Atlas replies to server tick and simplify AI responses

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
@@ -209,7 +209,7 @@ public class AIClient {
                 reply.append(loreHook).append(" ");
             }
 
-            reply.append(buildDynamicResponse(cleanMessage, context, player));
+            reply.append(buildDynamicResponse(cleanMessage, context));
 
             String background = backgroundBeat();
             if (!background.isEmpty()) {
@@ -251,35 +251,17 @@ public class AIClient {
             return message.toLowerCase(Locale.ROOT).contains(wakeWord);
         }
 
-        private String buildDynamicResponse(String message, String context, String player) {
-            StringBuilder builder = new StringBuilder();
-            String mood = buildMoodLine();
-            if (!mood.isBlank()) {
-                builder.append(mood).append(" ");
+        private String buildDynamicResponse(String message, String context) {
+            String contextNote = summarizeContext(context);
+            if (!contextNote.isBlank()) {
+                return contextNote;
             }
             String history = pickHistoryBeat();
             if (!history.isBlank()) {
-                builder.append(history).append(" ");
+                return history;
             }
-            String contextNote = summarizeContext(context);
-            if (!contextNote.isBlank()) {
-                builder.append("I remember you said: \"").append(contextNote).append("\". ");
-            }
-            builder.append("Tell me where you want to take this next, ").append(player).append(".");
-            return builder.toString().trim();
-        }
-
-        private String buildMoodLine() {
-            if (personalityTone.isBlank() && empathyLevel.isBlank()) {
-                return "";
-            }
-            if (!personalityTone.isBlank() && !empathyLevel.isBlank()) {
-                return "Staying " + personalityTone + " and " + empathyLevel + " for you.";
-            }
-            if (!personalityTone.isBlank()) {
-                return "Keeping the tone " + personalityTone + ".";
-            }
-            return "Staying " + empathyLevel + " while we plan.";
+            String cleanMessage = message == null ? "" : message.trim();
+            return cleanMessage;
         }
 
         private String pickHistoryBeat() {


### PR DESCRIPTION
### Motivation
- Users observed the AI reply appearing before the player's chat message and the replies felt robotic and overly canned.
- The change aims to ensure player chat appears first by deferring AI messages to the server tick and to make replies rely more on recent context and lore.

### Description
- In `AIChatListener` add a `PENDING_REPLIES` `ConcurrentLinkedQueue` and enqueue `PendingReply` objects instead of sending messages immediately from the chat handler.
- Add a `@SubscribeEvent` `onServerTick` handler that flushes queued replies to players on `ServerTickEvent.Post` and introduce the `PendingReply` record.
- Simplify `AIClient.buildDynamicResponse` to prefer recent context (`summarizeContext`) or a `pickHistoryBeat` before falling back to echoing the cleaned player message, removing the previous rigid mood/tone lines.
- Adjusted imports and callsites to match the new method signature changes and behavior for voice replies via `sendMessageWithVoice`.

### Testing
- No automated tests were executed for this change.
- The patch was applied and committed locally without running build or unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69606cba9ddc83288200121887a06053)