### PR TITLE
Permit bunker interior air carving while preserving boundary terrain

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/processor/BunkerPlacementProcessor.java
@@ -3,6 +3,7 @@ package com.thunder.wildernessodysseyapi.WorldGen.processor;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
@@ -27,8 +28,20 @@ public class BunkerPlacementProcessor extends StructureProcessor {
                                                              StructureTemplate.StructureBlockInfo placed,
                                                              StructurePlaceSettings settings) {
         if (placed.state().isAir()) {
-            return null;
+            BoundingBox bounds = settings.getBoundingBox();
+            if (bounds == null || isBoundary(pos, bounds)) {
+                return null;
+            }
         }
         return placed;
+    }
+
+    private boolean isBoundary(BlockPos pos, BoundingBox bounds) {
+        return pos.getX() == bounds.minX()
+                || pos.getX() == bounds.maxX()
+                || pos.getY() == bounds.minY()
+                || pos.getY() == bounds.maxY()
+                || pos.getZ() == bounds.minZ()
+                || pos.getZ() == bounds.maxZ();
     }
 }


### PR DESCRIPTION
### Motivation
- The bunker template previously prevented any air blocks from replacing existing terrain, which could leave terrain inside placed bunkers.
- The goal is to allow the template to carve out the bunker interior while still protecting the placement boundary so surrounding terrain is not removed.

### Description
- Updated `BunkerPlacementProcessor.processBlock` to consult `settings.getBoundingBox()` before skipping air placements.
- Air blocks are now skipped only when the bounding box is missing or the block `pos` lies on the template boundary, otherwise interior air is applied to carve the bunker.
- Added a private helper `isBoundary` to determine whether a `BlockPos` sits on the placement `BoundingBox` edges.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69669923e4e48328a134b6ab5343c80c)