### PR TITLE
Fix campfire particle sprite initialization

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/HigherSmoke/Particles/CustomCampfireParticle.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/HigherSmoke/Particles/CustomCampfireParticle.java
@@ -26,6 +26,7 @@ public class CustomCampfireParticle extends SimpleAnimatedParticle {
      */
     protected CustomCampfireParticle(ClientLevel level, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed, SpriteSet sprite) {
         super(level, x, y, z, sprite, 0.1F); // Gravity is set to 0.1F for natural rise
+        this.setSpriteFromAge(sprite);
         this.xd = xSpeed;
         this.yd = ySpeed;
         this.zd = zSpeed;


### PR DESCRIPTION
### Motivation
- Prevent a renderer NPE caused by an uninitialized particle sprite by ensuring the particle's sprite is set when created.

### Description
- Call `setSpriteFromAge(sprite)` in the `CustomCampfireParticle` constructor (`src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/HigherSmoke/Particles/CustomCampfireParticle.java`) to initialize the sprite from the provided `SpriteSet`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698177fd8a68832896db911df742f27e)