### PR TITLE
Read silent armor flag from ItemStack CUSTOM_DATA component

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/crouching/CrouchNoiseHelper.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/crouching/CrouchNoiseHelper.java
@@ -1,11 +1,12 @@
 package com.thunder.wildernessodysseyapi.crouching;
 
-import net.minecraft.nbt.CompoundTag;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.CustomData;
 
 public final class CrouchNoiseHelper {
     public static final String SILENT_ARMOR_TAG = "wildernessodysseyapi:silent_armor";
@@ -52,7 +53,7 @@ public final class CrouchNoiseHelper {
     }
 
     private static boolean isSilenced(ItemStack stack) {
-        CompoundTag tag = stack.getTag();
-        return tag != null && tag.getBoolean(SILENT_ARMOR_TAG);
+        CustomData customData = stack.get(DataComponents.CUSTOM_DATA);
+        return customData != null && customData.copyTag().getBoolean(SILENT_ARMOR_TAG);
     }
 }


### PR DESCRIPTION
### Motivation
- The code previously called `ItemStack.getTag()` which is not present in the current component-based API and produced a compile error.
- Item persistent data is exposed via data components, specifically `DataComponents.CUSTOM_DATA`, so the silent-armor flag must be read from that component.
- This change restores correct silent-armor detection so crouch visibility respects the `wildernessodysseyapi:silent_armor` flag.

### Description
- Replaced the removed `getTag()` usage with reading `CustomData` via `stack.get(DataComponents.CUSTOM_DATA)` and checking `customData.copyTag().getBoolean(...)` in `isSilenced`.
- Added imports for `DataComponents` and `CustomData` and removed the `CompoundTag` dependency.
- Kept the existing `getCrouchVisibilityMultiplier` logic unchanged aside from the updated silent-armor lookup.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965615f48f08328878521f96a346c7a)