### PR TITLE
Sample terrain replacer outside structure bounds

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/TerrainSurveyProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/TerrainSurveyProcessor.java
@@ -8,6 +8,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
@@ -46,7 +47,8 @@ public class TerrainSurveyProcessor extends StructureProcessor {
         }
 
         if (state.is(TerrainReplacerBlock.TERRAIN_REPLACER.get())) {
-            var material = TerrainReplacerEngine.sampleSurfaceMaterial(level, placed.pos());
+            BoundingBox bounds = settings.getBoundingBox();
+            var material = TerrainReplacerEngine.sampleSurfaceMaterialOutsideBounds(level, placed.pos(), bounds);
             BlockState sampled = TerrainReplacerEngine.chooseReplacement(material, placed.pos().getY());
             return new StructureTemplate.StructureBlockInfo(placed.pos(), sampled, placed.nbt());
         }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -160,9 +160,10 @@ public class NBTStructurePlacer {
                     id, estimated, StructureUtils.STRUCTURE_BLOCK_LIMIT);
         }
 
+        BoundingBox placementBox = expandPlacementBox(foundation.origin(), data.size(), data.template());
         boolean enableTerrainReplacer = shouldEnableTerrainReplacer(data);
         TerrainReplacementPlan replacementPlan = TerrainReplacerEngine.planReplacement(
-                level, foundation.origin(), data.terrainOffsets(), enableTerrainReplacer);
+                level, foundation.origin(), data.terrainOffsets(), enableTerrainReplacer, placementBox);
         if (!replacementPlan.enabled() && !data.terrainOffsets().isEmpty()) {
             if (!StructureConfig.ENABLE_TERRAIN_REPLACER.get()) {
                 ModConstants.LOGGER.info("Terrain replacer markers are present in {} but replacement is disabled via config.", id);
@@ -172,8 +173,6 @@ public class NBTStructurePlacer {
                 ModConstants.LOGGER.info("Terrain replacer markers are present in {} but replacement is disabled due to template safety checks.", id);
             }
         }
-
-        BoundingBox placementBox = expandPlacementBox(foundation.origin(), data.size(), data.template());
 
         StructurePlaceSettings settings = new StructurePlaceSettings()
                 // We already know the template dimensions, so skip the expensive shape discovery pass.


### PR DESCRIPTION
### Motivation
- Ensure terrain replacer markers sample real surrounding terrain instead of terrain inside the structure footprint. 
- Prevent structure interiors or survey pillars from influencing the sampled surface material used for replacement. 
- Provide a bounds-aware sampling path to be used both during placement planning and template processing. 

### Description
- Add a new `planReplacement` signature that accepts a `BoundingBox` and use it when computing replacement samples via `TerrainReplacerEngine.planReplacement`. 
- Introduce `sampleSurfaceMaterialOutsideBounds(LevelReader, BlockPos, BoundingBox)` and `pushOutsideBounds` in `TerrainReplacerEngine` to pick a nearby position outside the structure bounds to sample from. 
- Update `NBTStructurePlacer` to compute `placementBox` earlier and pass it into `planReplacement`. 
- Update `TerrainSurveyProcessor` to use the bounds-aware sampling helper (`sampleSurfaceMaterialOutsideBounds`) using the `StructurePlaceSettings` bounding box. 

### Testing
- No automated tests were executed as part of this change. 
- The change was committed locally; no CI/test run was requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a1a7c95c8328ba92a2256c11f009)