### PR TITLE
Enable richer Ollama context for AI chatbot

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
@@ -160,7 +160,8 @@ public class AIClient {
         }
         if (localModelClient != null) {
             String prompt = formatSystemPrompt(localSystemPrompt);
-            var response = localModelClient.generateReply(prompt, message, context);
+            String localContext = buildLocalModelContext(world, context);
+            var response = localModelClient.generateReply(prompt, message, localContext);
             if (response.isPresent()) {
                 String reply = response.get();
                 memoryStore.addAiMessage(world, player, settings.getPersonaName(), reply);
@@ -180,6 +181,42 @@ public class AIClient {
     private String sessionKey(String world, String player) {
         String worldKey = world == null || world.isBlank() ? "default" : world.trim();
         return worldKey + "::" + player;
+    }
+
+    private String buildLocalModelContext(String world, String conversationContext) {
+        StringBuilder builder = new StringBuilder();
+        if (world != null && !world.isBlank()) {
+            builder.append("World: ").append(world.trim()).append("\n");
+        }
+        if (!story.isEmpty()) {
+            builder.append("Lore:\n");
+            for (String line : story) {
+                builder.append("- ").append(line).append("\n");
+            }
+        }
+        if (!backgroundHistory.isEmpty()) {
+            builder.append("Background history:\n");
+            for (String line : backgroundHistory) {
+                builder.append("- ").append(line).append("\n");
+            }
+        }
+        if (!corruptedLore.isEmpty()) {
+            builder.append("Corrupted fragments:\n");
+            for (String line : corruptedLore) {
+                builder.append("- ").append(line).append("\n");
+            }
+        }
+        List<String> learnedFacts = knowledgeStore.getLearnedFacts();
+        if (learnedFacts != null && !learnedFacts.isEmpty()) {
+            builder.append("Learned facts:\n");
+            for (String line : learnedFacts) {
+                builder.append("- ").append(line).append("\n");
+            }
+        }
+        if (conversationContext != null && !conversationContext.isBlank()) {
+            builder.append("Recent conversation:\n").append(conversationContext.trim()).append("\n");
+        }
+        return builder.toString().trim();
     }
 
     private static class StorySession {

--- a/src/main/resources/ai_config.yaml
+++ b/src/main/resources/ai_config.yaml
@@ -19,8 +19,8 @@ settings:
   wake_word: "atlas"
   model: "local-story-engine"
 local_model:
-  enabled: false
+  enabled: true
   base_url: "http://localhost:11434"
   model: "llama3.1"
   timeout_seconds: 15
-  system_prompt: "You are {persona}, an in-world expedition AI. Stay {tone} and {empathy}. Do not provide crafting recipes or step-by-step crafting instructions. Keep responses immersive, lore-aware, and conversational."
+  system_prompt: "You are {persona}, an in-world expedition AI. Stay {tone} and {empathy}. You have no access to Google, the internet, or any external sources—only the in-world lore and knowledge provided. Do not provide crafting recipes or step-by-step crafting instructions. Keep responses immersive, lore-aware, and conversational."


### PR DESCRIPTION
### Motivation
- Provide the local model with richer in-game context so generated replies are more consistent with world lore and recent conversation.
- Make the local model integration useful by including learned facts, corrupted lore, and background history for in-world replies.
- Ensure the chatbot behavior is explicitly offline/self-hosted by clarifying the system prompt to forbid external sources.

### Description
- Add `buildLocalModelContext` to `AIClient` and pass the assembled context to `LocalModelClient.generateReply` instead of the raw conversation buffer.
- The assembled context includes the `world` name, configured `story` lore, `backgroundHistory`, `corruptedLore`, learned facts from the `AIKnowledgeStore`, and recent conversation.
- Enable the local model by default in `src/main/resources/ai_config.yaml` (`local_model.enabled: true`) and tighten the `system_prompt` to state the model has no access to Google or the internet.
- Minimal wiring changes only; existing fallback deterministic `StorySession` remains in use when the local model is unavailable.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960793e0534832880d13395e4ef866c)