### PR TITLE
Show telemetry consent prompt on title screen

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -32,6 +32,10 @@ import com.thunder.wildernessodysseyapi.globalchat.GlobalChatManager;
 import com.thunder.wildernessodysseyapi.rules.GameRulesListManager;
 import com.thunder.wildernessodysseyapi.tide.TideConfig;
 import com.thunder.wildernessodysseyapi.tide.TideManager;
+import com.thunder.wildernessodysseyapi.telemetry.PlayerTelemetryConfig;
+import com.thunder.wildernessodysseyapi.telemetry.PlayerTelemetryReporter;
+import com.thunder.wildernessodysseyapi.telemetry.TelemetryConsentCommand;
+import com.thunder.wildernessodysseyapi.telemetry.TelemetryConsentConfig;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -101,6 +105,7 @@ public class WildernessOdysseyAPIMainModClass {
         NeoForge.EVENT_BUS.register(BlacklistChecker.class);
         NeoForge.EVENT_BUS.register(InfiniteSourceHandler.class);
         NeoForge.EVENT_BUS.register(AIChatListener.class);
+        NeoForge.EVENT_BUS.register(PlayerTelemetryReporter.class);
 
         CryoTubeBlock.register(modEventBus);
         ModItems.register(modEventBus);
@@ -109,6 +114,8 @@ public class WildernessOdysseyAPIMainModClass {
                 CONFIG_FOLDER + "wildernessodysseyapi-structures.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.CLIENT, DonationReminderConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-donations-client.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.CLIENT, TelemetryConsentConfig.CONFIG_SPEC,
+                CONFIG_FOLDER + "wildernessodysseyapi-telemetry-client.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, AsyncThreadingConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-async.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, AntiCheatConfig.CONFIG_SPEC,
@@ -117,6 +124,8 @@ public class WildernessOdysseyAPIMainModClass {
                 CONFIG_FOLDER + "wildernessodysseyapi-structureblocks-server.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, TideConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-tides-server.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, PlayerTelemetryConfig.CONFIG_SPEC,
+                CONFIG_FOLDER + "wildernessodysseyapi-telemetry-server.toml");
         // Previously registered client-only events have been removed
         DonationReminderConfig.validateVersion();
 
@@ -168,6 +177,7 @@ public class WildernessOdysseyAPIMainModClass {
         GlobalChatCommand.register(dispatcher);
         GlobalChatOptToggleCommand.register(dispatcher);
         TideInfoCommand.register(dispatcher);
+        TelemetryConsentCommand.register(dispatcher);
     }
 
     /**

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/PlayerTelemetryConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/PlayerTelemetryConfig.java
@@ -1,0 +1,69 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+/**
+ * Server configuration for player telemetry exports.
+ */
+public final class PlayerTelemetryConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+
+    public static final ModConfigSpec.BooleanValue ENABLED;
+    public static final ModConfigSpec.ConfigValue<String> GEO_IP_ENDPOINT;
+    public static final ModConfigSpec.ConfigValue<String> ACCOUNT_AGE_ENDPOINT;
+    public static final ModConfigSpec.ConfigValue<String> SHEET_WEBHOOK_URL;
+    public static final ModConfigSpec.IntValue REQUEST_TIMEOUT_SECONDS;
+
+    private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
+
+    static {
+        BUILDER.push("playerTelemetry");
+
+        ENABLED = BUILDER.comment("Master toggle for exporting player telemetry to a Google Sheets webhook.")
+                .define("enabled", false);
+
+        GEO_IP_ENDPOINT = BUILDER.comment(
+                        "Geo IP lookup endpoint used to resolve state/country. Use {ip} as a placeholder.",
+                        "Example: https://ipapi.co/{ip}/json/")
+                .define("geoIpEndpoint", "https://ipapi.co/{ip}/json/");
+
+        ACCOUNT_AGE_ENDPOINT = BUILDER.comment(
+                        "Endpoint for player name history lookup to estimate account age. Use {uuid} placeholder.",
+                        "Example: https://api.mojang.com/user/profiles/{uuid}/names")
+                .define("accountAgeEndpoint", "https://api.mojang.com/user/profiles/{uuid}/names");
+
+        SHEET_WEBHOOK_URL = BUILDER.comment(
+                        "Google Sheets webhook URL (Apps Script or other endpoint) that accepts JSON payloads.",
+                        "Leave blank to disable exports even when telemetry is enabled.")
+                .define("sheetWebhookUrl", "");
+
+        REQUEST_TIMEOUT_SECONDS = BUILDER.comment("HTTP request timeout in seconds for telemetry lookups.")
+                .defineInRange("requestTimeoutSeconds", 10, 1, 60);
+
+        BUILDER.pop();
+
+        CONFIG_SPEC = BUILDER.build();
+    }
+
+    private PlayerTelemetryConfig() {
+    }
+
+    public static TelemetryConfigValues values() {
+        return new TelemetryConfigValues(
+                ENABLED.get(),
+                GEO_IP_ENDPOINT.get(),
+                ACCOUNT_AGE_ENDPOINT.get(),
+                SHEET_WEBHOOK_URL.get(),
+                REQUEST_TIMEOUT_SECONDS.get()
+        );
+    }
+
+    public record TelemetryConfigValues(
+            boolean enabled,
+            String geoIpEndpoint,
+            String accountAgeEndpoint,
+            String sheetWebhookUrl,
+            int requestTimeoutSeconds
+    ) {
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/PlayerTelemetryReporter.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/PlayerTelemetryReporter.java
@@ -1,0 +1,235 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.thunder.wildernessodysseyapi.async.AsyncTaskManager;
+import com.thunder.wildernessodysseyapi.telemetry.TelemetryConsentStore.ConsentDecision;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
+
+/**
+ * Collects player location and account age data and sends it to a Google Sheets webhook.
+ */
+public final class PlayerTelemetryReporter {
+    private static final Gson GSON = new GsonBuilder().create();
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    private PlayerTelemetryReporter() {
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) {
+            return;
+        }
+
+        PlayerTelemetryConfig.TelemetryConfigValues config = PlayerTelemetryConfig.values();
+        if (!config.enabled()) {
+            return;
+        }
+
+        if (config.sheetWebhookUrl() == null || config.sheetWebhookUrl().isBlank()) {
+            LOGGER.warn("[Telemetry] Telemetry enabled but sheetWebhookUrl is blank. Skipping export.");
+            return;
+        }
+
+        TelemetryConsentStore consentStore = TelemetryConsentStore.get(player.server);
+        if (consentStore.getDecision(player.getUUID()) != ConsentDecision.ACCEPTED) {
+            return;
+        }
+
+        String ipAddress = resolveIpAddress(player);
+        AsyncTaskManager.submitIoTask("player-telemetry-export", () -> {
+            try {
+                GeoInfo geoInfo = fetchGeoInfo(ipAddress, config);
+                AccountAgeInfo accountAge = fetchAccountAge(player.getUUID(), config);
+                postToSheet(player, geoInfo, accountAge, config.sheetWebhookUrl(), config.requestTimeoutSeconds());
+            } catch (Exception ex) {
+                LOGGER.error("[Telemetry] Failed to export telemetry for {}", player.getGameProfile().getName(), ex);
+            }
+            return Optional.empty();
+        });
+    }
+
+    private static String resolveIpAddress(ServerPlayer player) {
+        if (player.connection == null || player.connection.getConnection() == null) {
+            return null;
+        }
+        SocketAddress address = player.connection.getConnection().getRemoteAddress();
+        if (address instanceof InetSocketAddress inetSocketAddress) {
+            if (inetSocketAddress.getAddress() != null) {
+                return inetSocketAddress.getAddress().getHostAddress();
+            }
+        }
+        return null;
+    }
+
+    private static GeoInfo fetchGeoInfo(String ipAddress, PlayerTelemetryConfig.TelemetryConfigValues config) {
+        if (ipAddress == null || ipAddress.isBlank()) {
+            return GeoInfo.empty();
+        }
+        String endpointTemplate = config.geoIpEndpoint();
+        if (endpointTemplate == null || endpointTemplate.isBlank()) {
+            return GeoInfo.empty();
+        }
+        String endpoint = endpointTemplate.replace("{ip}", ipAddress.trim());
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint))
+                    .timeout(Duration.ofSeconds(config.requestTimeoutSeconds()))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+                LOGGER.warn("[Telemetry] Geo IP lookup failed (status {}).", response.statusCode());
+                return GeoInfo.empty();
+            }
+            JsonElement element = JsonParser.parseString(response.body());
+            if (!element.isJsonObject()) {
+                return GeoInfo.empty();
+            }
+            JsonObject object = element.getAsJsonObject();
+            String state = firstNonBlank(object, "region", "regionName", "state", "region_name");
+            String country = firstNonBlank(object, "country", "country_name", "countryName", "country_code", "countryCode");
+            return new GeoInfo(state, country);
+        } catch (Exception ex) {
+            LOGGER.warn("[Telemetry] Geo IP lookup failed: {}", ex.getMessage());
+            return GeoInfo.empty();
+        }
+    }
+
+    private static AccountAgeInfo fetchAccountAge(UUID uuid, PlayerTelemetryConfig.TelemetryConfigValues config) {
+        String endpointTemplate = config.accountAgeEndpoint();
+        if (uuid == null || endpointTemplate == null || endpointTemplate.isBlank()) {
+            return AccountAgeInfo.empty();
+        }
+        String compactUuid = uuid.toString().replace("-", "");
+        String endpoint = endpointTemplate.replace("{uuid}", compactUuid);
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint))
+                    .timeout(Duration.ofSeconds(config.requestTimeoutSeconds()))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+                LOGGER.warn("[Telemetry] Account age lookup failed (status {}).", response.statusCode());
+                return AccountAgeInfo.empty();
+            }
+            JsonElement element = JsonParser.parseString(response.body());
+            if (!element.isJsonArray()) {
+                return AccountAgeInfo.empty();
+            }
+            JsonArray array = element.getAsJsonArray();
+            Long earliestChange = null;
+            for (JsonElement entry : array) {
+                if (!entry.isJsonObject()) {
+                    continue;
+                }
+                JsonObject obj = entry.getAsJsonObject();
+                if (obj.has("changedToAt") && obj.get("changedToAt").isJsonPrimitive()) {
+                    long changedToAt = obj.get("changedToAt").getAsLong();
+                    if (changedToAt > 0 && (earliestChange == null || changedToAt < earliestChange)) {
+                        earliestChange = changedToAt;
+                    }
+                }
+            }
+            if (earliestChange == null) {
+                return AccountAgeInfo.empty();
+            }
+            Instant firstChange = Instant.ofEpochMilli(earliestChange);
+            long ageDays = Duration.between(firstChange, Instant.now()).toDays();
+            return new AccountAgeInfo(ageDays, firstChange);
+        } catch (Exception ex) {
+            LOGGER.warn("[Telemetry] Account age lookup failed: {}", ex.getMessage());
+            return AccountAgeInfo.empty();
+        }
+    }
+
+    private static void postToSheet(ServerPlayer player, GeoInfo geoInfo, AccountAgeInfo accountAge, String webhookUrl, int timeoutSeconds) {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("uuid", player.getUUID().toString());
+        payload.addProperty("player_name", player.getGameProfile().getName());
+        payload.addProperty("timestamp", Instant.now().toString());
+
+        if (geoInfo.state != null) {
+            payload.addProperty("state", geoInfo.state);
+        }
+        if (geoInfo.country != null) {
+            payload.addProperty("country", geoInfo.country);
+        }
+
+        if (accountAge.estimatedAgeDays != null) {
+            payload.addProperty("account_age_days", accountAge.estimatedAgeDays);
+            payload.addProperty("account_age_reference", accountAge.referenceDate.toString());
+        } else {
+            payload.addProperty("account_age_reference", "unknown");
+        }
+        payload.addProperty("account_age_source", accountAge.source);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(webhookUrl))
+                .timeout(Duration.ofSeconds(timeoutSeconds))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(GSON.toJson(payload)))
+                .build();
+        try {
+            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+                LOGGER.warn("[Telemetry] Sheet export failed (status {}).", response.statusCode());
+            } else {
+                LOGGER.info("[Telemetry] Exported telemetry for {}.", player.getGameProfile().getName());
+            }
+        } catch (Exception ex) {
+            LOGGER.warn("[Telemetry] Sheet export failed: {}", ex.getMessage());
+        }
+    }
+
+    private static String firstNonBlank(JsonObject object, String... keys) {
+        for (String key : keys) {
+            if (object.has(key) && object.get(key).isJsonPrimitive()) {
+                String value = object.get(key).getAsString();
+                if (value != null && !value.isBlank()) {
+                    return value;
+                }
+            }
+        }
+        return null;
+    }
+
+    private record GeoInfo(String state, String country) {
+        static GeoInfo empty() {
+            return new GeoInfo(null, null);
+        }
+    }
+
+    private record AccountAgeInfo(Long estimatedAgeDays, Instant referenceDate, String source) {
+        static AccountAgeInfo empty() {
+            return new AccountAgeInfo(null, null, "unknown");
+        }
+
+        AccountAgeInfo(Long estimatedAgeDays, Instant referenceDate) {
+            this(estimatedAgeDays, referenceDate, "name_change");
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentClientHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentClientHandler.java
@@ -21,7 +21,7 @@ public final class TelemetryConsentClientHandler {
     }
 
     @SubscribeEvent
-    public static void onClientLogin(ClientPlayerNetworkEvent.LoggedInEvent event) {
+    public static void onClientLogin(ClientPlayerNetworkEvent.LoggingIn event) {
         TelemetryConsentConfig.validateVersion();
         if (TelemetryConsentConfig.decision() != ConsentDecision.UNKNOWN) {
             return;

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentClientHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentClientHandler.java
@@ -1,0 +1,53 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.telemetry.TelemetryConsentStore.ConsentDecision;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+
+/**
+ * Displays telemetry consent UI on client login when needed.
+ */
+@EventBusSubscriber(modid = ModConstants.MOD_ID, value = Dist.CLIENT)
+public final class TelemetryConsentClientHandler {
+    private static boolean promptedThisSession = false;
+
+    private TelemetryConsentClientHandler() {
+    }
+
+    @SubscribeEvent
+    public static void onClientLogin(ClientPlayerNetworkEvent.LoggedInEvent event) {
+        TelemetryConsentConfig.validateVersion();
+        if (TelemetryConsentConfig.decision() != ConsentDecision.UNKNOWN) {
+            return;
+        }
+        Minecraft minecraft = Minecraft.getInstance();
+        minecraft.execute(() -> {
+            if (!promptedThisSession && minecraft.screen == null) {
+                promptedThisSession = true;
+                minecraft.setScreen(new TelemetryConsentScreen());
+            }
+        });
+    }
+
+    @SubscribeEvent
+    public static void onClientTick(ClientTickEvent.Post event) {
+        if (promptedThisSession) {
+            return;
+        }
+        TelemetryConsentConfig.validateVersion();
+        if (TelemetryConsentConfig.decision() != ConsentDecision.UNKNOWN) {
+            return;
+        }
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.screen instanceof TitleScreen) {
+            promptedThisSession = true;
+            minecraft.setScreen(new TelemetryConsentScreen());
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentCommand.java
@@ -1,0 +1,46 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.thunder.wildernessodysseyapi.telemetry.TelemetryConsentStore.ConsentDecision;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+/**
+ * Commands to set telemetry consent state.
+ */
+public final class TelemetryConsentCommand {
+    private TelemetryConsentCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("telemetryconsent")
+                .then(option("accept", ConsentDecision.ACCEPTED))
+                .then(option("decline", ConsentDecision.DECLINED))
+                .executes(context -> {
+                    ServerPlayer player = context.getSource().getPlayer();
+                    if (player == null) {
+                        return 0;
+                    }
+                    ConsentDecision decision = TelemetryConsentStore.get(player.server).getDecision(player.getUUID());
+                    player.sendSystemMessage(Component.translatable("command.wildernessodysseyapi.telemetry.status", decision.serialized()));
+                    return 1;
+                }));
+    }
+
+    private static ArgumentBuilder<CommandSourceStack, ?> option(String name, ConsentDecision decision) {
+        return Commands.literal(name)
+                .executes(context -> {
+                    ServerPlayer player = context.getSource().getPlayer();
+                    if (player == null) {
+                        return 0;
+                    }
+                    TelemetryConsentStore store = TelemetryConsentStore.get(player.server);
+                    store.setDecision(player.getUUID(), decision);
+                    player.sendSystemMessage(Component.translatable("command.wildernessodysseyapi.telemetry.set", decision.serialized()));
+                    return 1;
+                });
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentConfig.java
@@ -1,0 +1,53 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.telemetry.TelemetryConsentStore.ConsentDecision;
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+/**
+ * Client-side configuration for telemetry consent UI state.
+ */
+public final class TelemetryConsentConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+
+    private static final ModConfigSpec.ConfigValue<String> CONSENT_DECISION;
+    private static final ModConfigSpec.ConfigValue<String> CONSENT_VERSION;
+
+    static {
+        ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
+        builder.push("telemetryConsent");
+
+        CONSENT_DECISION = builder.comment("Client-side telemetry consent decision (accepted/declined/unknown).")
+                .define("decision", ConsentDecision.UNKNOWN.serialized());
+        CONSENT_VERSION = builder.comment("Mod version when consent was last recorded.")
+                .define("version", ModConstants.VERSION);
+
+        builder.pop();
+
+        CONFIG_SPEC = builder.build();
+    }
+
+    private TelemetryConsentConfig() {
+    }
+
+    public static ConsentDecision decision() {
+        return ConsentDecision.fromString(CONSENT_DECISION.get());
+    }
+
+    public static void setDecision(ConsentDecision decision) {
+        CONSENT_DECISION.set(decision.serialized());
+        CONFIG_SPEC.save();
+    }
+
+    public static void validateVersion() {
+        if (!CONFIG_SPEC.isLoaded()) {
+            return;
+        }
+        String currentVersion = ModConstants.VERSION;
+        if (!CONSENT_VERSION.get().equals(currentVersion)) {
+            CONSENT_DECISION.set(ConsentDecision.UNKNOWN.serialized());
+            CONSENT_VERSION.set(currentVersion);
+            CONFIG_SPEC.save();
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
@@ -1,0 +1,72 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import com.thunder.wildernessodysseyapi.telemetry.TelemetryConsentStore.ConsentDecision;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Simple consent dialog for telemetry sharing.
+ */
+public class TelemetryConsentScreen extends Screen {
+    private static final int BUTTON_WIDTH = 160;
+    private static final int BUTTON_HEIGHT = 20;
+
+    public TelemetryConsentScreen() {
+        super(Component.translatable("screen.wildernessodysseyapi.telemetry.title"));
+    }
+
+    @Override
+    protected void init() {
+        int centerX = this.width / 2;
+        int buttonY = this.height / 2 + 30;
+
+        addRenderableWidget(Button.builder(
+                        Component.translatable("screen.wildernessodysseyapi.telemetry.accept"),
+                        button -> handleChoice(ConsentDecision.ACCEPTED))
+                .bounds(centerX - BUTTON_WIDTH - 10, buttonY, BUTTON_WIDTH, BUTTON_HEIGHT)
+                .build());
+
+        addRenderableWidget(Button.builder(
+                        Component.translatable("screen.wildernessodysseyapi.telemetry.decline"),
+                        button -> handleChoice(ConsentDecision.DECLINED))
+                .bounds(centerX + 10, buttonY, BUTTON_WIDTH, BUTTON_HEIGHT)
+                .build());
+    }
+
+    private void handleChoice(ConsentDecision decision) {
+        TelemetryConsentConfig.setDecision(decision);
+        sendConsentCommand(decision);
+        Minecraft.getInstance().setScreen(null);
+    }
+
+    private void sendConsentCommand(ConsentDecision decision) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.player == null || minecraft.player.connection == null) {
+            return;
+        }
+        String command = decision == ConsentDecision.ACCEPTED ? "telemetryconsent accept" : "telemetryconsent decline";
+        minecraft.player.connection.sendCommand(command);
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        this.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
+        guiGraphics.drawCenteredString(this.font, this.title, this.width / 2, this.height / 2 - 40, 0xFFFFFFFF);
+        guiGraphics.drawCenteredString(
+                this.font,
+                Component.translatable("screen.wildernessodysseyapi.telemetry.description"),
+                this.width / 2,
+                this.height / 2 - 15,
+                0xFFDDDDDD
+        );
+        super.render(guiGraphics, mouseX, mouseY, partialTick);
+    }
+
+    @Override
+    public boolean shouldCloseOnEsc() {
+        return false;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentStore.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentStore.java
@@ -1,0 +1,111 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.saveddata.SavedData;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Persists player telemetry consent decisions on the server.
+ */
+public class TelemetryConsentStore extends SavedData {
+    private static final String DATA_NAME = ModConstants.MOD_ID + "_telemetry_consent";
+    private static final String VERSION_KEY = "version";
+    private static final String DECISIONS_KEY = "decisions";
+
+    private final Map<UUID, ConsentDecision> decisions = new HashMap<>();
+    private String version = ModConstants.VERSION;
+
+    public TelemetryConsentStore() {
+    }
+
+    public static TelemetryConsentStore get(MinecraftServer server) {
+        return server.overworld().getDataStorage().computeIfAbsent(
+                TelemetryConsentStore::load,
+                TelemetryConsentStore::new,
+                DATA_NAME
+        );
+    }
+
+    public ConsentDecision getDecision(UUID uuid) {
+        if (uuid == null) {
+            return ConsentDecision.UNKNOWN;
+        }
+        return decisions.getOrDefault(uuid, ConsentDecision.UNKNOWN);
+    }
+
+    public void setDecision(UUID uuid, ConsentDecision decision) {
+        if (uuid == null || decision == null) {
+            return;
+        }
+        decisions.put(uuid, decision);
+        setDirty();
+    }
+
+    @Override
+    public CompoundTag save(CompoundTag tag) {
+        tag.putString(VERSION_KEY, version);
+        CompoundTag decisionTag = new CompoundTag();
+        decisions.forEach((uuid, decision) -> decisionTag.putString(uuid.toString(), decision.serialized()));
+        tag.put(DECISIONS_KEY, decisionTag);
+        return tag;
+    }
+
+    public static TelemetryConsentStore load(CompoundTag tag) {
+        TelemetryConsentStore store = new TelemetryConsentStore();
+        if (tag == null) {
+            return store;
+        }
+        String savedVersion = tag.getString(VERSION_KEY);
+        if (!ModConstants.VERSION.equals(savedVersion)) {
+            store.version = ModConstants.VERSION;
+            return store;
+        }
+        store.version = savedVersion;
+        CompoundTag decisionTag = tag.getCompound(DECISIONS_KEY);
+        for (String key : decisionTag.getAllKeys()) {
+            try {
+                UUID uuid = UUID.fromString(key);
+                ConsentDecision decision = ConsentDecision.fromString(decisionTag.getString(key));
+                store.decisions.put(uuid, decision);
+            } catch (IllegalArgumentException ignored) {
+                // Skip invalid UUID entries.
+            }
+        }
+        return store;
+    }
+
+    public enum ConsentDecision {
+        ACCEPTED("accepted"),
+        DECLINED("declined"),
+        UNKNOWN("unknown");
+
+        private final String serialized;
+
+        ConsentDecision(String serialized) {
+            this.serialized = serialized;
+        }
+
+        public String serialized() {
+            return serialized;
+        }
+
+        public static ConsentDecision fromString(String value) {
+            if (value == null) {
+                return UNKNOWN;
+            }
+            String normalized = value.trim().toLowerCase(Locale.ROOT);
+            for (ConsentDecision decision : values()) {
+                if (decision.serialized.equals(normalized)) {
+                    return decision;
+                }
+            }
+            return UNKNOWN;
+        }
+    }
+}

--- a/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
+++ b/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
@@ -60,5 +60,11 @@
   "screen.wildernessodysseyapi.world_version.command": "Run /updateworldversion in chat if you are an operator.",
   "screen.wildernessodysseyapi.world_version.worldgen_warning": "World generation and structures may change.",
   "screen.wildernessodysseyapi.world_version.bug_tip": "For bugs, test in a fresh world before reporting.",
+  "screen.wildernessodysseyapi.telemetry.title": "Share Gameplay Statistics?",
+  "screen.wildernessodysseyapi.telemetry.description": "Share your country/state and account age to help improve the mod.",
+  "screen.wildernessodysseyapi.telemetry.accept": "I Accept",
+  "screen.wildernessodysseyapi.telemetry.decline": "I Decline",
+  "command.wildernessodysseyapi.telemetry.status": "Telemetry consent is currently set to: %s",
+  "command.wildernessodysseyapi.telemetry.set": "Telemetry consent updated to: %s",
   "pack.wildernessodysseyapi.plains_spawn.title": "Wilderness Odyssey Plains Spawn"
 }


### PR DESCRIPTION
### Motivation
- Ensure the telemetry consent dialog also appears when the main menu (title screen) is shown so clients are prompted even before joining a server. 
- Prevent repeatedly showing the dialog by ensuring the prompt appears at most once per client session while preserving the existing login-based flow.

### Description
- Updated `TelemetryConsentClientHandler` to add a `promptedThisSession` flag and guard the login flow to avoid duplicate prompts by checking the flag in `onClientLogin`.
- Subscribed to `ClientTickEvent.Post` and when the local `Minecraft` `screen` is an instance of `TitleScreen` the code now opens `TelemetryConsentScreen` (and sets `promptedThisSession`).
- Added the `TitleScreen` import and the `ClientTickEvent` handler to show the consent UI from the main menu while still validating version and existing client-side decision via `TelemetryConsentConfig`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697126cf40f88328b56dfb7b5b35fd9e)