### PR TITLE
Prevent auto-blend inside structure bounds

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/TerrainReplacerEngine.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/TerrainReplacerEngine.java
@@ -149,6 +149,9 @@ public final class TerrainReplacerEngine {
         BoundingBox outerBounds = expandBounds(bounds, radius);
         for (int x = outerBounds.minX(); x <= outerBounds.maxX(); x++) {
             for (int z = outerBounds.minZ(); z <= outerBounds.maxZ(); z++) {
+                if (bounds.isInside(new BlockPos(x, bounds.minY(), z))) {
+                    continue;
+                }
                 if (!mask.allows(x, z)) {
                     continue;
                 }


### PR DESCRIPTION
### Motivation
- Auto-blend was filling terrain inside structure footprints, causing terrain to spawn within structure interiors instead of adapting around them.
- The intent is to have terrain sampling and auto-blend operate outside the structure bounding box so placed templates keep their interiors intact.

### Description
- Added a guard in `TerrainReplacerEngine.applyAutoBlend` to skip columns that lie inside the structure bounding box by checking `bounds.isInside(new BlockPos(x, bounds.minY(), z))`.
- This change prevents filling blocks within the structure footprint so terrain will be sampled from outside the bounding box instead.
- Modified file: `src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/TerrainReplacerEngine.java`.

### Testing
- No automated tests were executed for this change.
- Change is a small deterministic logic update affecting `applyAutoBlend` behavior and should be covered by integration or worldgen tests when available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d34a5b68832899af3d7cd8a6bb8a)