### PR TITLE
Add GameTest verifying LocalModelClient can connect to a local AI server

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/gametest/AILocalModeGameTests.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/gametest/AILocalModeGameTests.java
@@ -1,0 +1,55 @@
+package com.thunder.wildernessodysseyapi.gametest;
+
+import com.thunder.wildernessodysseyapi.AI.AI_story.LocalModelClient;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.sun.net.httpserver.HttpServer;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.neoforged.neoforge.gametest.GameTestHolder;
+import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Optional;
+
+@GameTestHolder(ModConstants.MOD_ID)
+@PrefixGameTestTemplate(false)
+public class AILocalModeGameTests {
+    private static final String BATCH = "ai";
+
+    @GameTest(templateNamespace = "minecraft", template = "empty", batch = BATCH, timeoutTicks = 200)
+    public static void localModelConnects(GameTestHelper helper) {
+        HttpServer server;
+        try {
+            server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        } catch (IOException e) {
+            helper.fail("Failed to start local AI test server: " + e.getMessage());
+            return;
+        }
+
+        server.createContext("/api/generate", exchange -> {
+            byte[] response = "{\"response\":\"Test reply\"}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+
+        String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        LocalModelClient client = new LocalModelClient(baseUrl, "test-model", Duration.ofSeconds(2));
+
+        helper.runAtTickTime(1, () -> {
+            try {
+                Optional<String> reply = client.generateReply("system", "hello", "context");
+                helper.assertTrue(reply.isPresent(), "Local AI client did not return a response.");
+                helper.assertTrue("Test reply".equals(reply.orElse("")), "Local AI client response was unexpected.");
+                helper.succeed();
+            } finally {
+                server.stop(0);
+            }
+        });
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an automated GameTest that verifies the mod's AI client can connect to a local model endpoint to catch regressions in local-mode connectivity.
- Ensure the `LocalModelClient` HTTP integration is exercised inside the gametest harness so future changes to networking or payload handling are validated.

### Description
- Add `src/main/java/com/thunder/wildernessodysseyapi/gametest/AILocalModeGameTests.java` which contains the new GameTest `localModelConnects`.
- The test spins up a temporary `HttpServer` serving `/api/generate` with a JSON payload and instantiates `LocalModelClient` to call `generateReply` against that server.
- The test asserts the client returns a present response and that the response body equals the expected string, and it stops the test server when complete.

### Testing
- No automated tests were executed for this change in this rollout (the test is intended to be executed by the Minecraft GameTest harness/CI).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69629008a8cc8328ab4936d41a4a2e8c)