### PR TITLE
Tighten bunker dry-area checks to avoid interior fluids

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -246,6 +246,12 @@ public class NBTStructurePlacer {
         return data == null ? Vec3i.ZERO : data.size();
     }
 
+    /** Returns the leveling marker offset when present, or {@code null} if the template lacks one. */
+    public BlockPos peekLevelingOffset(ServerLevel level) {
+        TemplateData data = load(level);
+        return data == null ? null : data.levelingOffset();
+    }
+
     private PlacementFoundation resolvePlacementOrigin(ServerLevel level, BlockPos origin, BlockPos levelingOffset) {
         if (levelingOffset == null) {
             return new PlacementFoundation(origin, null);


### PR DESCRIPTION
### Motivation
- Prevent the starter bunker from being placed where water could end up inside its template volume. 
- Current checks sampled only surface positions and missed fluids within the template bounding box or buried placements. 
- Use the template leveling marker when available so area checks align with the actual placement origin. 

### Description
- Add `peekLevelingOffset(ServerLevel)` to `NBTStructurePlacer` to expose the template leveling marker for placement-time calculations. 
- Reduce the sampling granularity by changing `WATER_SAMPLE_STEP` from `8` to `4` in `SpawnBunkerPlacer`. 
- Replace the old `isAreaDry` surface-sampling logic with a volumetric scan that computes the placement origin using the template leveling offset and checks the full X/Z footprint and Y range for any non-empty fluid state using a `BlockPos.MutableBlockPos`. 

### Testing
- No automated tests were run against this change. 
- Compilation and basic repository checks were not performed as part of this PR description. 
- Manual runtime validation is recommended to confirm bunker placement avoids water in edge cases. 
- Follow-up unit or integration tests should exercise placement with and without a leveling marker and with buried/water-adjacent spawns.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69619200b97c8328b6384135d29f7928)