### PR TITLE
Skip custom loading backdrop for FancyMenu/Drippy and reflow telemetry consent text

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/LoadingOverlayMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/LoadingOverlayMixin.java
@@ -6,6 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.LoadingOverlay;
 import net.minecraft.resources.ResourceLocation;
+import net.neoforged.fml.ModList;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -25,6 +26,9 @@ public class LoadingOverlayMixin {
             return;
         }
         LoadingStallDetector.recordProgress();
+        if (ModList.get().isLoaded("fancymenu") || ModList.get().isLoaded("drippyloadingscreen")) {
+            return;
+        }
 
         int screenWidth = minecraft.getWindow().getGuiScaledWidth();
         int screenHeight = minecraft.getWindow().getGuiScaledHeight();

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
@@ -6,6 +6,10 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.FormattedCharSequence;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Simple consent dialog for telemetry sharing.
@@ -13,6 +17,14 @@ import net.minecraft.network.chat.Component;
 public class TelemetryConsentScreen extends Screen {
     private static final int BUTTON_WIDTH = 160;
     private static final int BUTTON_HEIGHT = 20;
+    private static final int TEXT_PADDING = 10;
+    private static final int BUTTON_TOP_MARGIN = 20;
+    private static final int MAX_TEXT_WIDTH = 320;
+
+    private List<FormattedCharSequence> descriptionLines = Collections.emptyList();
+    private int titleY;
+    private int descriptionY;
+    private int buttonY;
 
     public TelemetryConsentScreen() {
         super(Component.translatable("screen.wildernessodysseyapi.telemetry.title"));
@@ -21,18 +33,29 @@ public class TelemetryConsentScreen extends Screen {
     @Override
     protected void init() {
         int centerX = this.width / 2;
-        int buttonY = this.height / 2 + 30;
+        int maxTextWidth = Math.min(this.width - 40, MAX_TEXT_WIDTH);
+        this.descriptionLines = this.font.split(
+                Component.translatable("screen.wildernessodysseyapi.telemetry.description"),
+                maxTextWidth
+        );
+        int descriptionHeight = this.descriptionLines.size() * this.font.lineHeight;
+        int textBlockHeight = this.font.lineHeight + TEXT_PADDING + descriptionHeight;
+        int totalHeight = textBlockHeight + BUTTON_TOP_MARGIN + BUTTON_HEIGHT;
+        int startY = Math.max(20, (this.height - totalHeight) / 2);
+        this.titleY = startY;
+        this.descriptionY = this.titleY + this.font.lineHeight + TEXT_PADDING;
+        this.buttonY = this.descriptionY + descriptionHeight + BUTTON_TOP_MARGIN;
 
         addRenderableWidget(Button.builder(
                         Component.translatable("screen.wildernessodysseyapi.telemetry.accept"),
                         button -> handleChoice(ConsentDecision.ACCEPTED))
-                .bounds(centerX - BUTTON_WIDTH - 10, buttonY, BUTTON_WIDTH, BUTTON_HEIGHT)
+                .bounds(centerX - BUTTON_WIDTH - 10, this.buttonY, BUTTON_WIDTH, BUTTON_HEIGHT)
                 .build());
 
         addRenderableWidget(Button.builder(
                         Component.translatable("screen.wildernessodysseyapi.telemetry.decline"),
                         button -> handleChoice(ConsentDecision.DECLINED))
-                .bounds(centerX + 10, buttonY, BUTTON_WIDTH, BUTTON_HEIGHT)
+                .bounds(centerX + 10, this.buttonY, BUTTON_WIDTH, BUTTON_HEIGHT)
                 .build());
     }
 
@@ -54,14 +77,14 @@ public class TelemetryConsentScreen extends Screen {
     @Override
     public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         this.renderBackground(guiGraphics, mouseX, mouseY, partialTick);
-        guiGraphics.drawCenteredString(this.font, this.title, this.width / 2, this.height / 2 - 40, 0xFFFFFFFF);
-        guiGraphics.drawCenteredString(
-                this.font,
-                Component.translatable("screen.wildernessodysseyapi.telemetry.description"),
-                this.width / 2,
-                this.height / 2 - 15,
-                0xFFDDDDDD
-        );
+        int centerX = this.width / 2;
+        guiGraphics.drawCenteredString(this.font, this.title, centerX, this.titleY, 0xFFFFFFFF);
+        int lineY = this.descriptionY;
+        for (FormattedCharSequence line : this.descriptionLines) {
+            int lineX = centerX - this.font.width(line) / 2;
+            guiGraphics.drawString(this.font, line, lineX, lineY, 0xFFDDDDDD, false);
+            lineY += this.font.lineHeight;
+        }
         super.render(guiGraphics, mouseX, mouseY, partialTick);
     }
 


### PR DESCRIPTION
### Motivation
- Prevent visual conflicts on the loading screen when known menu/loading-screen mods are present by avoiding the mod's custom backdrop (`FancyMenu` and `DrippyLoadingScreen`).
- Fix the telemetry consent UI where the descriptive text can be blurred/overlapped by the buttons by ensuring the text is wrapped and the buttons are positioned below it.

### Description
- Add an early-return in `LoadingOverlayMixin` that checks `ModList.get().isLoaded("fancymenu")` or `ModList.get().isLoaded("drippyloadingscreen")` and skips drawing the custom loading background, and add the required `ModList` import.
- Reflow the telemetry consent copy by computing wrapped lines with `font.split`, measuring the text block height, and computing `titleY`, `descriptionY`, and `buttonY` so buttons are laid out below the wrapped description.
- Render wrapped description lines individually with `drawString` rather than a single centered call, and introduce layout constants (`TEXT_PADDING`, `BUTTON_TOP_MARGIN`, `MAX_TEXT_WIDTH`) and fields (`descriptionLines`, `titleY`, `descriptionY`, `buttonY`).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971ae28e3088328ad1240bdf835542c)