### PR TITLE
Add missing `processors` to impact_zone template pool element

### DIFF
--- a/src/main/resources/data/wildernessodysseyapi/worldgen/template_pool/impact_zone/start.json
+++ b/src/main/resources/data/wildernessodysseyapi/worldgen/template_pool/impact_zone/start.json
@@ -6,6 +6,7 @@
       "weight": 1,
       "element": {
         "element_type": "minecraft:single_pool_element",
+        "processors": "minecraft:empty",
         "projection": "rigid",
         "location": "wildernessodysseyapi:impact_zone"
       }


### PR DESCRIPTION
### Motivation
- The registry loader raised an `IllegalStateException` for `wildernessodysseyapi:impact_zone/start` due to a missing `processors` key in the template pool element. 
- Adding the `processors` field ensures the template pool element is parsed by `RegistryDataLoader` and prevents unbound-value registry errors. 

### Description
- Updated `src/main/resources/data/wildernessodysseyapi/worldgen/template_pool/impact_zone/start.json` to include a `processors` entry in the element object. 
- Inserted the line `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696692ec2d788328be76cefeaf24f613)