### PR TITLE
Replace Options telemetry button with TelemetryConsentScreen via client mixin

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/OptionsScreenTelemetryButtonMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/OptionsScreenTelemetryButtonMixin.java
@@ -3,7 +3,7 @@ package com.thunder.wildernessodysseyapi.mixin;
 import com.thunder.wildernessodysseyapi.telemetry.TelemetryConsentScreen;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.events.GuiEventListener;
-import net.minecraft.client.gui.screens.OptionsScreen;
+import net.minecraft.client.gui.screens.options.OptionsScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.contents.TranslatableContents;

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/OptionsScreenTelemetryButtonMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/OptionsScreenTelemetryButtonMixin.java
@@ -1,0 +1,58 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.thunder.wildernessodysseyapi.telemetry.TelemetryConsentScreen;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.screens.OptionsScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.contents.TranslatableContents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(OptionsScreen.class)
+public abstract class OptionsScreenTelemetryButtonMixin extends Screen {
+    private static final String TELEMETRY_BUTTON_KEY = "options.telemetry";
+
+    protected OptionsScreenTelemetryButtonMixin(Component title) {
+        super(title);
+    }
+
+    @Inject(method = "init", at = @At("TAIL"))
+    private void wildernessOdysseyApi$replaceTelemetryButton(CallbackInfo ci) {
+        Button telemetryButton = findTelemetryButton();
+        if (telemetryButton == null || this.minecraft == null) {
+            return;
+        }
+
+        int x = telemetryButton.getX();
+        int y = telemetryButton.getY();
+        int width = telemetryButton.getWidth();
+        int height = telemetryButton.getHeight();
+        removeWidget(telemetryButton);
+
+        addRenderableWidget(Button.builder(
+                        Component.translatable("screen.wildernessodysseyapi.telemetry.title"),
+                        button -> this.minecraft.setScreen(new TelemetryConsentScreen()))
+                .bounds(x, y, width, height)
+                .build());
+    }
+
+    private Button findTelemetryButton() {
+        for (GuiEventListener listener : this.children()) {
+            if (listener instanceof Button button && isTelemetryButton(button)) {
+                return button;
+            }
+        }
+        return null;
+    }
+
+    private boolean isTelemetryButton(Button button) {
+        if (button.getMessage().getContents() instanceof TranslatableContents contents) {
+            return TELEMETRY_BUTTON_KEY.equals(contents.getKey());
+        }
+        return false;
+    }
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -25,6 +25,7 @@
     "DebugMixin",
     "LoadingOverlayMixin",
     "MixinWorldCreationUiState",
+    "OptionsScreenTelemetryButtonMixin",
     "ParticleEngineMixin",
     "StructureBlockRendererMixin"
   ]


### PR DESCRIPTION
### Motivation
- Replace the vanilla Options screen telemetry entry with the mod's telemetry consent UI so users open the mod `TelemetryConsentScreen` from the Options menu. 

### Description
- Add `OptionsScreenTelemetryButtonMixin` which injects at the tail of `OptionsScreen.init` to locate and replace the vanilla telemetry `Button`. 
- The mixin identifies the existing button by checking the translatable key `options.telemetry`, removes it, and inserts a same-sized button that opens `TelemetryConsentScreen`. 
- Guard clauses ensure the replacement only runs when the button is found and `minecraft` is available. 
- Register the new client mixin in `mixins.wildernessodysseyapi.json` under the `client` section. 

### Testing
- No automated tests were executed for this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697242d9da90832882e6990dbfc62f48)