### PR TITLE
Add telemetry reliability, sampling, and queueing controls

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -40,6 +40,9 @@ import com.thunder.wildernessodysseyapi.telemetry.EventTelemetryConfig;
 import com.thunder.wildernessodysseyapi.telemetry.EventTelemetryReporter;
 import com.thunder.wildernessodysseyapi.telemetry.TelemetryConsentCommand;
 import com.thunder.wildernessodysseyapi.telemetry.TelemetryConsentConfig;
+import com.thunder.wildernessodysseyapi.telemetry.TelemetryConfig;
+import com.thunder.wildernessodysseyapi.telemetry.TelemetryQueueProcessor;
+import com.thunder.wildernessodysseyapi.telemetry.TelemetryQueueStatsCommand;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -111,6 +114,7 @@ public class WildernessOdysseyAPIMainModClass {
         NeoForge.EVENT_BUS.register(AIChatListener.class);
         NeoForge.EVENT_BUS.register(PlayerTelemetryReporter.class);
         NeoForge.EVENT_BUS.register(EventTelemetryReporter.class);
+        NeoForge.EVENT_BUS.register(TelemetryQueueProcessor.class);
 
         CryoTubeBlock.register(modEventBus);
         ModItems.register(modEventBus);
@@ -133,6 +137,8 @@ public class WildernessOdysseyAPIMainModClass {
                 CONFIG_FOLDER + "wildernessodysseyapi-telemetry-server.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, EventTelemetryConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-event-telemetry-server.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, TelemetryConfig.CONFIG_SPEC,
+                CONFIG_FOLDER + "wildernessodysseyapi-telemetry-master-server.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, FeedbackConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-feedback-server.toml");
         // Previously registered client-only events have been removed
@@ -187,6 +193,7 @@ public class WildernessOdysseyAPIMainModClass {
         GlobalChatOptToggleCommand.register(dispatcher);
         TideInfoCommand.register(dispatcher);
         TelemetryConsentCommand.register(dispatcher);
+        TelemetryQueueStatsCommand.register(dispatcher);
         FeedbackCommand.register(dispatcher);
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/EventTelemetryConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/EventTelemetryConfig.java
@@ -12,6 +12,13 @@ public final class EventTelemetryConfig {
     public static final ModConfigSpec.ConfigValue<String> WEBHOOK_URL;
     public static final ModConfigSpec.IntValue REQUEST_TIMEOUT_SECONDS;
     public static final ModConfigSpec.BooleanValue INCLUDE_PLAYER_IDENTIFIERS;
+    public static final ModConfigSpec.DoubleValue SAMPLE_RATE_PERCENT;
+    public static final ModConfigSpec.IntValue SAMPLE_EVERY_NTH;
+    public static final ModConfigSpec.BooleanValue HASH_PLAYER_IDENTIFIERS;
+    public static final ModConfigSpec.ConfigValue<String> IDENTIFIER_HASH_SALT;
+    public static final ModConfigSpec.IntValue RETRY_MAX_ATTEMPTS;
+    public static final ModConfigSpec.IntValue RETRY_BASE_DELAY_MS;
+    public static final ModConfigSpec.IntValue RETRY_MAX_DELAY_MS;
 
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 
@@ -33,6 +40,35 @@ public final class EventTelemetryConfig {
                         "When true, include player name/UUID for events if they consented to telemetry.")
                 .define("includePlayerIdentifiers", false);
 
+        SAMPLE_RATE_PERCENT = BUILDER.comment(
+                        "Sampling rate percentage for event telemetry (0-100).")
+                .defineInRange("sampleRatePercent", 100.0, 0.0, 100.0);
+
+        SAMPLE_EVERY_NTH = BUILDER.comment(
+                        "Only export every Nth event telemetry payload.",
+                        "Set to 1 to disable Nth sampling.")
+                .defineInRange("sampleEveryNth", 1, 1, 1000000);
+
+        HASH_PLAYER_IDENTIFIERS = BUILDER.comment(
+                        "Hash player identifiers (UUID/name) before sending event telemetry.")
+                .define("hashPlayerIdentifiers", false);
+
+        IDENTIFIER_HASH_SALT = BUILDER.comment(
+                        "Optional salt appended before hashing identifiers.")
+                .define("identifierHashSalt", "");
+
+        RETRY_MAX_ATTEMPTS = BUILDER.comment(
+                        "Maximum retry attempts for event telemetry HTTP requests.")
+                .defineInRange("retryMaxAttempts", 2, 0, 10);
+
+        RETRY_BASE_DELAY_MS = BUILDER.comment(
+                        "Base delay in milliseconds for exponential backoff retries.")
+                .defineInRange("retryBaseDelayMs", 500, 50, 10000);
+
+        RETRY_MAX_DELAY_MS = BUILDER.comment(
+                        "Maximum delay in milliseconds for exponential backoff retries.")
+                .defineInRange("retryMaxDelayMs", 5000, 100, 60000);
+
         BUILDER.pop();
 
         CONFIG_SPEC = BUILDER.build();
@@ -46,7 +82,14 @@ public final class EventTelemetryConfig {
                 ENABLED.get(),
                 WEBHOOK_URL.get(),
                 REQUEST_TIMEOUT_SECONDS.get(),
-                INCLUDE_PLAYER_IDENTIFIERS.get()
+                INCLUDE_PLAYER_IDENTIFIERS.get(),
+                SAMPLE_RATE_PERCENT.get(),
+                SAMPLE_EVERY_NTH.get(),
+                HASH_PLAYER_IDENTIFIERS.get(),
+                IDENTIFIER_HASH_SALT.get(),
+                RETRY_MAX_ATTEMPTS.get(),
+                RETRY_BASE_DELAY_MS.get(),
+                RETRY_MAX_DELAY_MS.get()
         );
     }
 
@@ -54,7 +97,14 @@ public final class EventTelemetryConfig {
             boolean enabled,
             String webhookUrl,
             int requestTimeoutSeconds,
-            boolean includePlayerIdentifiers
+            boolean includePlayerIdentifiers,
+            double sampleRatePercent,
+            int sampleEveryNth,
+            boolean hashPlayerIdentifiers,
+            String identifierHashSalt,
+            int retryMaxAttempts,
+            int retryBaseDelayMs,
+            int retryMaxDelayMs
     ) {
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/PlayerTelemetryConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/PlayerTelemetryConfig.java
@@ -15,6 +15,15 @@ public final class PlayerTelemetryConfig {
     public static final ModConfigSpec.IntValue REQUEST_TIMEOUT_SECONDS;
     public static final ModConfigSpec.BooleanValue EXPORT_ON_LOGOUT;
     public static final ModConfigSpec.BooleanValue INCLUDE_SPARK_REPORT;
+    public static final ModConfigSpec.DoubleValue SAMPLE_RATE_PERCENT;
+    public static final ModConfigSpec.IntValue SAMPLE_EVERY_NTH;
+    public static final ModConfigSpec.BooleanValue HASH_PLAYER_IDENTIFIERS;
+    public static final ModConfigSpec.ConfigValue<String> IDENTIFIER_HASH_SALT;
+    public static final ModConfigSpec.IntValue GEO_CACHE_TTL_SECONDS;
+    public static final ModConfigSpec.IntValue ACCOUNT_AGE_CACHE_TTL_SECONDS;
+    public static final ModConfigSpec.IntValue RETRY_MAX_ATTEMPTS;
+    public static final ModConfigSpec.IntValue RETRY_BASE_DELAY_MS;
+    public static final ModConfigSpec.IntValue RETRY_MAX_DELAY_MS;
 
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 
@@ -52,6 +61,44 @@ public final class PlayerTelemetryConfig {
                         "Requires exportOnLogout to be enabled.")
                 .define("includeSparkReport", false);
 
+        SAMPLE_RATE_PERCENT = BUILDER.comment(
+                        "Sampling rate percentage for player telemetry (0-100).",
+                        "Use together with sampleEveryNth for large servers.")
+                .defineInRange("sampleRatePercent", 100.0, 0.0, 100.0);
+
+        SAMPLE_EVERY_NTH = BUILDER.comment(
+                        "Only export every Nth player telemetry event.",
+                        "Set to 1 to disable Nth sampling.")
+                .defineInRange("sampleEveryNth", 1, 1, 1000000);
+
+        HASH_PLAYER_IDENTIFIERS = BUILDER.comment(
+                        "Hash player identifiers (UUID/name) before sending telemetry.")
+                .define("hashPlayerIdentifiers", false);
+
+        IDENTIFIER_HASH_SALT = BUILDER.comment(
+                        "Optional salt appended before hashing identifiers.")
+                .define("identifierHashSalt", "");
+
+        GEO_CACHE_TTL_SECONDS = BUILDER.comment(
+                        "Cache GeoIP lookup results per UUID for this many seconds.")
+                .defineInRange("geoCacheTtlSeconds", 21600, 0, 604800);
+
+        ACCOUNT_AGE_CACHE_TTL_SECONDS = BUILDER.comment(
+                        "Cache account age lookup results per UUID for this many seconds.")
+                .defineInRange("accountAgeCacheTtlSeconds", 86400, 0, 604800);
+
+        RETRY_MAX_ATTEMPTS = BUILDER.comment(
+                        "Maximum retry attempts for telemetry HTTP requests.")
+                .defineInRange("retryMaxAttempts", 2, 0, 10);
+
+        RETRY_BASE_DELAY_MS = BUILDER.comment(
+                        "Base delay in milliseconds for exponential backoff retries.")
+                .defineInRange("retryBaseDelayMs", 500, 50, 10000);
+
+        RETRY_MAX_DELAY_MS = BUILDER.comment(
+                        "Maximum delay in milliseconds for exponential backoff retries.")
+                .defineInRange("retryMaxDelayMs", 5000, 100, 60000);
+
         BUILDER.pop();
 
         CONFIG_SPEC = BUILDER.build();
@@ -68,7 +115,16 @@ public final class PlayerTelemetryConfig {
                 SHEET_WEBHOOK_URL.get(),
                 REQUEST_TIMEOUT_SECONDS.get(),
                 EXPORT_ON_LOGOUT.get(),
-                INCLUDE_SPARK_REPORT.get()
+                INCLUDE_SPARK_REPORT.get(),
+                SAMPLE_RATE_PERCENT.get(),
+                SAMPLE_EVERY_NTH.get(),
+                HASH_PLAYER_IDENTIFIERS.get(),
+                IDENTIFIER_HASH_SALT.get(),
+                GEO_CACHE_TTL_SECONDS.get(),
+                ACCOUNT_AGE_CACHE_TTL_SECONDS.get(),
+                RETRY_MAX_ATTEMPTS.get(),
+                RETRY_BASE_DELAY_MS.get(),
+                RETRY_MAX_DELAY_MS.get()
         );
     }
 
@@ -79,7 +135,16 @@ public final class PlayerTelemetryConfig {
             String sheetWebhookUrl,
             int requestTimeoutSeconds,
             boolean exportOnLogout,
-            boolean includeSparkReport
+            boolean includeSparkReport,
+            double sampleRatePercent,
+            int sampleEveryNth,
+            boolean hashPlayerIdentifiers,
+            String identifierHashSalt,
+            int geoCacheTtlSeconds,
+            int accountAgeCacheTtlSeconds,
+            int retryMaxAttempts,
+            int retryBaseDelayMs,
+            int retryMaxDelayMs
     ) {
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryConfig.java
@@ -1,0 +1,57 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+/**
+ * Server-wide telemetry configuration options.
+ */
+public final class TelemetryConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+
+    public static final ModConfigSpec.BooleanValue MASTER_ENABLED;
+    public static final ModConfigSpec.IntValue QUEUE_MAX_SIZE;
+    public static final ModConfigSpec.IntValue QUEUE_FLUSH_INTERVAL_TICKS;
+    public static final ModConfigSpec.IntValue QUEUE_FLUSH_BATCH_SIZE;
+
+    private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
+
+    static {
+        BUILDER.push("telemetry");
+
+        MASTER_ENABLED = BUILDER.comment("Master toggle for all telemetry features.")
+                .define("enabled", true);
+
+        QUEUE_MAX_SIZE = BUILDER.comment("Maximum number of telemetry payloads to keep in the retry queue.")
+                .defineInRange("queueMaxSize", 512, 1, 10000);
+
+        QUEUE_FLUSH_INTERVAL_TICKS = BUILDER.comment("How often (in ticks) to flush queued telemetry payloads.")
+                .defineInRange("queueFlushIntervalTicks", 200, 20, 12000);
+
+        QUEUE_FLUSH_BATCH_SIZE = BUILDER.comment("Maximum number of queued payloads to attempt per flush.")
+                .defineInRange("queueFlushBatchSize", 32, 1, 512);
+
+        BUILDER.pop();
+
+        CONFIG_SPEC = BUILDER.build();
+    }
+
+    private TelemetryConfig() {
+    }
+
+    public static TelemetryValues values() {
+        return new TelemetryValues(
+                MASTER_ENABLED.get(),
+                QUEUE_MAX_SIZE.get(),
+                QUEUE_FLUSH_INTERVAL_TICKS.get(),
+                QUEUE_FLUSH_BATCH_SIZE.get()
+        );
+    }
+
+    public record TelemetryValues(
+            boolean enabled,
+            int queueMaxSize,
+            int queueFlushIntervalTicks,
+            int queueFlushBatchSize
+    ) {
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryHashing.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryHashing.java
@@ -1,0 +1,27 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+public final class TelemetryHashing {
+    private TelemetryHashing() {
+    }
+
+    public static String hashIdentifier(String value, String salt) {
+        if (value == null) {
+            return null;
+        }
+        String input = value + (salt == null ? "" : salt);
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder();
+            for (byte b : hashed) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (Exception ex) {
+            return value;
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryHttp.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryHttp.java
@@ -1,0 +1,59 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Shared HTTP utilities for telemetry with retry/backoff.
+ */
+public final class TelemetryHttp {
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    private TelemetryHttp() {
+    }
+
+    public static HttpResponse<String> sendWithRetry(HttpRequest request, int maxRetries, Duration baseDelay,
+                                                     Duration maxDelay) throws Exception {
+        int attempt = 0;
+        Exception lastException = null;
+        HttpResponse<String> lastResponse = null;
+
+        while (attempt <= maxRetries) {
+            try {
+                HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+                lastResponse = response;
+                if (response.statusCode() / 100 == 2) {
+                    return response;
+                }
+            } catch (Exception ex) {
+                lastException = ex;
+            }
+
+            if (attempt == maxRetries) {
+                break;
+            }
+            long delayMillis = calculateDelayMillis(baseDelay, maxDelay, attempt);
+            Thread.sleep(delayMillis);
+            attempt++;
+        }
+
+        if (lastException != null) {
+            throw lastException;
+        }
+        return lastResponse;
+    }
+
+    private static long calculateDelayMillis(Duration baseDelay, Duration maxDelay, int attempt) {
+        long baseMillis = Math.max(1L, baseDelay.toMillis());
+        long maxMillis = Math.max(baseMillis, maxDelay.toMillis());
+        long expDelay = Math.min(maxMillis, baseMillis * (1L << Math.min(attempt, 10)));
+        double jitter = ThreadLocalRandom.current().nextDouble(0.5, 1.5);
+        long delay = (long) (expDelay * jitter);
+        return Math.max(1L, Math.min(delay, maxMillis));
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryPayloads.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryPayloads.java
@@ -1,0 +1,27 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
+public final class TelemetryPayloads {
+    public static final int SCHEMA_VERSION = 1;
+    private static final Gson GSON = new GsonBuilder().create();
+
+    private TelemetryPayloads() {
+    }
+
+    public static HttpRequest buildRequest(String webhookUrl, int timeoutSeconds, JsonObject payload) {
+        String body = payload == null ? "{}" : GSON.toJson(payload);
+        return HttpRequest.newBuilder()
+                .uri(URI.create(webhookUrl))
+                .timeout(Duration.ofSeconds(timeoutSeconds))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueue.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueue.java
@@ -40,7 +40,7 @@ public final class TelemetryQueue {
     }
 
     private static TelemetryQueue createForServer(MinecraftServer server) {
-        Path configDir = server.getFile("config/wildernessodysseyapi").toPath();
+        Path configDir = server.getFile("config/wildernessodysseyapi");
         Path spoolFile = configDir.resolve("telemetry-queue.jsonl");
         return new TelemetryQueue(spoolFile);
     }
@@ -172,7 +172,7 @@ public final class TelemetryQueue {
     }
 
     public record TelemetryQueueStats(int pending, int failed, Instant lastSuccess) {
-        public Optional<Instant> lastSuccess() {
+        public Optional<Instant> lastSuccessOptional() {
             return Optional.ofNullable(lastSuccess);
         }
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueue.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueue.java
@@ -1,0 +1,179 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import net.minecraft.server.MinecraftServer;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.thunder.wildernessodysseyapi.Core.ModConstants.LOGGER;
+
+public final class TelemetryQueue {
+    private static final Gson GSON = new GsonBuilder().create();
+    private static final Map<MinecraftServer, TelemetryQueue> QUEUES = new ConcurrentHashMap<>();
+
+    private final Deque<PendingTelemetryPayload> queue = new ArrayDeque<>();
+    private final Path spoolPath;
+    private final AtomicInteger failedCount = new AtomicInteger();
+    private Instant lastSuccess;
+
+    private TelemetryQueue(Path spoolPath) {
+        this.spoolPath = spoolPath;
+        loadFromDisk();
+    }
+
+    public static TelemetryQueue get(MinecraftServer server) {
+        return QUEUES.computeIfAbsent(server, TelemetryQueue::createForServer);
+    }
+
+    private static TelemetryQueue createForServer(MinecraftServer server) {
+        Path configDir = server.getFile("config/wildernessodysseyapi").toPath();
+        Path spoolFile = configDir.resolve("telemetry-queue.jsonl");
+        return new TelemetryQueue(spoolFile);
+    }
+
+    public synchronized void enqueue(PendingTelemetryPayload payload, int maxQueueSize) {
+        if (queue.size() >= maxQueueSize) {
+            queue.pollFirst();
+            failedCount.incrementAndGet();
+        }
+        queue.addLast(payload);
+        persistAll();
+    }
+
+    public synchronized int flush(int maxBatchSize) {
+        int attempted = 0;
+        boolean changed = false;
+        while (!queue.isEmpty() && attempted < maxBatchSize) {
+            PendingTelemetryPayload payload = queue.pollFirst();
+            attempted++;
+            boolean sent = payload.send();
+            if (sent) {
+                lastSuccess = Instant.now();
+                changed = true;
+            } else {
+                payload.incrementAttempts();
+                queue.addLast(payload);
+                failedCount.incrementAndGet();
+                changed = true;
+            }
+        }
+        if (changed) {
+            persistAll();
+        }
+        return attempted;
+    }
+
+    public synchronized TelemetryQueueStats stats() {
+        return new TelemetryQueueStats(queue.size(), failedCount.get(), lastSuccess);
+    }
+
+    private void loadFromDisk() {
+        if (!Files.exists(spoolPath)) {
+            return;
+        }
+        try (BufferedReader reader = Files.newBufferedReader(spoolPath)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.isBlank()) {
+                    continue;
+                }
+                PendingTelemetryPayload payload = GSON.fromJson(line, PendingTelemetryPayload.class);
+                if (payload != null && payload.payload != null && payload.webhookUrl != null) {
+                    queue.addLast(payload);
+                }
+            }
+        } catch (IOException ex) {
+            LOGGER.warn("[Telemetry] Failed to load telemetry queue: {}", ex.getMessage());
+        }
+    }
+
+    private void persistAll() {
+        try {
+            Files.createDirectories(spoolPath.getParent());
+        } catch (IOException ex) {
+            LOGGER.warn("[Telemetry] Failed to create telemetry queue directory: {}", ex.getMessage());
+            return;
+        }
+        try (BufferedWriter writer = Files.newBufferedWriter(spoolPath)) {
+            for (PendingTelemetryPayload payload : queue) {
+                writer.write(GSON.toJson(payload));
+                writer.newLine();
+            }
+        } catch (IOException ex) {
+            LOGGER.warn("[Telemetry] Failed to persist telemetry queue: {}", ex.getMessage());
+        }
+    }
+
+    public static final class PendingTelemetryPayload {
+        private String type;
+        private JsonObject payload;
+        private String webhookUrl;
+        private int timeoutSeconds;
+        private int maxRetries;
+        private long retryBaseDelayMs;
+        private long retryMaxDelayMs;
+        private int attempts;
+        private Instant createdAt;
+        private Instant lastAttempt;
+
+        @SuppressWarnings("unused")
+        private PendingTelemetryPayload() {
+        }
+
+        public PendingTelemetryPayload(String type, JsonObject payload, String webhookUrl, int timeoutSeconds,
+                                       int maxRetries, Duration baseDelay, Duration maxDelay) {
+            this.type = type;
+            this.payload = payload;
+            this.webhookUrl = webhookUrl;
+            this.timeoutSeconds = timeoutSeconds;
+            this.maxRetries = maxRetries;
+            this.retryBaseDelayMs = baseDelay.toMillis();
+            this.retryMaxDelayMs = maxDelay.toMillis();
+            this.attempts = 0;
+            this.createdAt = Instant.now();
+        }
+
+        public boolean send() {
+            if (payload == null || webhookUrl == null || webhookUrl.isBlank()) {
+                return false;
+            }
+            try {
+                var response = TelemetryHttp.sendWithRetry(
+                        TelemetryPayloads.buildRequest(webhookUrl, timeoutSeconds, payload),
+                        maxRetries,
+                        Duration.ofMillis(retryBaseDelayMs),
+                        Duration.ofMillis(retryMaxDelayMs)
+                );
+                return response != null && response.statusCode() / 100 == 2;
+            } catch (Exception ex) {
+                LOGGER.warn("[Telemetry] Queued payload send failed ({}): {}", type, ex.getMessage());
+                return false;
+            }
+        }
+
+        public void incrementAttempts() {
+            attempts++;
+            lastAttempt = Instant.now();
+        }
+    }
+
+    public record TelemetryQueueStats(int pending, int failed, Instant lastSuccess) {
+        public Optional<Instant> lastSuccess() {
+            return Optional.ofNullable(lastSuccess);
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueueProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueueProcessor.java
@@ -1,0 +1,29 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.event.TickEvent;
+
+/**
+ * Flushes queued telemetry payloads on a schedule.
+ */
+public final class TelemetryQueueProcessor {
+    private TelemetryQueueProcessor() {
+    }
+
+    @SubscribeEvent
+    public static void onServerTick(TickEvent.ServerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END || event.getServer() == null) {
+            return;
+        }
+        TelemetryConfig.TelemetryValues config = TelemetryConfig.values();
+        if (!config.enabled()) {
+            return;
+        }
+        int interval = Math.max(1, config.queueFlushIntervalTicks());
+        if (event.getServer().getTickCount() % interval != 0) {
+            return;
+        }
+        TelemetryQueue queue = TelemetryQueue.get(event.getServer());
+        queue.flush(config.queueFlushBatchSize());
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueueProcessor.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueueProcessor.java
@@ -1,7 +1,7 @@
 package com.thunder.wildernessodysseyapi.telemetry;
 
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.neoforge.event.TickEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
 
 /**
  * Flushes queued telemetry payloads on a schedule.
@@ -11,8 +11,8 @@ public final class TelemetryQueueProcessor {
     }
 
     @SubscribeEvent
-    public static void onServerTick(TickEvent.ServerTickEvent event) {
-        if (event.phase != TickEvent.Phase.END || event.getServer() == null) {
+    public static void onServerTick(ServerTickEvent.Post event) {
+        if (event.getServer() == null) {
             return;
         }
         TelemetryConfig.TelemetryValues config = TelemetryConfig.values();

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueueStatsCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueueStatsCommand.java
@@ -1,0 +1,31 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public final class TelemetryQueueStatsCommand {
+    private TelemetryQueueStatsCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("telemetrystats")
+                .requires(source -> source.hasPermission(2))
+                .executes(context -> {
+                    CommandSourceStack source = context.getSource();
+                    TelemetryQueue.TelemetryQueueStats stats = TelemetryQueue.get(source.getServer()).stats();
+                    Optional<Instant> lastSuccess = stats.lastSuccess();
+                    source.sendSuccess(() -> Component.translatable(
+                            "command.wildernessodysseyapi.telemetry.stats",
+                            stats.pending(),
+                            stats.failed(),
+                            lastSuccess.map(Instant::toString).orElse("never")
+                    ), false);
+                    return 1;
+                }));
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueueStatsCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetryQueueStatsCommand.java
@@ -18,7 +18,7 @@ public final class TelemetryQueueStatsCommand {
                 .executes(context -> {
                     CommandSourceStack source = context.getSource();
                     TelemetryQueue.TelemetryQueueStats stats = TelemetryQueue.get(source.getServer()).stats();
-                    Optional<Instant> lastSuccess = stats.lastSuccess();
+                    Optional<Instant> lastSuccess = stats.lastSuccessOptional();
                     source.sendSuccess(() -> Component.translatable(
                             "command.wildernessodysseyapi.telemetry.stats",
                             stats.pending(),

--- a/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetrySampling.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/telemetry/TelemetrySampling.java
@@ -1,0 +1,40 @@
+package com.thunder.wildernessodysseyapi.telemetry;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Utility for sampling telemetry events.
+ */
+public final class TelemetrySampling {
+    private static final Map<String, AtomicLong> COUNTERS = new ConcurrentHashMap<>();
+
+    private TelemetrySampling() {
+    }
+
+    public static boolean shouldSample(String key, int sampleEveryNth, double sampleRatePercent) {
+        if (sampleEveryNth <= 1 && sampleRatePercent >= 100.0) {
+            return true;
+        }
+
+        if (sampleEveryNth > 1) {
+            long count = COUNTERS.computeIfAbsent(key, ignored -> new AtomicLong()).incrementAndGet();
+            if (count % sampleEveryNth != 0) {
+                return false;
+            }
+        }
+
+        if (sampleRatePercent <= 0.0) {
+            return false;
+        }
+
+        if (sampleRatePercent >= 100.0) {
+            return true;
+        }
+
+        double roll = ThreadLocalRandom.current().nextDouble(0.0, 100.0);
+        return roll < sampleRatePercent;
+    }
+}

--- a/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
+++ b/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
@@ -69,6 +69,7 @@
   "screen.wildernessodysseyapi.telemetry.toggle.off": "Turn Telemetry Off",
   "command.wildernessodysseyapi.telemetry.status": "Telemetry consent is currently set to: %s",
   "command.wildernessodysseyapi.telemetry.set": "Telemetry consent updated to: %s",
+  "command.wildernessodysseyapi.telemetry.stats": "Telemetry queue stats: pending=%s, failed=%s, last_success=%s",
   "command.wildernessodysseyapi.feedback.players_only": "Only players can use this command.",
   "command.wildernessodysseyapi.feedback.disabled": "Feedback submissions are disabled on this server.",
   "command.wildernessodysseyapi.feedback.not_configured": "Feedback webhook is not configured. Contact an admin.",


### PR DESCRIPTION
### Motivation
- Improve telemetry reliability and operator control by adding a master toggle, retry/backoff with disk-spooled queueing, and visibility into queued payloads.
- Reduce telemetry volume on large servers and protect player privacy by providing sampling and identifier-hashing options.
- Cache expensive lookups (GeoIP/account-age) and enable configurable behavior for timeouts and retries to make telemetry robust in unreliable networks.

### Description
- Added infrastructure classes `TelemetryConfig`, `TelemetrySampling`, `TelemetryHttp`, `TelemetryPayloads`, `TelemetryHashing`, `TelemetryQueue`, `TelemetryQueueProcessor`, and `TelemetryQueueStatsCommand` to provide master config, sampling, HTTP retry/backoff, schema'ed payloads, identifier hashing, a disk-spooled retry queue and a scheduled flush + admin stats command.
- Extended `PlayerTelemetryConfig` and `EventTelemetryConfig` to include sampling controls, identifier hashing/salt, caching TTLs, and retry/backoff parameters, and implemented those features in `PlayerTelemetryReporter` and `EventTelemetryReporter` (sampling, caching, schema version, hashing, `TelemetryHttp` retries, and enqueue-on-failure).
- Implemented queue persistence and retry semantics via `TelemetryQueue` (JSONL spool), and a tick-based `TelemetryQueueProcessor` that flushes queued payloads per `TelemetryConfig` settings.
- Registered the master telemetry config, queue processor and `telemetrystats` command in `WildernessOdysseyAPIMainModClass` and added a localized message key `command.wildernessodysseyapi.telemetry.stats`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973cb072c4c83288b6a6038cc9f197d)