### PR TITLE
Clear fluids during bunker terrain cleanup

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProc
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.StructureBlockInfo;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplateManager;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
@@ -680,7 +681,7 @@ public class NBTStructurePlacer {
                     }
                     cursor.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
                     BlockState existing = level.getBlockState(cursor);
-                    if (!isTerrainBlock(existing)) {
+                    if (!isTerrainBlock(existing) && !isFluidBlock(existing)) {
                         continue;
                     }
                     level.setBlock(cursor, Blocks.AIR.defaultBlockState(), 2);
@@ -694,5 +695,10 @@ public class NBTStructurePlacer {
                 || state.is(BlockTags.SAND)
                 || state.is(BlockTags.BASE_STONE_OVERWORLD)
                 || state.is(Blocks.GRAVEL);
+    }
+
+    private boolean isFluidBlock(BlockState state) {
+        return state.getFluidState().is(Fluids.WATER)
+                || state.getFluidState().is(Fluids.LAVA);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent water and lava from lingering inside the starter bunker footprint when clearing empty template space during placement.

### Description
- Update `NBTStructurePlacer.clearTerrainInsideStructure` to also consider fluid blocks removable by adding a new `isFluidBlock` helper (checking `Fluids.WATER` and `Fluids.LAVA`) and adjusting the removal condition accordingly, and add the `net.minecraft.world.level.material.Fluids` import.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696719b2b3688328b9df8827ea679d88)