### PR TITLE
Expose moon-phase tide scaling and refine tide update/proximity behavior

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideConfig.java
@@ -14,6 +14,7 @@ public final class TideConfig {
     public static final ModConfigSpec.DoubleValue RIVER_AMPLITUDE_BLOCKS;
     public static final ModConfigSpec.DoubleValue PHASE_OFFSET_MINUTES;
     public static final ModConfigSpec.DoubleValue CURRENT_STRENGTH;
+    public static final ModConfigSpec.DoubleValue PLAYER_PROXIMITY_BLOCKS;
 
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 
@@ -38,6 +39,9 @@ public final class TideConfig {
         CURRENT_STRENGTH = BUILDER.comment("Vertical force multiplier applied to entities in water to reflect rising/falling tides.")
                 .defineInRange("currentStrength", 0.004D, 0.0D, 0.05D);
 
+        PLAYER_PROXIMITY_BLOCKS = BUILDER.comment("Maximum distance to the nearest player before tide currents apply. Set to 0 to always apply.")
+                .defineInRange("playerProximityBlocks", 128.0D, 0.0D, 1024.0D);
+
         BUILDER.pop();
 
         CONFIG_SPEC = BUILDER.build();
@@ -53,7 +57,8 @@ public final class TideConfig {
                 OCEAN_AMPLITUDE_BLOCKS.get(),
                 RIVER_AMPLITUDE_BLOCKS.get(),
                 PHASE_OFFSET_MINUTES.get(),
-                CURRENT_STRENGTH.get()
+                CURRENT_STRENGTH.get(),
+                PLAYER_PROXIMITY_BLOCKS.get()
         );
     }
 
@@ -67,7 +72,8 @@ public final class TideConfig {
                 OCEAN_AMPLITUDE_BLOCKS.getDefault(),
                 RIVER_AMPLITUDE_BLOCKS.getDefault(),
                 PHASE_OFFSET_MINUTES.getDefault(),
-                CURRENT_STRENGTH.getDefault()
+                CURRENT_STRENGTH.getDefault(),
+                PLAYER_PROXIMITY_BLOCKS.getDefault()
         );
     }
 
@@ -80,7 +86,8 @@ public final class TideConfig {
             double oceanAmplitudeBlocks,
             double riverAmplitudeBlocks,
             double phaseOffsetMinutes,
-            double currentStrength
+            double currentStrength,
+            double playerProximityBlocks
     ) {
         public long cycleTicks() {
             return (long) Math.max(1L, Math.round(cycleMinutes * 60.0D * 20.0D));

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/TideInfoCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/TideInfoCommand.java
@@ -31,16 +31,21 @@ public final class TideInfoCommand {
         BlockPos pos = BlockPos.containing(source.getPosition());
 
         double amplitude = TideManager.getLocalAmplitude(level, pos);
+        double moonFactor = TideManager.getMoonPhaseAmplitudeFactor(level);
+        amplitude *= moonFactor;
         double tideHeight = snapshot.normalizedHeight() * amplitude;
         double trendPerTick = snapshot.verticalChangePerTick() * amplitude;
+        int moonPhase = level.getMoonPhase();
 
         String message = String.format(
-                "Tide at %d %d %d: %.2f blocks (%s, Δ=%.4f/tick, cycle %.1f min)",
+                "Tide at %d %d %d: %.2f blocks (%s, Δ=%.4f/tick, cycle %.1f min, moon phase %d, factor %.2f)",
                 pos.getX(), pos.getY(), pos.getZ(),
                 tideHeight,
                 snapshot.trendDescription(),
                 trendPerTick,
-                snapshot.cycleTicks() / 20.0D / 60.0D
+                snapshot.cycleTicks() / 20.0D / 60.0D,
+                moonPhase,
+                moonFactor
         );
 
         source.sendSuccess(() -> Component.literal(message), false);


### PR DESCRIPTION
### Motivation
- Make tide amplitude respond to lunar phase so currents feel stronger on full/new moons and weaker on quarters.  
- Reduce unnecessary work by avoiding tide updates in dimensions with no players and by skipping entities in unloaded chunks.  
- Ensure tides are clearly documented as distinct from any wave simulation and allow operators to gate tide effects by player proximity via configuration.

### Description
- Added `getMoonPhaseAmplitudeFactor(ServerLevel)` to `TideManager` and applied the returned factor to local amplitude calculations used for entity forces.  
- Updated `TideInfoCommand` to include the moon phase and the applied moon-factor in its output and to use the moon-scaled amplitude when reporting tide height.  
- Early-return optimizations in `TideManager.onServerTick` and `TideManager.onEntityTick`: skip dimension updates when `level.players().isEmpty()`, skip entities in unloaded chunks via `serverLevel.hasChunkAt(...)`, and skip applying currents when no player is within the configured `playerProximityBlocks`.  
- Clarified the `TideManager` class javadoc to note tides are distinct from any wave simulation and used the existing `playerProximityBlocks` config value to gate proximity checks.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c008a769883289dd519b7186158cc)