### PR TITLE
Cull off-screen campfire smoke using camera look and distance-based throttling

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/CampfireBlockMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/CampfireBlockMixin.java
@@ -1,18 +1,21 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.CampfireBlock;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import it.unimi.dsi.fastutil.longs.Long2LongMap;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
-import it.unimi.dsi.fastutil.longs.LongIterator;
 
 /**
  * The type Campfire block mixin.
@@ -34,35 +37,76 @@ public class CampfireBlockMixin {
 
         long gameTime = level.getGameTime();
         long key = pos.asLong();
-        long lastTime = LAST_PARTICLE_TIME.getOrDefault(key, 0L);
+        long lastTime = LAST_PARTICLE_TIME.get(key);
 
-        // Throttle particle spawn per campfire every 5 ticks (1/4 second)
-        if (gameTime - lastTime < 5) return;
+        Player player = level.getNearestPlayer(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, 256, false);
+        if (player == null) {
+            return;
+        }
+
+        double distanceSq = player.distanceToSqr(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
+        if (distanceSq > 256 * 256) {
+            return;
+        }
+
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft != null && minecraft.gameRenderer != null) {
+            Vec3 cameraPos = minecraft.gameRenderer.getMainCamera().getPosition();
+            Vec3 cameraLook = minecraft.gameRenderer.getMainCamera().getLookVector();
+            Vec3 toCampfire = new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5).subtract(cameraPos);
+            if (distanceSq > 64 * 64 && cameraLook.dot(toCampfire.normalize()) < 0.2) {
+                return;
+            }
+        }
+
+        int throttleInterval = 5;
+        int columns = 2;
+        int minSteps = 5;
+        int extraSteps = 4;
+        if (distanceSq > 128 * 128) {
+            throttleInterval = 20;
+            columns = 1;
+            minSteps = 1;
+            extraSteps = 1;
+        } else if (distanceSq > 64 * 64) {
+            throttleInterval = 10;
+            columns = 1;
+            minSteps = 2;
+            extraSteps = 2;
+        }
+
+        // Throttle particle spawn per campfire based on distance
+        if (gameTime - lastTime < throttleInterval) return;
         LAST_PARTICLE_TIME.put(key, gameTime);
 
         // Periodically clean up stale entries to avoid unbounded growth
         if (gameTime % 200 == 0) {
-            LongIterator iter = LAST_PARTICLE_TIME.keySet().iterator();
-            while (iter.hasNext()) {
-                long k = iter.nextLong();
-                long value = LAST_PARTICLE_TIME.get(k);
-                if (gameTime - value > 200) {
-                    iter.remove();
+            Long2LongMap.FastEntrySet entries = LAST_PARTICLE_TIME.long2LongEntrySet();
+            var iterator = entries.fastIterator();
+            while (iterator.hasNext()) {
+                Long2LongMap.Entry entry = iterator.next();
+                if (gameTime - entry.getLongValue() > 200) {
+                    iterator.remove();
                 }
             }
         }
 
         RandomSource random = level.getRandom();
         int maxHeight = level.getMaxBuildHeight();
+        int minHeight = pos.getY() + 10;
+        int heightRange = maxHeight - minHeight;
+        if (heightRange <= 0) {
+            return;
+        }
 
         // Generate a sparse column effect
-        for (int i = 0; i < 2; ++i) {
+        for (int i = 0; i < columns; ++i) {
             double x = pos.getX() + 0.5 + random.nextGaussian() * 0.05;
             double z = pos.getZ() + 0.5 + random.nextGaussian() * 0.05;
 
-            int steps = 5 + random.nextInt(4); // Vary how many particles per column
+            int steps = minSteps + random.nextInt(extraSteps); // Vary how many particles per column
             for (int j = 0; j < steps; j++) {
-                int height = pos.getY() + 10 + random.nextInt(maxHeight - pos.getY() - 10);
+                int height = minHeight + random.nextInt(heightRange);
                 level.addAlwaysVisibleParticle(
                         isSignalFire ? ParticleTypes.CAMPFIRE_SIGNAL_SMOKE : ParticleTypes.CAMPFIRE_COSY_SMOKE,
                         true,


### PR DESCRIPTION
### Motivation
- Reduce particle and CPU load by skipping far-away campfire smoke that the player is not looking at while preserving visible signals when the player does look toward them. 
- Avoid unbounded growth of the emission tracking map and prevent invalid height calculations. 
- Combine proximity-based logic with client camera info when available so behavior is robust on client environments.

### Description
- Add camera look-based culling using `Minecraft.getInstance().gameRenderer.getMainCamera()` to avoid spawning smoke for distant campfires that are off-screen. 
- Keep the nearest-player proximity check via `level.getNearestPlayer(...)` and compute `throttleInterval`, `columns`, `minSteps`, and `extraSteps` from the player's squared distance so spawn rate and density scale with distance. 
- Throttle per-campfire emission using the `LAST_PARTICLE_TIME` map and periodically remove stale entries via `Long2LongMap.FastEntrySet.fastIterator()` to prevent unbounded growth. 
- Bound `minHeight`/`heightRange` and early-return when invalid, and generate smoke using `level.addAlwaysVisibleParticle(...)` with configurable column/step counts.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698227828ee483288b753dd1737be133)