### PR TITLE
Bundle default changelog template and use it on first run

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -8,6 +8,7 @@ import com.thunder.wildernessodysseyapi.ModPackPatches.ModListTracker.commands.M
 import com.thunder.wildernessodysseyapi.ModPackPatches.ModListTracker.commands.ModListVersionCommand;
 import com.thunder.wildernessodysseyapi.command.GlobalChatCommand;
 import com.thunder.wildernessodysseyapi.command.GlobalChatOptToggleCommand;
+import com.thunder.wildernessodysseyapi.command.ChangelogCommand;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
 import com.thunder.wildernessodysseyapi.WorldGen.processor.ModProcessors;
@@ -158,6 +159,7 @@ public class WildernessOdysseyAPIMainModClass {
         StructureInfoCommand.register(event.getDispatcher());
         FaqCommand.register(event.getDispatcher());
         DonateCommand.register(event.getDispatcher());
+        ChangelogCommand.register(dispatcher);
         WorldGenScanCommand.register(event.getDispatcher());
         StructurePlacementDebugCommand.register(event.getDispatcher());
         GlobalChatCommand.register(dispatcher);

--- a/src/main/java/com/thunder/wildernessodysseyapi/changelog/ChangelogAnnouncements.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/changelog/ChangelogAnnouncements.java
@@ -1,0 +1,52 @@
+package com.thunder.wildernessodysseyapi.changelog;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.storage.LevelResource;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.server.ServerStartingEvent;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@EventBusSubscriber
+public class ChangelogAnnouncements {
+
+    private static final AtomicBoolean announced = new AtomicBoolean(false);
+    private static volatile boolean newWorld = false;
+
+    @SubscribeEvent
+    public static void onServerStarting(ServerStartingEvent event) {
+        MinecraftServer server = event.getServer();
+        Path worldVersionPath = server.getWorldPath(LevelResource.ROOT).resolve("world_version.json");
+        newWorld = !Files.exists(worldVersionPath);
+        announced.set(false);
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) {
+            return;
+        }
+        if (!newWorld || announced.get()) {
+            return;
+        }
+        MinecraftServer server = player.serverLevel().getServer();
+        Path seenPath = server.getWorldPath(LevelResource.ROOT).resolve("wildernessodysseyapi_changelog.json");
+        if (Files.exists(seenPath)) {
+            announced.set(true);
+            return;
+        }
+        if (!announced.compareAndSet(false, true)) {
+            return;
+        }
+        boolean sent = ChangelogManager.sendChangelog(player, ModConstants.VERSION);
+        if (sent) {
+            ChangelogManager.writeSeenFile(seenPath, ModConstants.VERSION);
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/changelog/ChangelogManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/changelog/ChangelogManager.java
@@ -1,0 +1,174 @@
+package com.thunder.wildernessodysseyapi.changelog;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class ChangelogManager {
+
+    private static final Path CHANGELOG_PATH = Paths.get("config", ModConstants.MOD_ID, "changelog.txt");
+    private static final String DEFAULT_RESOURCE = "/config/wildernessodysseyapi/changelog.txt";
+
+    private ChangelogManager() {
+    }
+
+    public static List<String> getAvailableVersions() {
+        return new ArrayList<>(loadChangelog().keySet());
+    }
+
+    public static int sendChangelog(CommandSourceStack source, String version) {
+        Map<String, List<String>> entries = loadChangelog();
+        List<String> lines = entries.get(version);
+        if (lines == null) {
+            source.sendFailure(Component.literal("No changelog found for version " + version + "."));
+            return 0;
+        }
+        List<Component> components = buildChangelogComponents(version, lines);
+        for (Component component : components) {
+            source.sendSuccess(() -> component, false);
+        }
+        return 1;
+    }
+
+    public static boolean sendChangelog(ServerPlayer player, String version) {
+        Map<String, List<String>> entries = loadChangelog();
+        List<String> lines = entries.get(version);
+        if (lines == null) {
+            player.sendSystemMessage(Component.literal("No changelog found for version " + version + ".")
+                    .withStyle(ChatFormatting.RED));
+            return false;
+        }
+        List<Component> components = buildChangelogComponents(version, lines);
+        for (Component component : components) {
+            player.sendSystemMessage(component);
+        }
+        return true;
+    }
+
+    public static void writeSeenFile(Path seenPath, String version) {
+        try {
+            if (seenPath.getParent() != null && !Files.exists(seenPath.getParent())) {
+                Files.createDirectories(seenPath.getParent());
+            }
+            JsonObject obj = new JsonObject();
+            obj.addProperty("last_seen_version", version);
+            try (Writer writer = Files.newBufferedWriter(seenPath, StandardCharsets.UTF_8)) {
+                new GsonBuilder().setPrettyPrinting().create().toJson(obj, writer);
+            }
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to write changelog seen file at {}: {}", seenPath, e.getMessage());
+        }
+    }
+
+    private static List<Component> buildChangelogComponents(String version, List<String> lines) {
+        List<Component> components = new ArrayList<>();
+        components.add(Component.literal("Wilderness Odyssey Changelog " + version)
+                .withStyle(ChatFormatting.GOLD, ChatFormatting.BOLD));
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                continue;
+            }
+            if (trimmed.endsWith(":")) {
+                components.add(Component.literal(trimmed)
+                        .withStyle(ChatFormatting.YELLOW, ChatFormatting.BOLD));
+                continue;
+            }
+            if (trimmed.startsWith("-")) {
+                String item = trimmed.startsWith("- ") ? trimmed.substring(2) : trimmed.substring(1);
+                components.add(Component.literal("• " + item)
+                        .withStyle(ChatFormatting.GRAY));
+                continue;
+            }
+            components.add(Component.literal(trimmed).withStyle(ChatFormatting.WHITE));
+        }
+        return components;
+    }
+
+    private static Map<String, List<String>> loadChangelog() {
+        ensureChangelogFile();
+        Map<String, List<String>> entries = new LinkedHashMap<>();
+        try {
+            List<String> lines = Files.readAllLines(CHANGELOG_PATH, StandardCharsets.UTF_8);
+            String currentVersion = null;
+            for (String line : lines) {
+                String trimmed = line.trim();
+                if (trimmed.startsWith("## ")) {
+                    currentVersion = trimmed.substring(3).trim();
+                    entries.putIfAbsent(currentVersion, new ArrayList<>());
+                    continue;
+                }
+                if (currentVersion != null) {
+                    entries.get(currentVersion).add(line);
+                }
+            }
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to read changelog file {}: {}", CHANGELOG_PATH, e.getMessage());
+        }
+        return entries;
+    }
+
+    private static void ensureChangelogFile() {
+        try {
+            if (Files.exists(CHANGELOG_PATH)) {
+                return;
+            }
+            if (CHANGELOG_PATH.getParent() != null) {
+                Files.createDirectories(CHANGELOG_PATH.getParent());
+            }
+            if (copyBundledChangelog()) {
+                return;
+            }
+            List<String> defaultLines = List.of(
+                    "# Wilderness Odyssey Changelog",
+                    "## " + ModConstants.VERSION,
+                    "Added:",
+                    "- Welcome to your new world!",
+                    "Changed:",
+                    "- Customize this file in config/" + ModConstants.MOD_ID + "/changelog.txt",
+                    "Fixed:",
+                    "- ",
+                    "",
+                    "## 0.0.3",
+                    "Added:",
+                    "- Example previous release entry",
+                    "Changed:",
+                    "- ",
+                    "Fixed:",
+                    "- "
+            );
+            Files.write(CHANGELOG_PATH, defaultLines, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to create default changelog file {}: {}", CHANGELOG_PATH, e.getMessage());
+        }
+    }
+
+    private static boolean copyBundledChangelog() {
+        try (InputStream stream = ChangelogManager.class.getResourceAsStream(DEFAULT_RESOURCE)) {
+            if (stream == null) {
+                return false;
+            }
+            Files.copy(stream, CHANGELOG_PATH);
+            return true;
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to copy bundled changelog from {}: {}", DEFAULT_RESOURCE, e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/ChangelogCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/ChangelogCommand.java
@@ -1,0 +1,26 @@
+package com.thunder.wildernessodysseyapi.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.changelog.ChangelogManager;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+
+public class ChangelogCommand {
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("changelog")
+                .then(Commands.argument("version", StringArgumentType.word())
+                        .suggests((context, builder) -> {
+                            for (String version : ChangelogManager.getAvailableVersions()) {
+                                builder.suggest(version);
+                            }
+                            return builder.buildFuture();
+                        })
+                        .executes(ctx -> ChangelogManager.sendChangelog(ctx.getSource(),
+                                StringArgumentType.getString(ctx, "version"))))
+                .executes(ctx -> ChangelogManager.sendChangelog(ctx.getSource(), ModConstants.VERSION))
+        );
+    }
+}

--- a/src/main/resources/config/wildernessodysseyapi/changelog.txt
+++ b/src/main/resources/config/wildernessodysseyapi/changelog.txt
@@ -1,0 +1,16 @@
+# Wilderness Odyssey Changelog
+## 0.0.4
+Added:
+- Welcome to Wilderness Odyssey!
+Changed:
+- Update this file in config/wildernessodysseyapi/changelog.txt to customize releases.
+Fixed:
+- 
+
+## 0.0.3
+Added:
+- Example previous release entry
+Changed:
+- 
+Fixed:
+- 


### PR DESCRIPTION
### Motivation
- Ship a premade, user-editable changelog with the mod so new installs get a sensible default instead of an auto-generated placeholder. 
- Ensure first-run behavior copies the bundled template into `config/<modid>/changelog.txt` while keeping the original fallback logic if the resource is absent.

### Description
- Added a bundled changelog resource at `src/main/resources/config/wildernessodysseyapi/changelog.txt` containing a template release entry. 
- Updated `ChangelogManager` to declare `DEFAULT_RESOURCE`, attempt `copyBundledChangelog()` from the JAR via `getResourceAsStream`, and fall back to the previous `List<String>` default when the resource is not found. 
- Implemented `copyBundledChangelog()` which copies the bundled resource to `config/<modid>/changelog.txt` and logs failures. 
- Added `ChangelogAnnouncements` to announce the changelog once on new worlds and `ChangelogCommand` plus registration in the main mod class so players can use `/changelog [version]` on demand.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966fc1832e08328904ecc62fe76dc94)