### PR TITLE
Limit terrain replacement to structure edges and refine auto-blend base detection

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/TerrainSurveyProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/TerrainSurveyProcessor.java
@@ -48,11 +48,26 @@ public class TerrainSurveyProcessor extends StructureProcessor {
 
         if (state.is(TerrainReplacerBlock.TERRAIN_REPLACER.get())) {
             BoundingBox bounds = settings.getBoundingBox();
+            if (isInteriorToBounds(bounds, placed.pos())) {
+                return new StructureTemplate.StructureBlockInfo(placed.pos(), Blocks.AIR.defaultBlockState(), placed.nbt());
+            }
             var material = TerrainReplacerEngine.sampleSurfaceMaterialOutsideBounds(level, placed.pos(), bounds);
             BlockState sampled = TerrainReplacerEngine.chooseReplacement(material, placed.pos().getY());
             return new StructureTemplate.StructureBlockInfo(placed.pos(), sampled, placed.nbt());
         }
 
         return placed;
+    }
+
+    private boolean isInteriorToBounds(BoundingBox bounds, BlockPos worldPos) {
+        if (bounds == null) {
+            return false;
+        }
+        return worldPos.getX() > bounds.minX()
+                && worldPos.getX() < bounds.maxX()
+                && worldPos.getY() > bounds.minY()
+                && worldPos.getY() < bounds.maxY()
+                && worldPos.getZ() > bounds.minZ()
+                && worldPos.getZ() < bounds.maxZ();
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent terrain-replacer markers from modifying interior space of placed templates by using the structure bounding box to distinguish interior vs edge.
- Ensure automatic terrain blending only considers columns that actually touch the template base layer instead of using a hard-coded base check.
- Apply consistent behavior for both runtime placement and datapack template processors so terrain is blended around structures rather than into them.

### Description
- Updated `applyTerrainReplacement` in `NBTStructurePlacer` to accept the placement `BoundingBox` and clear interior terrain-replacer markers to air when inside the bounds by using `isInteriorToBounds`.
- Added the same interior-bounds check to the datapack processor `TerrainSurveyProcessor` so `TerrainReplacerBlock` markers inside the template bounds are stripped to air during template processing.
- Kept and refined the auto-blend mask logic so the template base is detected using a `globalMinY` across palettes and columns are supported only when `lowestY[i] == globalMinY`.
- Added `isInteriorToBounds` helpers and a `@Nullable` import, and updated affected call sites to pass `placementBox` when applying terrain replacement.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965b471535483289a020b212500e2ca)