### PR TITLE
Fix telemetry consent layout and stabilize consent versioning

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentConfig.java
@@ -19,8 +19,8 @@ public final class TelemetryConsentConfig {
 
         CONSENT_DECISION = builder.comment("Client-side telemetry consent decision (accepted/declined/unknown).")
                 .define("decision", ConsentDecision.UNKNOWN.serialized());
-        CONSENT_VERSION = builder.comment("Mod version when consent was last recorded.")
-                .define("version", ModConstants.VERSION);
+        CONSENT_VERSION = builder.comment("Modpack world version when consent was last recorded.")
+                .define("version", ModConstants.MOD_DEFAULT_WORLD_VERSION);
 
         builder.pop();
 
@@ -36,6 +36,7 @@ public final class TelemetryConsentConfig {
 
     public static void setDecision(ConsentDecision decision) {
         CONSENT_DECISION.set(decision.serialized());
+        CONSENT_VERSION.set(ModConstants.MOD_DEFAULT_WORLD_VERSION);
         CONFIG_SPEC.save();
     }
 
@@ -43,7 +44,7 @@ public final class TelemetryConsentConfig {
         if (!CONFIG_SPEC.isLoaded()) {
             return;
         }
-        String currentVersion = ModConstants.VERSION;
+        String currentVersion = ModConstants.MOD_DEFAULT_WORLD_VERSION;
         if (!CONSENT_VERSION.get().equals(currentVersion)) {
             CONSENT_DECISION.set(ConsentDecision.UNKNOWN.serialized());
             CONSENT_VERSION.set(currentVersion);

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
@@ -47,12 +47,13 @@ public class TelemetryConsentScreen extends Screen {
         );
         int descriptionHeight = this.descriptionLines.size() * this.font.lineHeight;
         int textBlockHeight = this.font.lineHeight + TEXT_PADDING + descriptionHeight + TEXT_PADDING + this.font.lineHeight;
-        int totalHeight = textBlockHeight + BUTTON_TOP_MARGIN + (BUTTON_HEIGHT * 2) + 6;
+        int buttonGap = BUTTON_TOP_MARGIN + TEXT_PADDING;
+        int totalHeight = textBlockHeight + buttonGap + (BUTTON_HEIGHT * 2) + 6;
         int startY = Math.max(20, (this.height - totalHeight) / 2);
         this.titleY = startY;
         this.descriptionY = this.titleY + this.font.lineHeight + TEXT_PADDING;
         this.statusY = this.descriptionY + descriptionHeight + TEXT_PADDING;
-        this.buttonY = this.statusY + this.font.lineHeight + BUTTON_TOP_MARGIN;
+        this.buttonY = this.statusY + this.font.lineHeight + buttonGap;
 
         this.toggleButton = addRenderableWidget(Button.builder(toggleLabel(), button -> toggleDecision())
                 .bounds(centerX - (BUTTON_WIDTH / 2), this.buttonY, BUTTON_WIDTH, BUTTON_HEIGHT)


### PR DESCRIPTION
### Motivation
- Prevent the telemetry consent status text from being rendered behind the action buttons by adding explicit vertical spacing in the UI.
- Stop consent decisions from being invalidated by mod version bumps by aligning stored consent version to the stable modpack world version.

### Description
- Updated `TelemetryConsentConfig` to use `ModConstants.MOD_DEFAULT_WORLD_VERSION` as the `CONSENT_VERSION` default and to save that value in `setDecision` when the user chooses a decision.
- Updated `TelemetryConsentConfig.validateVersion` to compare against `ModConstants.MOD_DEFAULT_WORLD_VERSION` so consent persists across mod version changes.
- Adjusted `TelemetryConsentScreen` layout by introducing a `buttonGap` (computed from `BUTTON_TOP_MARGIN + TEXT_PADDING`) and using it to compute `buttonY`, adding extra vertical spacing between the status text and buttons to prevent overlap.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972487f0a0c83289da2e64c7da6a98e)