### PR TITLE
Avoid auto-blend filling structure interiors

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/configurable/StructureConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/configurable/StructureConfig.java
@@ -23,6 +23,8 @@ public class StructureConfig {
     public static final ModConfigSpec.DoubleValue TERRAIN_REPLACER_WARNING_THRESHOLD;
     /** Fill gaps below structures even when no terrain markers are present. */
     public static final ModConfigSpec.BooleanValue ENABLE_AUTO_TERRAIN_BLEND;
+    /** Skip auto-blend in columns where the structure does not touch the template's bottom layer. */
+    public static final ModConfigSpec.BooleanValue ENABLE_SMART_AUTO_TERRAIN_BLEND;
     /** Maximum height (in blocks) to fill when auto-blending under structures. */
     public static final ModConfigSpec.IntValue AUTO_TERRAIN_BLEND_MAX_DEPTH;
     /** Horizontal radius (in blocks) to feather terrain around placed structures. */
@@ -69,6 +71,11 @@ public class StructureConfig {
                         "If true, structure placement will attempt to blend terrain even when no terrain marker blocks exist."
                 )
                 .define("enableAutoTerrainBlend", true);
+        ENABLE_SMART_AUTO_TERRAIN_BLEND = BUILDER.comment(
+                        "If true, auto-blend will skip columns where the structure does not touch the template's bottom layer."
+                                + " Helps prevent terrain from filling structure interiors."
+                )
+                .define("enableSmartAutoTerrainBlend", true);
         AUTO_TERRAIN_BLEND_MAX_DEPTH = BUILDER.comment(
                         "Maximum number of blocks to fill upward from the surface when auto-blending structures."
                 )


### PR DESCRIPTION
### Motivation
- Prevent the auto-terrain-blend step from filling interior columns of templates where the structure does not touch the bottom layer. 
- Reduce accidental terrain intrusion into placed templates and improve placement safety for complex templates. 
- Make the behavior configurable so pack authors can opt into or out of the smarter blending logic. 

### Description
- Add a column mask mechanism via the `AutoBlendMask` record and an overloaded `applyAutoBlend` that accepts a mask in `TerrainReplacerEngine`. 
- Wire smart masking into placement by building a mask from the template bottom layer and passing it to `TerrainReplacerEngine.applyAutoBlend` inside `NBTStructurePlacer`. 
- Implement reflective palette scanning (`resolvePaletteBlocks`) and `PALETTE_BLOCK_FIELD_NAMES` to extract block lists from template palettes and fall back with a logged warning if inaccessible. 
- Expose a new config toggle `ENABLE_SMART_AUTO_TERRAIN_BLEND` in `StructureConfig` to enable or disable the smart auto-blend behavior. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696077c80d088328ad62f969d0f216bd)