### PR TITLE
Handle local model connection and timeout failures gracefully

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/LocalModelClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/LocalModelClient.java
@@ -5,10 +5,12 @@ import com.google.gson.GsonBuilder;
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,6 +55,12 @@ public class LocalModelClient {
                 return Optional.empty();
             }
             return Optional.of(parsed.response.trim());
+        } catch (ConnectException e) {
+            ModConstants.LOGGER.warn("Local model request failed: unable to connect to {}.", endpoint);
+            return Optional.empty();
+        } catch (HttpTimeoutException e) {
+            ModConstants.LOGGER.warn("Local model request timed out for {}.", endpoint);
+            return Optional.empty();
         } catch (IOException e) {
             ModConstants.LOGGER.warn("Local model request failed.", e);
             return Optional.empty();


### PR DESCRIPTION
### Motivation
- Avoid noisy stack traces when the local model endpoint is unreachable or connection attempts fail. 
- Provide clear, concise log messages for connection and timeout failures to make diagnostics easier. 
- Preserve existing fallback behavior so the AI continues to operate offline when the local model is unavailable.

### Description
- Added targeted `catch` blocks for `ConnectException` and `HttpTimeoutException` in `LocalModelClient.generateReply` to handle connection and timeout failures explicitly. 
- Emit concise warnings via `ModConstants.LOGGER.warn` and return `Optional.empty()` for these cases so callers fall back cleanly. 
- Kept existing `IOException` and `InterruptedException` handling intact. 
- Modified file: `src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/LocalModelClient.java`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961463f36d48328b6d239a476e069b4)