### PR TITLE
Seed default AI onboarding flow and persist per-player progress

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIChatListener.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIChatListener.java
@@ -54,6 +54,12 @@ public class AIChatListener {
 
         ACTIVE_SESSIONS.add(player.getUUID());
 
+        String onboardingReply = CLIENT.handleOnboarding(player.getUUID(), message);
+        if (onboardingReply != null && !onboardingReply.isBlank()) {
+            PENDING_REPLIES.add(new PendingReply(player.getUUID(), onboardingReply));
+            return;
+        }
+
         String worldKey = player.serverLevel().dimension().location().toString();
         VoiceIntegration.VoiceResult reply = CLIENT.sendMessageWithVoice(worldKey,
                 player.getName().getString(), message);

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIConfig.java
@@ -12,6 +12,7 @@ public class AIConfig {
     private final Personality personality = new Personality();
     private final Settings settings = new Settings();
     private final LocalModel localModel = new LocalModel();
+    private final Onboarding onboarding = new Onboarding();
 
     public List<String> getStory() {
         return story;
@@ -43,6 +44,10 @@ public class AIConfig {
 
     public LocalModel getLocalModel() {
         return localModel;
+    }
+
+    public Onboarding getOnboarding() {
+        return onboarding;
     }
 
     public static class LocalModel {
@@ -205,6 +210,63 @@ public class AIConfig {
 
         public void setModel(String model) {
             this.model = model;
+        }
+    }
+
+    public static class Onboarding {
+        private Boolean enabled;
+        private String completionMessage;
+        private String invalidChoiceMessage;
+        private final List<OnboardingStep> steps = new ArrayList<>();
+
+        public Boolean getEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getCompletionMessage() {
+            return completionMessage;
+        }
+
+        public void setCompletionMessage(String completionMessage) {
+            this.completionMessage = completionMessage;
+        }
+
+        public String getInvalidChoiceMessage() {
+            return invalidChoiceMessage;
+        }
+
+        public void setInvalidChoiceMessage(String invalidChoiceMessage) {
+            this.invalidChoiceMessage = invalidChoiceMessage;
+        }
+
+        public List<OnboardingStep> getSteps() {
+            return steps;
+        }
+    }
+
+    public static class OnboardingStep {
+        private String prompt;
+        private final List<String> choices = new ArrayList<>();
+        private final List<String> responses = new ArrayList<>();
+
+        public String getPrompt() {
+            return prompt;
+        }
+
+        public void setPrompt(String prompt) {
+            this.prompt = prompt;
+        }
+
+        public List<String> getChoices() {
+            return choices;
+        }
+
+        public List<String> getResponses() {
+            return responses;
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIOnboardingStore.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/AIOnboardingStore.java
@@ -1,0 +1,112 @@
+package com.thunder.wildernessodysseyapi.AI.AI_story;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import net.neoforged.fml.loading.FMLPaths;
+
+/**
+ * Persists onboarding progress per player so the AI can switch to chat mode.
+ */
+public class AIOnboardingStore {
+
+    private static final String CONFIG_NAME = "ai_onboarding.yaml";
+    private static final String ROOT_KEY = "players";
+
+    private final Path configPath;
+    private final Map<UUID, Integer> playerSteps = new HashMap<>();
+
+    public AIOnboardingStore() {
+        this.configPath = FMLPaths.CONFIGDIR.get().resolve(CONFIG_NAME);
+        load();
+    }
+
+    public synchronized int getStep(UUID playerId) {
+        return playerSteps.getOrDefault(playerId, 0);
+    }
+
+    public synchronized void setStep(UUID playerId, int step) {
+        if (playerId == null) {
+            return;
+        }
+        if (step <= 0) {
+            playerSteps.remove(playerId);
+        } else {
+            playerSteps.put(playerId, step);
+        }
+        save();
+    }
+
+    private void load() {
+        if (!Files.exists(configPath)) {
+            writeDefaultFile();
+            return;
+        }
+        List<String> lines;
+        try {
+            lines = Files.readAllLines(configPath, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to read AI onboarding config at {}.", configPath, e);
+            return;
+        }
+        boolean inList = false;
+        for (String line : lines) {
+            String trimmed = line.strip();
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                continue;
+            }
+            if (!line.startsWith(" ")) {
+                inList = trimmed.startsWith(ROOT_KEY + ":");
+                continue;
+            }
+            if (!inList) {
+                continue;
+            }
+            String[] parts = trimmed.split(":", 2);
+            if (parts.length < 2) {
+                continue;
+            }
+            try {
+                UUID playerId = UUID.fromString(parts[0].trim());
+                int step = Integer.parseInt(parts[1].trim());
+                if (step > 0) {
+                    playerSteps.put(playerId, step);
+                }
+            } catch (IllegalArgumentException ignored) {
+                // Ignore malformed entries.
+            }
+        }
+    }
+
+    private void writeDefaultFile() {
+        try {
+            Files.createDirectories(configPath.getParent());
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to create config directory for AI onboarding.", e);
+            return;
+        }
+        save();
+    }
+
+    private synchronized void save() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("# Tracks Atlas onboarding progress per player UUID.\n");
+        builder.append(ROOT_KEY).append(":\n");
+        for (Map.Entry<UUID, Integer> entry : playerSteps.entrySet()) {
+            builder.append("  ").append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+        }
+        try {
+            Files.writeString(configPath, builder.toString(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to persist AI onboarding config at {}.", configPath, e);
+        }
+    }
+}

--- a/src/main/resources/ai_config.yaml
+++ b/src/main/resources/ai_config.yaml
@@ -28,3 +28,39 @@ local_model:
   bundled_server_args: "--host 127.0.0.1 --port 11434 --model llama3.2:3b"
   timeout_seconds: 15
   system_prompt: "You are {persona}, an in-world expedition AI. Stay {tone} and {empathy}. You have no access to Google, the internet, or any external sources—only the in-world lore and knowledge provided. Do not provide crafting recipes or step-by-step crafting instructions. Keep responses immersive, lore-aware, and conversational."
+onboarding:
+  enabled: true
+  completion_message: "Onboarding complete. I'm ready for full expedition chat support."
+  invalid_choice_message: "Choose one of the numbered options so I can configure your mission."
+  steps:
+    - prompt: "Welcome back to the surface. Which briefing do you want first?"
+      choices:
+        - "Mission goals"
+        - "Supply checklist"
+        - "Hazard warnings"
+      responses:
+        - "Mission goals loaded: secure shelter, mark resources, and avoid deep craters."
+        - "Supply checklist loaded: water, rations, light sources, and repair tools."
+        - "Hazard warnings loaded: toxic dust, unstable debris, and rogue sensors."
+    - prompt: "Pick your expedition focus."
+      choices:
+        - "Exploration"
+        - "Rescue"
+        - "Research"
+      responses:
+        - "Exploration path set. I'll prioritize navigation tips and point-of-interest scans."
+        - "Rescue path set. I'll prioritize survivor signals and safe routes."
+        - "Research path set. I'll prioritize anomaly logs and artifact tracking."
+    - prompt: "How should I communicate?"
+      choices:
+        - "Short updates"
+        - "Detailed reports"
+        - "Only when asked"
+      responses:
+        - "Short updates enabled."
+        - "Detailed reports enabled."
+        - "Silent standby enabled, I will respond only when addressed."
+onboarding_steps:
+  - "Welcome back to the surface. Which briefing do you want first?|Mission goals;Supply checklist;Hazard warnings|Mission goals loaded: secure shelter, mark resources, and avoid deep craters.;Supply checklist loaded: water, rations, light sources, and repair tools.;Hazard warnings loaded: toxic dust, unstable debris, and rogue sensors."
+  - "Pick your expedition focus.|Exploration;Rescue;Research|Exploration path set. I'll prioritize navigation tips and point-of-interest scans.;Rescue path set. I'll prioritize survivor signals and safe routes.;Research path set. I'll prioritize anomaly logs and artifact tracking."
+  - "How should I communicate?|Short updates;Detailed reports;Only when asked|Short updates enabled.;Detailed reports enabled.;Silent standby enabled, I will respond only when addressed."


### PR DESCRIPTION
### Motivation
- Provide a built-in onboarding flow so players get a usable guided setup even when no custom steps are configured. 
- Persist per-player onboarding progress so the AI can switch to normal chat mode and not re-prompt players across restarts.
- Ensure chat routing runs the onboarding flow first before normal AI replies so new players are guided automatically.

### Description
- Extend `AIConfig` with `Onboarding` and `OnboardingStep`, and expose `getOnboarding()` so onboarding can be configured via YAML or code. 
- Enhance `AIConfigLoader` to parse `onboarding` and the compact `onboarding_steps` string format via `readOnboardingSteps`/`parseOnboardingStepString` as a fallback. 
- Add `AIOnboardingStore` that persists per-player step indices to `ai_onboarding.yaml` under the config dir and exposes `getStep`/`setStep`. 
- Implement onboarding runtime in `AIClient` including `configureOnboarding`, `handleOnboarding`, choice resolution (`resolveChoiceIndex`/`resolveChoiceResponse`), prompt building, `combineResponses`, and a `buildDefaultOnboardingSteps()` fallback that seeds step content when onboarding is enabled but no steps exist. 
- Route chat through onboarding by invoking `CLIENT.handleOnboarding(...)` in `AIChatListener` and short-circuiting normal replies when onboarding prompts/responses are returned. 
- Add default onboarding content to `src/main/resources/ai_config.yaml` so a prebuilt onboarding is available out-of-the-box.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb4aa7cdc8328ad2a86ee4406784d)