### PR TITLE
Add Atlas enable toggle and disable offline AI fallbacks

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIChatListener.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIChatListener.java
@@ -35,6 +35,9 @@ public class AIChatListener {
         if (message.isEmpty()) {
             return;
         }
+        if (!CLIENT.isAtlasEnabled()) {
+            return;
+        }
         if (!isHoldingActivationItem(player)) {
             return;
         }
@@ -55,6 +58,9 @@ public class AIChatListener {
         VoiceIntegration.VoiceResult reply = CLIENT.sendMessageWithVoice(worldKey,
                 player.getName().getString(), message);
 
+        if (reply.text() == null || reply.text().isBlank()) {
+            return;
+        }
         PENDING_REPLIES.add(new PendingReply(player.getUUID(), reply.text()));
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIClient.java
@@ -48,6 +48,10 @@ public class AIClient {
         return settings.getWakeWord();
     }
 
+    public boolean isAtlasEnabled() {
+        return settings.isAtlasEnabled();
+    }
+
     private void loadStory() {
         AIConfig config = AIConfigLoader.load();
         story.addAll(config.getStory());
@@ -72,6 +76,9 @@ public class AIClient {
             return;
         }
         AIConfig.Settings configSettings = config.getSettings();
+        if (configSettings.getAtlasEnabled() != null) {
+            settings.setAtlasEnabled(configSettings.getAtlasEnabled());
+        }
         if (configSettings.getVoiceEnabled() != null) {
             settings.setVoiceEnabled(configSettings.getVoiceEnabled());
         }
@@ -159,6 +166,9 @@ public class AIClient {
     }
 
     public VoiceIntegration.VoiceResult sendMessageWithVoice(String world, String player, String message) {
+        if (!settings.isAtlasEnabled()) {
+            return voiceIntegration.wrap("");
+        }
         String learnedFact = knowledgeStore.extractLearnedFact(message);
         if (learnedFact != null) {
             boolean added = knowledgeStore.addFact(learnedFact);
@@ -175,9 +185,7 @@ public class AIClient {
             context = context.isBlank() ? knowledgeContext : context + "\n" + knowledgeContext;
         }
         if (localModelClient == null) {
-            String reply = buildOfflineReply(world, player, message, false, false);
-            memoryStore.addAiMessage(world, player, settings.getPersonaName(), reply);
-            return voiceIntegration.wrap(reply);
+            return voiceIntegration.wrap("");
         }
         String prompt = formatSystemPrompt(localSystemPrompt);
         String localContext = buildLocalModelContext(world, context);
@@ -197,9 +205,7 @@ public class AIClient {
             return voiceIntegration.wrap(reply);
         }
         stopLocalModelServerIfNeeded();
-        String reply = buildOfflineReply(world, player, message, true, autoStartLocalServer);
-        memoryStore.addAiMessage(world, player, settings.getPersonaName(), reply);
-        return voiceIntegration.wrap(reply);
+        return voiceIntegration.wrap("");
     }
 
     private boolean isLocalServerRunning() {

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIConfig.java
@@ -161,10 +161,19 @@ public class AIConfig {
     }
 
     public static class Settings {
+        private Boolean atlasEnabled;
         private Boolean voiceEnabled;
         private Boolean speechRecognition;
         private String wakeWord;
         private String model;
+
+        public Boolean getAtlasEnabled() {
+            return atlasEnabled;
+        }
+
+        public void setAtlasEnabled(Boolean atlasEnabled) {
+            this.atlasEnabled = atlasEnabled;
+        }
 
         public Boolean getVoiceEnabled() {
             return voiceEnabled;

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIConfigLoader.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIConfigLoader.java
@@ -97,6 +97,7 @@ public final class AIConfigLoader {
         config.getPersonality().setEmpathy(readStringValue(personality.get("empathy")));
 
         Map<String, Object> settings = readStringObjectMap(root.get("settings"));
+        config.getSettings().setAtlasEnabled(readBoolean(settings.get("atlas_enabled")));
         config.getSettings().setVoiceEnabled(readBoolean(settings.get("voice_enabled")));
         config.getSettings().setSpeechRecognition(readBoolean(settings.get("speech_recognition")));
         config.getSettings().setWakeWord(readStringValue(settings.get("wake_word")));

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AISettings.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AISettings.java
@@ -7,6 +7,7 @@ public class AISettings {
 
     private boolean voiceEnabled = false;
     private boolean speechRecognition = false;
+    private boolean atlasEnabled = true;
     private String modelName = "local-story-engine";
     private String wakeWord = "atlas";
     private String personaName = "Atlas";
@@ -27,6 +28,14 @@ public class AISettings {
 
     public void setSpeechRecognition(boolean speechRecognition) {
         this.speechRecognition = speechRecognition;
+    }
+
+    public boolean isAtlasEnabled() {
+        return atlasEnabled;
+    }
+
+    public void setAtlasEnabled(boolean atlasEnabled) {
+        this.atlasEnabled = atlasEnabled;
     }
 
     public String getModelName() {

--- a/src/main/resources/ai_config.yaml
+++ b/src/main/resources/ai_config.yaml
@@ -13,6 +13,7 @@ corrupted_data:
   - "Signal jitter... memory block 7b missing."
 corrupted_prefix: "[Signal noise]"
 settings:
+  atlas_enabled: true
   voice_enabled: true
   speech_recognition: false
   wake_word: "atlas"


### PR DESCRIPTION
### Motivation
- Provide an online-only AI mode with a configurable Atlas on/off switch and prevent the mod from replying with offline-generated AI text when no local model is available.

### Description
- Add `atlasEnabled` to `AISettings` and expose it in `AIConfig.Settings` so it can be loaded from YAML via `AIConfigLoader` and defaulted in `ai_config.yaml`.
- Expose `AIClient.isAtlasEnabled()` and apply the `atlas_enabled` config when loading settings in `AIClient`.
- Gate chat handling in `AIChatListener` with `CLIENT.isAtlasEnabled()` and ignore empty replies so no blank messages are queued or sent.
- Remove offline fallback replies in `AIClient.sendMessageWithVoice()` when the local model is unavailable, returning an empty `VoiceResult` instead of synthesizing an offline response.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69771b23a0408328804f3908181e74e1)