### PR TITLE
Increase impact zone max distance

### DIFF
--- a/src/main/resources/data/wildernessodysseyapi/worldgen/structure/impact_zone.json
+++ b/src/main/resources/data/wildernessodysseyapi/worldgen/structure/impact_zone.json
@@ -10,6 +10,6 @@
     "absolute": 0
   },
   "project_start_to_heightmap": "WORLD_SURFACE_WG",
-  "max_distance_from_center": 116,
+  "max_distance_from_center": 256,
   "use_expansion_hack": false
 }


### PR DESCRIPTION
### Motivation
- Impact zone templates were failing to spawn when parts of larger prefabs fell outside the current `max_distance_from_center` limit.
- The jigsaw placer needs a larger radius to locate distant pool pieces for big impact zone templates.
- Raising the placement radius should allow larger impact zone structures to be placed successfully.

### Description
- Updated `src/main/resources/data/wildernessodysseyapi/worldgen/structure/impact_zone.json` to change `max_distance_from_center` from `116` to `256`.
- This increases the jigsaw structure placement radius for the impact zone start pool.
- No Java code or processors were modified, this is a data-only change.

### Testing
- No automated tests were executed for this data-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69629a735efc832894d68d4fce8866d5)