### PR TITLE
Gate logout telemetry via config and include playtime & optional Spark report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,8 @@ dependencies {
     }
     implementation "curse.maven:selene-499980:7113115"
     implementation "curse.maven:amendments-896746:7054319"
-    implementation "curse.maven:spark-361579:6225208"
+    compileOnly "curse.maven:spark-361579:6225208"
+    localRuntime "curse.maven:spark-361579:6225208"
     implementation "curse.maven:sodium-394468:6382651"
     implementation "curse.maven:irisshaders-455508:6661598"
     implementation "curse.maven:nova-apii-1248874:7507458"

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/PlayerTelemetryConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/PlayerTelemetryConfig.java
@@ -13,6 +13,8 @@ public final class PlayerTelemetryConfig {
     public static final ModConfigSpec.ConfigValue<String> ACCOUNT_AGE_ENDPOINT;
     public static final ModConfigSpec.ConfigValue<String> SHEET_WEBHOOK_URL;
     public static final ModConfigSpec.IntValue REQUEST_TIMEOUT_SECONDS;
+    public static final ModConfigSpec.BooleanValue EXPORT_ON_LOGOUT;
+    public static final ModConfigSpec.BooleanValue INCLUDE_SPARK_REPORT;
 
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 
@@ -40,6 +42,16 @@ public final class PlayerTelemetryConfig {
         REQUEST_TIMEOUT_SECONDS = BUILDER.comment("HTTP request timeout in seconds for telemetry lookups.")
                 .defineInRange("requestTimeoutSeconds", 10, 1, 60);
 
+        EXPORT_ON_LOGOUT = BUILDER.comment(
+                        "Send a telemetry export when a player logs out.",
+                        "If disabled, telemetry only exports on login.")
+                .define("exportOnLogout", true);
+
+        INCLUDE_SPARK_REPORT = BUILDER.comment(
+                        "When Spark is installed, attach a Spark report URL to logout exports.",
+                        "Requires exportOnLogout to be enabled.")
+                .define("includeSparkReport", false);
+
         BUILDER.pop();
 
         CONFIG_SPEC = BUILDER.build();
@@ -54,7 +66,9 @@ public final class PlayerTelemetryConfig {
                 GEO_IP_ENDPOINT.get(),
                 ACCOUNT_AGE_ENDPOINT.get(),
                 SHEET_WEBHOOK_URL.get(),
-                REQUEST_TIMEOUT_SECONDS.get()
+                REQUEST_TIMEOUT_SECONDS.get(),
+                EXPORT_ON_LOGOUT.get(),
+                INCLUDE_SPARK_REPORT.get()
         );
     }
 
@@ -63,7 +77,9 @@ public final class PlayerTelemetryConfig {
             String geoIpEndpoint,
             String accountAgeEndpoint,
             String sheetWebhookUrl,
-            int requestTimeoutSeconds
+            int requestTimeoutSeconds,
+            boolean exportOnLogout,
+            boolean includeSparkReport
     ) {
     }
 }

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -70,3 +70,9 @@ versionRange="[1.4.0,)"
 ordering="NONE"
 side="BOTH"
 
+[[dependencies.wildernessodysseyapi]]
+modId="spark"
+mandatory=false
+versionRange="[1.0.0,)"
+ordering="NONE"
+side="BOTH"


### PR DESCRIPTION
### Motivation
- Provide operators a way to control when telemetry is exported by adding configuration gates for logout exports and optional Spark report attachment.
- Ensure telemetry payloads include total play time and an event type so exports are more useful for analysis.
- Make Spark an optional runtime dependency and only query it when configured to avoid hard dependency or unnecessary work.

### Description
- Added `exportOnLogout` and `includeSparkReport` config options and exposed them through `PlayerTelemetryConfig.values()` in `PlayerTelemetryConfig.java`.
- Updated login and logout flows in `PlayerTelemetryReporter.java` to respect `enabled`, `sheetWebhookUrl`, `exportOnLogout`, and consent checks before exporting telemetry.
- Included `total_play_time_seconds` and `event_type` in the JSON payload, added `getTotalPlayTimeSeconds`, and changed `postToSheet` to accept playtime, Spark URL, and event type.
- Implemented optional Spark integration via reflection and a proxy `CommandSender` in `fetchSparkReportUrl`, and made Spark a non-mandatory dependency by changing `build.gradle` to `compileOnly`/`localRuntime` and declaring it as optional in `neoforge.mods.toml`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973c0137264832895cbc89a6466e30c)