### PR TITLE
Use ItemStack#getTag() for silent armor check

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/crouching/CrouchNoiseHelper.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/crouching/CrouchNoiseHelper.java
@@ -52,9 +52,6 @@ public final class CrouchNoiseHelper {
     }
 
     private static boolean isSilenced(ItemStack stack) {
-        if (!stack.hasTag()) {
-            return false;
-        }
         CompoundTag tag = stack.getTag();
         return tag != null && tag.getBoolean(SILENT_ARMOR_TAG);
     }


### PR DESCRIPTION
### Motivation
- Newer mappings removed `ItemStack#hasTag()`, causing a compile error when checking NBT on armor items.
- The crouch noise logic needs a safe null-aware NBT check to determine `wildernessodysseyapi:silent_armor`.

### Description
- Simplified `isSilenced(ItemStack)` to call `stack.getTag()` and check for `null` before reading the boolean tag.
- Removed usage of the removed `hasTag()` API and preserved the previous behavior by returning `false` when the tag is absent.

### Testing
- No automated tests were run for this change.
- Manual compilation was not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655f948cb083288209713aeab9cf2e)