### PR TITLE
Replace deprecated chunk checks (hasChunkAt -> hasChunk with ChunkPos)

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideManager.java
@@ -2,6 +2,7 @@ package com.thunder.wildernessodysseyapi.ModPackPatches.Ocean.tide;
 
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
@@ -129,7 +130,8 @@ public final class TideManager {
         if (!cachedConfig.enabled() || !entity.isInWaterOrBubble()) {
             return;
         }
-        if (!serverLevel.hasChunkAt(entity.blockPosition())) {
+        ChunkPos entityChunk = new ChunkPos(entity.blockPosition());
+        if (!serverLevel.hasChunk(entityChunk.x, entityChunk.z)) {
             return;
         }
         BlockPos entityPos = entity.blockPosition();

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -11,6 +11,7 @@ import net.minecraft.core.Vec3i;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -611,7 +612,8 @@ public abstract class StructureBlockEntityMixin extends BlockEntity implements S
     @Unique
     private java.lang.Boolean wildernessodysseyapi$validateCorner(ServerLevel serverLevel, BlockPos position,
             String structureNameKey) {
-        if (!serverLevel.hasChunkAt(position)) {
+        ChunkPos chunkPos = new ChunkPos(position);
+        if (!serverLevel.hasChunk(chunkPos.x, chunkPos.z)) {
             return null;
         }
         BlockState blockState = serverLevel.getBlockState(position);
@@ -914,7 +916,8 @@ public abstract class StructureBlockEntityMixin extends BlockEntity implements S
         BlockState cornerState = Blocks.STRUCTURE_BLOCK.defaultBlockState().setValue(StructureBlock.MODE, StructureMode.CORNER);
 
         for (BlockPos target : desiredCorners) {
-            if (!serverLevel.hasChunkAt(target)) {
+            ChunkPos chunkPos = new ChunkPos(target);
+            if (!serverLevel.hasChunk(chunkPos.x, chunkPos.z)) {
                 continue;
             }
             BlockState state = serverLevel.getBlockState(target);


### PR DESCRIPTION
### Motivation
- Replace usages of the deprecated `hasChunkAt` API to remove deprecation warnings and avoid future breakage while keeping existing chunk-presence semantics.

### Description
- Added `net.minecraft.world.level.ChunkPos` and replaced `serverLevel.hasChunkAt(entity.blockPosition())` with a `ChunkPos` and `serverLevel.hasChunk(chunkPos.x, chunkPos.z)` in `TideManager`'s `onEntityTick` path.
- Replaced `hasChunkAt` checks in `StructureBlockEntityMixin` (in corner validation and desired-corner placement) with `ChunkPos` + `serverLevel.hasChunk(chunkPos.x, chunkPos.z)` while leaving surrounding logic unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980df53dfd48328bc147b0c5635e3a7)