### PR TITLE
Require dirt columns for auto-blend and ignore STRUCTURE_VOID in auto-blend mask

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -661,7 +661,7 @@ public class NBTStructurePlacer {
                 continue;
             }
             for (StructureBlockInfo info : blocks) {
-                if (info.state().isAir()) {
+                if (info.state().isAir() || info.state().is(Blocks.STRUCTURE_VOID)) {
                     continue;
                 }
                 int localX = info.pos().getX();


### PR DESCRIPTION
### Motivation
- Prevent terrain auto-blend from filling into structure interiors by only filling where natural soil exists.
- Avoid structure template placeholder markers (`STRUCTURE_VOID`) from counting as solid structure blocks when building the auto-blend mask.
- Stop auto-blend propagation when encountering immovable rock layers so bunkers with stone/bedrock interiors are not filled.

### Description
- Treat `Blocks.STRUCTURE_VOID` like air in `NBTStructurePlacer.buildAutoBlendMask` so void markers are ignored when computing the lowest structure block per column.  
- Add `MIN_DIRT_COLUMN` and a new `hasContiguousDirtColumn` helper in `TerrainReplacerEngine` that scans downward for contiguous dirt (using `BlockTags.DIRT`).  
- Gate `applyAutoBlend` with `hasContiguousDirtColumn` so auto-fill only proceeds for columns with at least `MIN_DIRT_COLUMN` dirt blocks and returns early when stone or bedrock is encountered.  
- Import `BlockTags` and adjust early-return logic to reduce false-positive terrain fills under templates.

### Testing
- No automated tests were run against these changes.  
- No CI or local build/compile was executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961d568bc208328a1be6392b7708625)