### PR TITLE
Sync telemetry consent with server on login

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConsentScreen.java
@@ -112,21 +112,12 @@ public class TelemetryConsentScreen extends Screen {
 
     private void applyDecision() {
         TelemetryConsentConfig.setDecision(currentDecision);
-        sendConsentCommand(currentDecision);
+        TelemetryConsentClientHandler.syncDecisionIfPossible(currentDecision);
         returnToParent();
     }
 
     private void returnToParent() {
         Minecraft.getInstance().setScreen(parent);
-    }
-
-    private void sendConsentCommand(ConsentDecision decision) {
-        Minecraft minecraft = Minecraft.getInstance();
-        if (minecraft.player == null || minecraft.player.connection == null) {
-            return;
-        }
-        String command = decision == ConsentDecision.ACCEPTED ? "telemetryconsent accept" : "telemetryconsent decline";
-        minecraft.player.connection.sendCommand(command);
     }
 
     @Override


### PR DESCRIPTION
### Motivation
- Ensure a client-side telemetry consent choice made before connecting is applied server-side when the player logs in.
- Avoid prompting the user redundantly when a stored decision already exists.
- Centralize command sending so UI and login logic reuse the same sync behavior.

### Description
- Added `syncDecisionIfPossible(ConsentDecision)` to `TelemetryConsentClientHandler` to send the appropriate `telemetryconsent` command when a player and connection are available.
- Updated `onClientLogin` in `TelemetryConsentClientHandler` to read the stored decision and either show the consent UI when unknown or call the sync helper when a decision exists.
- Replaced the inline send-command implementation in `TelemetryConsentScreen.applyDecision()` with a call to `TelemetryConsentClientHandler.syncDecisionIfPossible()` to reuse the same logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a2a4607483288f6dbb73053f0292)