### PR TITLE
Clear all non-air blocks when placing bunker and notify neighbors

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -683,7 +683,7 @@ public class NBTStructurePlacer {
                     if (!BunkerTerrainClearer.shouldClear(existing)) {
                         continue;
                     }
-                    level.setBlock(cursor, Blocks.AIR.defaultBlockState(), 2);
+                    level.setBlock(cursor, Blocks.AIR.defaultBlockState(), 3);
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- The bunker placement should remove all blocks (including ores and fluids) inside the footprint rather than preserving ores.
- Cleared blocks must notify neighbors so fluid spread/decay and other neighbor-dependent updates occur correctly.

### Description
- Update `BunkerTerrainClearer.shouldClear` to return `!state.isAir() && !state.is(Blocks.STRUCTURE_VOID)`, removing the previous ore-preservation check so ores and fluids are cleared.
- Change `NBTStructurePlacer` to call `level.setBlock(cursor, Blocks.AIR.defaultBlockState(), 3)` so neighbor updates are triggered when blocks are replaced with air.
- Remove the now-unused `BlockTags` import and adjust method Javadoc to reflect the new clearing behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696729a7b9b48328961c7b32bdc1a140)