### PR TITLE
Cache palette reflection for world-gen and optimize structure corner cache lookups

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -151,7 +151,8 @@ public abstract class StructureBlockEntityMixin extends BlockEntity implements S
         if (structureNameKey != null) {
             StructureBlockCornerCache cache = StructureBlockCornerCache.getIfPresent(serverLevel);
             if (cache != null) {
-                java.util.List<BlockPos> cachedCorners = cache.findCorners(structureNameKey, blockPos, detectionRadius);
+                java.util.List<BlockPos> cachedCorners = cache.findCornersUnsorted(structureNameKey, blockPos,
+                        detectionRadius);
                 for (BlockPos cachedCorner : cachedCorners) {
                     if (cachedCorner.equals(blockPos)) {
                         continue;
@@ -649,7 +650,7 @@ public abstract class StructureBlockEntityMixin extends BlockEntity implements S
         StructureBlockCornerCache cache = StructureBlockCornerCache.getIfPresent(serverLevel);
         boolean addedFromCache = false;
         if (cache != null) {
-            java.util.List<BlockPos> cachedCorners = cache.findCorners(structureNameKey, origin, searchRadius);
+            java.util.List<BlockPos> cachedCorners = cache.findCornersUnsorted(structureNameKey, origin, searchRadius);
             for (BlockPos cachedCorner : cachedCorners) {
                 if (cachedCorner.equals(origin)) {
                     continue;

--- a/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockCornerCache.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockCornerCache.java
@@ -81,6 +81,19 @@ public final class StructureBlockCornerCache {
      * Streams known corner positions for the provided structure name, sorted by manhattan distance.
      */
     public synchronized java.util.List<BlockPos> findCorners(String structureName, BlockPos origin, int maxDistance) {
+        java.util.List<BlockPos> result = findCornersUnsorted(structureName, origin, maxDistance);
+        if (result.size() <= 1) {
+            return result;
+        }
+        result.sort(java.util.Comparator.comparingInt(pos -> pos.distManhattan(origin)));
+        return result;
+    }
+
+    /**
+     * Streams known corner positions for the provided structure name without sorting.
+     */
+    public synchronized java.util.List<BlockPos> findCornersUnsorted(String structureName, BlockPos origin,
+            int maxDistance) {
         String normalized = normalize(structureName);
         if (normalized == null) {
             return java.util.Collections.emptyList();
@@ -91,13 +104,16 @@ public final class StructureBlockCornerCache {
         }
         int range = maxDistance < 0 ? Integer.MAX_VALUE : maxDistance;
         java.util.ArrayList<BlockPos> result = new java.util.ArrayList<>(corners.size());
+        if (range == Integer.MAX_VALUE) {
+            result.addAll(corners);
+            return result;
+        }
         for (BlockPos corner : corners) {
             if (!isWithinRange(origin, corner, range)) {
                 continue;
             }
             result.add(corner);
         }
-        result.sort(java.util.Comparator.comparingInt(pos -> pos.distManhattan(origin)));
         return result;
     }
 


### PR DESCRIPTION
### Motivation
- Reduce CPU overhead during structure handling and world generation by avoiding repeated reflection and redundant sorting work. 
- Ensure structure placement (auto-blend / terrain clearing) and structure block validation paths are efficient when scanning palettes and cached corners. 

### Description
- Add `PALETTE_BLOCK_FIELDS` cache and `findPaletteBlocksField` helper to `NBTStructurePlacer` so `resolvePaletteBlocks` reuses a reflected `Field` per palette `Class` instead of repeatedly probing via reflection. 
- Add `findCornersUnsorted` to `StructureBlockCornerCache` and make `findCorners` delegate to it, sorting only when necessary, and fast-path unlimited-range queries to return the whole set. 
- Update `StructureBlockEntityMixin` to call `findCornersUnsorted` in local cache and far-corner scan paths to avoid redundant sorting during validation and scanning. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69685de74bc08328a69b935b7fbfabf7)