### PR TITLE
Disable telemetry consent prompt on load

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/telemetry/TelemetryConsentClientHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/telemetry/TelemetryConsentClientHandler.java
@@ -3,7 +3,6 @@ package com.thunder.wildernessodysseyapi.ModPackPatches.telemetry;
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
 import com.thunder.wildernessodysseyapi.ModPackPatches.telemetry.TelemetryConsentStore.ConsentDecision;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.screens.TitleScreen;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -26,12 +25,7 @@ public final class TelemetryConsentClientHandler {
         ConsentDecision decision = TelemetryConsentConfig.decision();
         Minecraft minecraft = Minecraft.getInstance();
         minecraft.execute(() -> {
-            if (decision == ConsentDecision.UNKNOWN) {
-                if (!promptedThisSession && minecraft.level != null) {
-                    promptedThisSession = true;
-                    minecraft.setScreen(new TelemetryConsentScreen(minecraft.screen));
-                }
-            } else {
+            if (decision != ConsentDecision.UNKNOWN) {
                 syncDecisionIfPossible(decision);
             }
         });
@@ -51,17 +45,8 @@ public final class TelemetryConsentClientHandler {
 
     @SubscribeEvent
     public static void onClientTick(ClientTickEvent.Post event) {
-        if (promptedThisSession) {
-            return;
-        }
-        TelemetryConsentConfig.validateVersion();
-        if (TelemetryConsentConfig.decision() != ConsentDecision.UNKNOWN) {
-            return;
-        }
-        Minecraft minecraft = Minecraft.getInstance();
-        if (minecraft.screen instanceof TitleScreen) {
-            promptedThisSession = true;
-            minecraft.setScreen(new TelemetryConsentScreen(minecraft.screen));
+        if (!promptedThisSession) {
+            TelemetryConsentConfig.validateVersion();
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent the telemetry consent UI from automatically opening when a player loads the game so players are not interrupted by the dialog. 
- Ensure existing consent decisions are still propagated to the server when known by the client.

### Description
- Change `onClientLogin` to only call `syncDecisionIfPossible` when `TelemetryConsentConfig.decision()` is not `UNKNOWN`, removing the automatic `TelemetryConsentScreen` display. 
- Remove usage/import of `TitleScreen`/`TelemetryConsentScreen` from the login/tick flow so the screen is no longer shown on title screen or login. 
- Simplify `onClientTick` to only perform `TelemetryConsentConfig.validateVersion()` when not already prompted, removing the title-screen prompt behavior.

### Testing
- No automated tests were run on the modified code in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981110706948328b7aa30e6219c4df1)