### PR TITLE
Disable telemetry on dedicated servers

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/PlayerTelemetryReporter.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/PlayerTelemetryReporter.java
@@ -42,6 +42,9 @@ public final class PlayerTelemetryReporter {
         if (!(event.getEntity() instanceof ServerPlayer player)) {
             return;
         }
+        if (player.server.isDedicatedServer()) {
+            return;
+        }
 
         PlayerTelemetryConfig.TelemetryConfigValues config = PlayerTelemetryConfig.values();
         if (!config.enabled()) {


### PR DESCRIPTION
### Motivation
- Prevent the mod from exporting player telemetry from dedicated (server) instances so telemetry only runs for client-hosted/integrated sessions.

### Description
- Add an early return in `PlayerTelemetryReporter.onPlayerLogin` (`if (player.server.isDedicatedServer()) return;`) to skip telemetry on dedicated servers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bee19c648328b4d092600ad94601)