### PR TITLE
Gate AI and global chat process launch via config defaults

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/command/GlobalChatCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/GlobalChatCommand.java
@@ -168,15 +168,18 @@ public class GlobalChatCommand {
 
     private static int startServer(CommandContext<CommandSourceStack> ctx) {
         int port = IntegerArgumentType.getInteger(ctx, "port");
-        if (GlobalChatManager.getInstance().getSettings() != null
-                && !GlobalChatManager.getInstance().getSettings().allowServerAutostart()) {
+        GlobalChatSettings settings = GlobalChatManager.getInstance().getSettings();
+        if (settings == null || !settings.enabled()) {
+            ctx.getSource().sendFailure(Component.literal("Global chat is disabled. Enable it in config before starting the relay server."));
+            return 0;
+        }
+        if (!settings.allowServerAutostart()) {
             ctx.getSource().sendFailure(Component.literal("Relay autostart is disabled; start the central server on the dedicated host you configured."));
             return 0;
         }
         try {
-            GlobalChatManager manager = GlobalChatManager.getInstance();
-            String moderationToken = manager.getSettings() != null ? manager.getSettings().moderationToken() : "";
-            String clusterToken = manager.getSettings() != null ? manager.getSettings().clusterToken() : "";
+            String moderationToken = settings.moderationToken();
+            String clusterToken = settings.clusterToken();
             SERVER_PROCESS.start(port, moderationToken, clusterToken);
             ctx.getSource().sendSuccess(() -> Component.literal("Started relay server on port " + port), true);
             return 1;
@@ -208,10 +211,7 @@ public class GlobalChatCommand {
 
     private static int setAllowAutostart(CommandContext<CommandSourceStack> ctx) {
         boolean enabled = BoolArgumentType.getBool(ctx, "enabled");
-        GlobalChatManager manager = GlobalChatManager.getInstance();
-        if (manager.getSettings() != null) {
-            manager.getSettings().setAllowServerAutostart(enabled);
-        }
+        GlobalChatManager.getInstance().setAllowServerAutostart(enabled);
         ctx.getSource().sendSuccess(() -> Component.literal("Relay server autostart " + (enabled ? "enabled" : "disabled") + "."), true);
         return 1;
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatManager.java
@@ -242,6 +242,14 @@ public class GlobalChatManager {
         settings.save(settingsFile);
     }
 
+    public void setAllowServerAutostart(boolean enabled) {
+        if (settings == null) {
+            return;
+        }
+        settings.setAllowServerAutostart(enabled);
+        settings.save(settingsFile);
+    }
+
     public void sendModerationAction(String action, String target, long durationSeconds, boolean includeIp,
                                      String role, String ip, String reason) {
         if (!connected.get() || settings == null || settings.moderationToken().isEmpty()) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatSettings.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatSettings.java
@@ -24,7 +24,7 @@ public class GlobalChatSettings {
 
     private String host = DEFAULT_RELAY_HOST;
     private int port = DEFAULT_RELAY_PORT;
-    private boolean enabled = true;
+    private boolean enabled = false;
     private List<String> downtimeHistory = new ArrayList<>();
     private boolean allowServerAutostart = false;
     private String moderationToken = "";

--- a/src/main/resources/ai_config.yaml
+++ b/src/main/resources/ai_config.yaml
@@ -18,8 +18,8 @@ settings:
   wake_word: "atlas"
   model: "local-story-engine"
 local_model:
-  enabled: true
-  auto_start: true
+  enabled: false
+  auto_start: false
   base_url: "http://localhost:11434"
   model: "llama3.2:3b"
   start_command: ""


### PR DESCRIPTION
### Motivation
- Prevent the mod from auto-launching local AI or starting the global chat relay by default to avoid unexpected external processes.
- Ensure relay autostart permission is persisted and controlled through the manager to allow server operators to opt in explicitly.
- Align default behavior with platform/mod distribution guidelines by making AI and global chat process launches opt-in.

### Description
- Disable bundled local model auto-start in `src/main/resources/ai_config.yaml` by setting `local_model.enabled` and `local_model.auto_start` to `false`.
- Default global chat to disabled in `GlobalChatSettings` by changing the `enabled` default to `false`.
- Add `setAllowServerAutostart(boolean)` to `GlobalChatManager` so autostart permission changes are saved via the manager.
- Update `GlobalChatCommand` to require global chat to be enabled before starting the relay, use the loaded `GlobalChatSettings` for tokens, and route the `allowautostart` command through the manager.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696faf1d916c8328a4d0762abd7cd223)