### PR TITLE
Remove unsupported `max_distance_from_center` from impact_zone structure

### DIFF
--- a/src/main/resources/data/wildernessodysseyapi/worldgen/structure/impact_zone.json
+++ b/src/main/resources/data/wildernessodysseyapi/worldgen/structure/impact_zone.json
@@ -10,6 +10,5 @@
     "absolute": 0
   },
   "project_start_to_heightmap": "WORLD_SURFACE_WG",
-  "max_distance_from_center": 256,
   "use_expansion_hack": false
 }


### PR DESCRIPTION
### Motivation
- The `max_distance_from_center` setting is not supported and can cause registry load errors when the structure is parsed.
- Removing the unsupported field ensures the structure definition conforms to the current worldgen schema.
- This change targets the impact zone jigsaw structure to prevent startup/runtime failures.

### Description
- Deleted the `"max_distance_from_center": 256` entry from `src/main/resources/data/wildernessodysseyapi/worldgen/structure/impact_zone.json`.
- The structure remains a `minecraft:jigsaw` with `start_pool`, `size`, and `terrain_adaptation` preserved.
- The file change was staged and committed with a descriptive message.

### Testing
- No automated tests were run for this change.
- The file was successfully updated and committed in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965650bee008328aea8e70a3397f584)