### PR TITLE
Refine spawn bunker terrain clearing and restore impact zone adaptation

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -648,6 +648,11 @@ public class NBTStructurePlacer {
 
         int volume = sizeX * sizeY * sizeZ;
         BitSet occupied = new BitSet(volume);
+        int columns = sizeX * sizeZ;
+        int[] minYByColumn = new int[columns];
+        int[] maxYByColumn = new int[columns];
+        Arrays.fill(minYByColumn, Integer.MAX_VALUE);
+        Arrays.fill(maxYByColumn, Integer.MIN_VALUE);
         for (StructureTemplate.Palette palette : accessor.getPalettes()) {
             List<StructureBlockInfo> blocks = resolvePaletteBlocks(palette);
             if (blocks.isEmpty()) {
@@ -667,13 +672,22 @@ public class NBTStructurePlacer {
                 }
                 int index = x + sizeX * (y + sizeY * z);
                 occupied.set(index);
+                int columnIndex = x + sizeX * z;
+                minYByColumn[columnIndex] = Math.min(minYByColumn[columnIndex], y);
+                maxYByColumn[columnIndex] = Math.max(maxYByColumn[columnIndex], y);
             }
         }
 
         BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
         for (int x = 0; x < sizeX; x++) {
-            for (int y = 0; y < sizeY; y++) {
-                for (int z = 0; z < sizeZ; z++) {
+            for (int z = 0; z < sizeZ; z++) {
+                int columnIndex = x + sizeX * z;
+                int minY = minYByColumn[columnIndex];
+                int maxY = maxYByColumn[columnIndex];
+                if (minY == Integer.MAX_VALUE || maxY == Integer.MIN_VALUE) {
+                    continue;
+                }
+                for (int y = minY; y <= maxY; y++) {
                     int index = x + sizeX * (y + sizeY * z);
                     if (occupied.get(index)) {
                         continue;


### PR DESCRIPTION
### Motivation
- Prevent the spawn bunker placer from hollowing the entire structure bounding box so surrounding terrain can blend naturally around the bunker. 
- Ensure the impact zone structure uses the intended terrain adaptation of `bury` rather than the previously proposed `beard_thin` so that impact sites remain buried.

### Description
- Restrict clearing in `clearTerrainInsideStructure` to vertical columns that actually contain non-air structure blocks by tracking per-column `minYByColumn` and `maxYByColumn` and only clearing between those bounds. 
- Update occupancy calculation to populate `minYByColumn`/`maxYByColumn` while still marking `occupied` slots for structure blocks. 
- Restore `terrain_adaptation` to `bury` in `src/main/resources/data/wildernessodysseyapi/worldgen/structure/impact_zone.json` and refine clearing logic in `src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java` (method `clearTerrainInsideStructure`).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696729d70bdc8328ae551b1cc70aa857)