### PR TITLE
Avoid repeated world preset selection

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/MixinWorldCreationUiState.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/MixinWorldCreationUiState.java
@@ -17,11 +17,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  */
 public class MixinWorldCreationUiState {
 
+    private boolean wildernessOdysseyApi$defaultPresetApplied;
+
     /**
      * After preset lists are populated, switch to the large biomes preset.
      */
     @Inject(method = "updatePresetLists", at = @At("TAIL"))
     private void forceLargeBiomesPreset(CallbackInfo ci) {
+        if (wildernessOdysseyApi$defaultPresetApplied) {
+            return;
+        }
         WorldCreationUiState state = (WorldCreationUiState)(Object)this;
         WorldCreationContext context = state.getSettings();
 
@@ -29,6 +34,7 @@ public class MixinWorldCreationUiState {
 
         getter.get(WorldPresets.LARGE_BIOMES).ifPresent(holder -> {
             state.setWorldType(new WorldCreationUiState.WorldTypeEntry(holder));
+            wildernessOdysseyApi$defaultPresetApplied = true;
         });
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce repeated `WorldCreationUiState` preset updates which could cause freezes during world generation UI preparation in large modpacks by applying the default preset only once.

### Description
- Add a boolean field `wildernessOdysseyApi$defaultPresetApplied` and guard in the injected `forceLargeBiomesPreset` so the default `WorldPresets.LARGE_BIOMES` selection is applied only once and then skipped on subsequent `updatePresetLists` calls.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698112a7419c832888a624451cb69d89)