### PR TITLE
Replace deprecated BoundingBox.encapsulate usage

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -512,15 +512,15 @@ public class NBTStructurePlacer {
             return baseBox;
         }
 
-        BoundingBox expanded = BoundingBox.fromCorners(
-                new BlockPos(baseBox.minX(), baseBox.minY(), baseBox.minZ()),
-                new BlockPos(baseBox.maxX(), baseBox.maxY(), baseBox.maxZ()));
+        List<BlockPos> positions = new ArrayList<>();
+        positions.add(new BlockPos(baseBox.minX(), baseBox.minY(), baseBox.minZ()));
+        positions.add(new BlockPos(baseBox.maxX(), baseBox.maxY(), baseBox.maxZ()));
 
         for (StructureTemplate.StructureEntityInfo info : accessor.getEntityInfoList()) {
-            BlockPos entityPos = origin.offset(info.blockPos);
-            expanded.encapsulate(entityPos);
+            positions.add(origin.offset(info.blockPos));
         }
-        return expanded;
+
+        return BoundingBox.encapsulatingPositions(positions).orElse(baseBox);
     }
 
     private BlockState normalizeLevelingReplacement(BlockState replacement) {


### PR DESCRIPTION
### Motivation
- Avoid use of the deprecated `BoundingBox.encapsulate` and ensure the placement bounding box still encloses entities baked into a template so contraptions (e.g., rope pulleys) below the footprint are not discarded.

### Description
- Replace manual mutation via `expanded.encapsulate(...)` in `expandPlacementBox` with collecting corner and entity positions into a `List<BlockPos>` and returning `BoundingBox.encapsulatingPositions(positions).orElse(baseBox)`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a67579948328b876e6d4c39e8fbd)