### PR TITLE
Restrict spawn bunker placement to a hardcoded biome whitelist

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/spawn/SpawnBunkerPlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/spawn/SpawnBunkerPlacer.java
@@ -33,7 +33,13 @@ public final class SpawnBunkerPlacer {
     private static final int OCEAN_BUFFER_RADIUS = 128;
     private static final int OCEAN_BUFFER_STEP = 16;
     private static final int WATER_SAMPLE_STEP = 4;
-    private static final Set<ResourceKey<Biome>> WHITELISTED_SPAWN_BIOMES = Set.of();
+    private static final Set<ResourceKey<Biome>> WHITELISTED_SPAWN_BIOMES = Set.of(
+            Biomes.PLAINS,
+            Biomes.SUNFLOWER_PLAINS,
+            Biomes.MEADOW,
+            Biomes.FOREST,
+            Biomes.BIRCH_FOREST,
+            Biomes.TAIGA);
     private static final Set<ResourceKey<Biome>> BLACKLISTED_SPAWN_BIOMES = Set.of(
             Biomes.OCEAN,
             Biomes.DEEP_OCEAN,


### PR DESCRIPTION
### Motivation
- Ensure spawn bunker placement is controlled by biome rather than by a small set of hardcoded anchor offsets, addressing the inline request to target biomes.
- Avoid non-deterministic or undesired anchor offset fallback behavior and prefer selecting a suitable land position filtered by biome policy.

### Description
- Replace the empty `WHITELISTED_SPAWN_BIOMES` with a hardcoded whitelist containing `Biomes.PLAINS`, `Biomes.SUNFLOWER_PLAINS`, `Biomes.MEADOW`, `Biomes.FOREST`, `Biomes.BIRCH_FOREST`, and `Biomes.TAIGA` in `SpawnBunkerPlacer.java`.
- Remove the previous `ALLOWED_ANCHOR_OFFSETS` usage and the `findAllowedAnchor` fallback logic, simplifying `resolveAnchor` to call `findLandAnchor` directly.
- Keep the existing land-search and blacklist behavior intact via `findLandAnchor` and `BLACKLISTED_SPAWN_BIOMES`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966b466e5988328a7c133a6d3bc537d)