### PR TITLE
Fix telemetry screen return flow

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/OptionsScreenTelemetryButtonMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/OptionsScreenTelemetryButtonMixin.java
@@ -35,7 +35,7 @@ public abstract class OptionsScreenTelemetryButtonMixin extends Screen {
 
         addRenderableWidget(Button.builder(
                         Component.translatable("screen.wildernessodysseyapi.telemetry.title"),
-                        button -> this.minecraft.setScreen(new TelemetryConsentScreen()))
+                        button -> this.minecraft.setScreen(new TelemetryConsentScreen(this)))
                 .bounds(x, y, width, height)
                 .build());
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentClientHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentClientHandler.java
@@ -30,7 +30,7 @@ public final class TelemetryConsentClientHandler {
         minecraft.execute(() -> {
             if (!promptedThisSession && minecraft.level != null) {
                 promptedThisSession = true;
-                minecraft.setScreen(new TelemetryConsentScreen());
+                minecraft.setScreen(new TelemetryConsentScreen(minecraft.screen));
             }
         });
     }
@@ -47,7 +47,7 @@ public final class TelemetryConsentClientHandler {
         Minecraft minecraft = Minecraft.getInstance();
         if (minecraft.screen instanceof TitleScreen) {
             promptedThisSession = true;
-            minecraft.setScreen(new TelemetryConsentScreen());
+            minecraft.setScreen(new TelemetryConsentScreen(minecraft.screen));
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
@@ -28,9 +28,15 @@ public class TelemetryConsentScreen extends Screen {
     private int buttonY;
     private ConsentDecision currentDecision = ConsentDecision.ACCEPTED;
     private Button toggleButton;
+    private final Screen parent;
 
     public TelemetryConsentScreen() {
+        this(null);
+    }
+
+    public TelemetryConsentScreen(Screen parent) {
         super(Component.translatable("screen.wildernessodysseyapi.telemetry.title"));
+        this.parent = parent;
     }
 
     @Override
@@ -97,7 +103,11 @@ public class TelemetryConsentScreen extends Screen {
     private void applyDecision() {
         TelemetryConsentConfig.setDecision(currentDecision);
         sendConsentCommand(currentDecision);
-        Minecraft.getInstance().setScreen(null);
+        returnToParent();
+    }
+
+    private void returnToParent() {
+        Minecraft.getInstance().setScreen(parent);
     }
 
     private void sendConsentCommand(ConsentDecision decision) {
@@ -126,6 +136,11 @@ public class TelemetryConsentScreen extends Screen {
 
     @Override
     public boolean shouldCloseOnEsc() {
-        return false;
+        return parent != null;
+    }
+
+    @Override
+    public void onClose() {
+        returnToParent();
     }
 }


### PR DESCRIPTION
### Motivation
- The telemetry consent UI could drop players back into the game or not return to the originating screen when opened from the Options screen or title/login, causing a confusing flow.

### Description
- Add a `parent` `Screen` field and an overloaded constructor to `TelemetryConsentScreen` and route Done/Esc/close to return to that parent via `returnToParent()` instead of `setScreen(null)`.
- Make `shouldCloseOnEsc()` conditional (`return parent != null`) and implement `onClose()` to return to the parent screen.
- Update the options mixin to open the consent UI with the current options screen as the parent by calling `new TelemetryConsentScreen(this)` in `OptionsScreenTelemetryButtonMixin`.
- Update `TelemetryConsentClientHandler` to pass the current `minecraft.screen` as the parent when showing the consent screen on login or from the title screen.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697252b098f08328846fa214da70d7ac)