### PR TITLE
Use double precision for crouch visibility in mixin and helper

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/crouching/CrouchNoiseHelper.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/crouching/CrouchNoiseHelper.java
@@ -10,20 +10,20 @@ import net.minecraft.world.item.component.CustomData;
 
 public final class CrouchNoiseHelper {
     public static final String SILENT_ARMOR_TAG = "wildernessodysseyapi:silent_armor";
-    private static final float LEATHER_MULTIPLIER = 0.5F;
-    private static final float CHAIN_MULTIPLIER = 0.6F;
-    private static final float IRON_MULTIPLIER = 0.7F;
-    private static final float GOLD_MULTIPLIER = 0.8F;
-    private static final float DIAMOND_MULTIPLIER = 0.9F;
-    private static final float NETHERITE_MULTIPLIER = 1.0F;
+    private static final double LEATHER_MULTIPLIER = 0.5D;
+    private static final double CHAIN_MULTIPLIER = 0.6D;
+    private static final double IRON_MULTIPLIER = 0.7D;
+    private static final double GOLD_MULTIPLIER = 0.8D;
+    private static final double DIAMOND_MULTIPLIER = 0.9D;
+    private static final double NETHERITE_MULTIPLIER = 1.0D;
 
     private CrouchNoiseHelper() {
     }
 
-    public static float getCrouchVisibilityMultiplier(Player player) {
+    public static double getCrouchVisibilityMultiplier(Player player) {
         ItemStack boots = player.getItemBySlot(EquipmentSlot.FEET);
         if (boots.isEmpty()) {
-            return 0.0F;
+            return 0.0D;
         }
         if (isSilenced(boots)) {
             return LEATHER_MULTIPLIER;

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/LivingEntityMixin.java
@@ -15,7 +15,7 @@ public abstract class LivingEntityMixin {
     @Inject(method = "getVisibilityPercent", at = @At("RETURN"), cancellable = true)
     private void wildernessodysseyapi$reduceMobDetectionWhenCrouching(
             Entity viewer,
-            CallbackInfoReturnable<Float> callbackInfo
+            CallbackInfoReturnable<Double> callbackInfo
     ) {
         if (!(viewer instanceof Mob)) {
             return;
@@ -23,12 +23,12 @@ public abstract class LivingEntityMixin {
         if (!((Object) this instanceof Player player) || !player.isCrouching()) {
             return;
         }
-        float multiplier = CrouchNoiseHelper.getCrouchVisibilityMultiplier(player);
-        if (multiplier <= 0.0F) {
-            callbackInfo.setReturnValue(0.0F);
+        double multiplier = CrouchNoiseHelper.getCrouchVisibilityMultiplier(player);
+        if (multiplier <= 0.0D) {
+            callbackInfo.setReturnValue(0.0D);
             return;
         }
-        float visibility = callbackInfo.getReturnValue();
-        callbackInfo.setReturnValue(Math.max(0.0F, visibility * multiplier));
+        double visibility = callbackInfo.getReturnValue();
+        callbackInfo.setReturnValue(Math.max(0.0D, visibility * multiplier));
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent runtime type mismatches and the ClassCastException observed when the mixin returned a `Float` while the target expected a `Double`. 
- Make the mixin and helper use a consistent numeric precision that matches the `getVisibilityPercent` target signature. 

### Description
- Update `LivingEntityMixin` to use `CallbackInfoReturnable<Double>`, convert local visibility/multiplier variables to `double`, and normalize numeric literals to double precision. 
- Update `CrouchNoiseHelper` constant multipliers to `double` and change `getCrouchVisibilityMultiplier` to return `double`, with return literals adjusted to double precision. 
- Ensure `callbackInfo.setReturnValue` calls pass `double` values so the mixin and helper signatures match. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967163adde8832886785a80aaf21eee)