### PR TITLE
Skip smart auto-blend for starter bunker and widen support tolerance

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/structure/NBTStructurePlacer.java
@@ -196,7 +196,7 @@ public class NBTStructurePlacer {
             int maxDepth = StructureConfig.AUTO_TERRAIN_BLEND_MAX_DEPTH.get();
             int radius = resolveAutoBlendRadius(data.size());
             TerrainReplacerEngine.AutoBlendMask mask = TerrainReplacerEngine.AutoBlendMask.allowAll();
-            if (StructureConfig.ENABLE_SMART_AUTO_TERRAIN_BLEND.get()) {
+            if (!isStarterBunker() && StructureConfig.ENABLE_SMART_AUTO_TERRAIN_BLEND.get()) {
                 mask = buildAutoBlendMask(data.template(), foundation.origin(), data.size());
             }
             autoBlended = TerrainReplacerEngine.applyAutoBlend(level, placementBox, maxDepth, radius, mask);
@@ -598,10 +598,11 @@ public class NBTStructurePlacer {
             return TerrainReplacerEngine.AutoBlendMask.allowAll();
         }
 
+        final int supportTolerance = 1;
         boolean[] supported = new boolean[sizeX * sizeZ];
         boolean anySupported = false;
         for (int i = 0; i < lowestY.length; i++) {
-            if (lowestY[i] != Integer.MAX_VALUE && lowestY[i] == globalMinY) {
+            if (lowestY[i] != Integer.MAX_VALUE && lowestY[i] <= globalMinY + supportTolerance) {
                 supported[i] = true;
                 anySupported = true;
             }


### PR DESCRIPTION
### Motivation
- Prevent uneven terrain edges around the starter bunker by not applying the smart auto-blend mask to that structure.
- Make the auto-blend support detection less strict so columns near the template's lowest layer are considered supported and reduce jagged terrain transitions.

### Description
- Skip calling `buildAutoBlendMask(...)` for starter bunkers by changing the condition to `if (!isStarterBunker() && StructureConfig.ENABLE_SMART_AUTO_TERRAIN_BLEND.get())` so the bunker uses the full `allowAll` mask.
- Introduce `supportTolerance = 1` in `buildAutoBlendMask` and change the supported-column check from `lowestY == globalMinY` to `lowestY <= globalMinY + supportTolerance` so nearby low columns count as supported.
- Preserve the fallback behavior of returning `TerrainReplacerEngine.AutoBlendMask.allowAll()` when no supported columns are detected.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dae4ed4908328a4792ad0381de605)