### PR TITLE
Increase bunker terrain blend radius and avoid template air overwrites

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java
@@ -2,16 +2,14 @@ package com.thunder.wildernessodysseyapi.WorldGen.processor;
 
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 /**
- * Ensures air blocks from the bunker template are placed so the interior stays clear.
+ * Prevents air blocks from the bunker template from replacing existing terrain.
  */
 public class BunkerPlacementProcessor extends StructureProcessor {
     public static final MapCodec<BunkerPlacementProcessor> CODEC = MapCodec.unit(BunkerPlacementProcessor::new);
@@ -29,21 +27,8 @@ public class BunkerPlacementProcessor extends StructureProcessor {
                                                              StructureTemplate.StructureBlockInfo placed,
                                                              StructurePlaceSettings settings) {
         if (placed.state().isAir()) {
-            BlockState existing = level.getBlockState(pos);
-            if (!shouldClear(existing)) {
-                return null;
-            }
+            return null;
         }
         return placed;
-    }
-
-    private static boolean shouldClear(BlockState existing) {
-        if (existing.isAir()) {
-            return true;
-        }
-        if (!existing.getFluidState().isEmpty()) {
-            return true;
-        }
-        return existing.is(BlockTags.DIRT);
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/spawn/SpawnBunkerPlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/spawn/SpawnBunkerPlacer.java
@@ -33,8 +33,7 @@ public final class SpawnBunkerPlacer {
     private static final int OCEAN_BUFFER_RADIUS = 128;
     private static final int OCEAN_BUFFER_STEP = 16;
     private static final int WATER_SAMPLE_STEP = 4;
-    private static final Set<ResourceKey<Biome>> WHITELISTED_SPAWN_BIOMES = Set.of(
-            Biomes.PLAINS);
+    private static final Set<ResourceKey<Biome>> WHITELISTED_SPAWN_BIOMES = Set.of();
     private static final Set<ResourceKey<Biome>> BLACKLISTED_SPAWN_BIOMES = Set.of(
             Biomes.OCEAN,
             Biomes.DEEP_OCEAN,

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -201,7 +201,7 @@ public class NBTStructurePlacer {
                 && data.terrainOffsets().isEmpty()
                 && StructureConfig.ENABLE_AUTO_TERRAIN_BLEND.get()) {
             int maxDepth = StructureConfig.AUTO_TERRAIN_BLEND_MAX_DEPTH.get();
-            int radius = StructureConfig.AUTO_TERRAIN_BLEND_RADIUS.get();
+            int radius = resolveAutoBlendRadius(data.size());
             TerrainReplacerEngine.AutoBlendMask mask = TerrainReplacerEngine.AutoBlendMask.allowAll();
             if (StructureConfig.ENABLE_SMART_AUTO_TERRAIN_BLEND.get()) {
                 mask = buildAutoBlendMask(data.template(), foundation.origin(), data.size());
@@ -656,6 +656,17 @@ public class NBTStructurePlacer {
     private boolean isStarterBunker() {
         return ModConstants.MOD_ID.equals(id.getNamespace())
                 && "bunker".equals(id.getPath());
+    }
+
+    private int resolveAutoBlendRadius(Vec3i size) {
+        int configuredRadius = StructureConfig.AUTO_TERRAIN_BLEND_RADIUS.get();
+        if (!isStarterBunker()) {
+            return configuredRadius;
+        }
+        int maxSpan = Math.max(size.getX(), size.getZ());
+        int sizeRadius = maxSpan > 0 ? maxSpan / 24 : 0;
+        int blendedRadius = Math.max(configuredRadius, Math.max(4, sizeRadius));
+        return Math.min(12, blendedRadius);
     }
 
     private TerrainReplacerEngine.AutoBlendMask buildAutoBlendMask(StructureTemplate template, BlockPos origin, Vec3i size) {


### PR DESCRIPTION
### Motivation
- Prevent template "air" blocks from overwriting existing terrain when placing the bunker so surrounding world content is preserved. 
- Make terrain auto-blending scale with the bunker template size so large bunkers feather terrain farther out and avoid hard edges. 
- Ensure starter-bunker specific placement rules (e.g., forcing dirt marker behavior) remain isolated to the bunker template. 
- Relax spawn-biome whitelist (cleared) so starter bunker spawn selection is not artificially limited to a single biome.

### Description
- Change `BunkerPlacementProcessor.processBlock` to return `null` when `placed.state().isAir()` so template air will not replace existing blocks, and remove the unused `shouldClear` helper and related imports.  
- Add `resolveAutoBlendRadius(Vec3i)` to `NBTStructurePlacer` and call it instead of using `StructureConfig.AUTO_TERRAIN_BLEND_RADIUS` directly, so the starter bunker uses a radius derived from the template size with a configurable baseline and clamped bounds (`min 4`, `max 12`, and scaled by `max(sizeX, sizeZ) / 24`).  
- Use the size-aware radius only for the starter bunker (`isStarterBunker()`), preserving default behavior for other structures.  
- Clear the `WHITELISTED_SPAWN_BIOMES` set in `SpawnBunkerPlacer` (was `Biomes.PLAINS`) to avoid unintentional spawn restrictions.

### Testing
- No automated tests were run for these changes.  
- Changes compile-time impact was limited to processors and the structure placer (no test execution performed).  
- Manual runtime verification is recommended in a dev environment to validate visual blending and bunker placement surface behavior.  
- No CI or unit tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696689ab5a8c8328a01393b6bbab70d9)