### PR TITLE
Delay telemetry consent prompt until in-world and increase dialog spacing

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentClientHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentClientHandler.java
@@ -28,7 +28,7 @@ public final class TelemetryConsentClientHandler {
         }
         Minecraft minecraft = Minecraft.getInstance();
         minecraft.execute(() -> {
-            if (!promptedThisSession && minecraft.screen == null) {
+            if (!promptedThisSession && minecraft.level != null) {
                 promptedThisSession = true;
                 minecraft.setScreen(new TelemetryConsentScreen());
             }

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
@@ -18,7 +18,7 @@ public class TelemetryConsentScreen extends Screen {
     private static final int BUTTON_WIDTH = 180;
     private static final int BUTTON_HEIGHT = 20;
     private static final int TEXT_PADDING = 10;
-    private static final int BUTTON_TOP_MARGIN = 14;
+    private static final int BUTTON_TOP_MARGIN = 18;
     private static final int MAX_TEXT_WIDTH = 340;
 
     private List<FormattedCharSequence> descriptionLines = Collections.emptyList();
@@ -47,7 +47,7 @@ public class TelemetryConsentScreen extends Screen {
         );
         int descriptionHeight = this.descriptionLines.size() * this.font.lineHeight;
         int textBlockHeight = this.font.lineHeight + TEXT_PADDING + descriptionHeight + TEXT_PADDING + this.font.lineHeight;
-        int buttonGap = BUTTON_TOP_MARGIN + TEXT_PADDING;
+        int buttonGap = BUTTON_TOP_MARGIN + TEXT_PADDING + 4;
         int totalHeight = textBlockHeight + buttonGap + (BUTTON_HEIGHT * 2) + 6;
         int startY = Math.max(20, (this.height - totalHeight) / 2);
         this.titleY = startY;


### PR DESCRIPTION
### Motivation
- Prevent the telemetry consent screen from appearing too early (before the main menu/title) which caused UI and text overlap issues.
- Ensure the consent dialog layout leaves enough space between descriptive text and buttons to avoid rendering text behind controls.

### Description
- Change login prompt condition from checking `minecraft.screen == null` to `minecraft.level != null` so the consent UI is shown only when a world/level is available.
- Increase `BUTTON_TOP_MARGIN` from `14` to `18` to give more vertical spacing for the dialog.
- Add an extra `+ 4` pixels to the `buttonGap` calculation to further separate the text block from the buttons.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724fb7a76c8328b8b11fc41a963df2)