### PR TITLE
Simplify bunker terrain clearing

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/BunkerTerrainClearer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/BunkerTerrainClearer.java
@@ -1,0 +1,19 @@
+package com.thunder.wildernessodysseyapi.WorldGen.structure;
+
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * Defines which existing blocks get cleared to air when the starter bunker is placed.
+ */
+public final class BunkerTerrainClearer {
+    private BunkerTerrainClearer() {
+    }
+
+    /**
+     * Clears any non-air block (including fluids) inside the bunker footprint.
+     */
+    public static boolean shouldClear(BlockState state) {
+        return !state.isAir() && !state.is(Blocks.STRUCTURE_VOID);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -680,23 +680,12 @@ public class NBTStructurePlacer {
                     }
                     cursor.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
                     BlockState existing = level.getBlockState(cursor);
-                    if (!isTerrainBlock(existing)) {
+                    if (!BunkerTerrainClearer.shouldClear(existing)) {
                         continue;
                     }
                     level.setBlock(cursor, Blocks.AIR.defaultBlockState(), 2);
                 }
             }
         }
-    }
-
-    private boolean isTerrainBlock(BlockState state) {
-        return state.is(BlockTags.DIRT)
-                || state.is(BlockTags.SAND)
-                || state.is(BlockTags.BASE_STONE_OVERWORLD)
-                || state.is(BlockTags.GOLD_ORES)
-                || state.is(BlockTags.COAL_ORES)
-                || state.is(BlockTags.IRON_ORES)
-                || state.is(BlockTags.UNDERWATER_BONEMEALS)
-                || state.is(Blocks.GRAVEL);
     }
 }


### PR DESCRIPTION
### Motivation
- Make bunker placement always clear existing blocks (including fluids and tagged blocks) to air so the starter bunker does not require maintaining an external database of replacable blocks.

### Description
- Add `BunkerTerrainClearer` with `shouldClear(BlockState)` that returns true for any non-air and non-`STRUCTURE_VOID` block so fluids and all block tags are cleared.
- Update `NBTStructurePlacer.clearTerrainInsideStructure` to use `BunkerTerrainClearer.shouldClear(...)` instead of the previous `isTerrainBlock(...)` whitelist and remove the old whitelist logic.
- The new behavior ensures any non-air content inside the bunker footprint is replaced with air while preserving `STRUCTURE_VOID` markers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696727722e4883288975159399d1a512)