### PR TITLE
Refine neural frame geometry and add curio render toggles

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Client/ChipSetCurioRenderer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Client/ChipSetCurioRenderer.java
@@ -1,0 +1,61 @@
+package com.thunder.wildernessodysseyapi.Client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.thunder.wildernessodysseyapi.config.CurioRenderConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.RenderLayerParent;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
+import top.theillusivec4.curios.api.SlotContext;
+import top.theillusivec4.curios.api.client.ICurioRenderer;
+
+public class ChipSetCurioRenderer implements ICurioRenderer {
+    @Override
+    public <T extends LivingEntity, M extends EntityModel<T>> void render(ItemStack stack,
+                                                                          SlotContext slotContext,
+                                                                          PoseStack poseStack,
+                                                                          RenderLayerParent<T, M> renderLayerParent,
+                                                                          MultiBufferSource buffer,
+                                                                          int packedLight,
+                                                                          float limbSwing,
+                                                                          float limbSwingAmount,
+                                                                          float partialTick,
+                                                                          float ageInTicks,
+                                                                          float netHeadYaw,
+                                                                          float headPitch) {
+        if (!CurioRenderConfig.RENDER_CHIP_SET.get()) {
+            return;
+        }
+
+        T entity = slotContext.entity();
+        poseStack.pushPose();
+        ICurioRenderer.translateIfSneaking(poseStack, entity);
+
+        M model = renderLayerParent.getModel();
+        if (model instanceof HumanoidModel<?> humanoidModel) {
+            ICurioRenderer.followHeadRotations(entity, humanoidModel.head);
+            humanoidModel.head.translateAndRotate(poseStack);
+        }
+
+        poseStack.translate(0.35F, -0.2F, 0.0F);
+        poseStack.scale(0.35F, 0.35F, 0.35F);
+
+        Minecraft.getInstance().getItemRenderer().renderStatic(
+                stack,
+                ItemDisplayContext.HEAD,
+                packedLight,
+                OverlayTexture.NO_OVERLAY,
+                poseStack,
+                buffer,
+                entity.level(),
+                entity.getId()
+        );
+
+        poseStack.popPose();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/Client/ChipSetRendererRegistration.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Client/ChipSetRendererRegistration.java
@@ -1,0 +1,20 @@
+package com.thunder.wildernessodysseyapi.Client;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.item.ModItems;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import top.theillusivec4.curios.api.client.CuriosRendererRegistry;
+
+@EventBusSubscriber(modid = ModConstants.MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+public final class ChipSetRendererRegistration {
+    private ChipSetRendererRegistration() {
+    }
+
+    @SubscribeEvent
+    public static void onClientSetup(FMLClientSetupEvent event) {
+        event.enqueueWork(() -> CuriosRendererRegistry.register(ModItems.CLOAK_CHIP.get(), ChipSetCurioRenderer::new));
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameModel.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameModel.java
@@ -33,7 +33,9 @@ public class NeuralFrameModel extends EntityModel<AbstractClientPlayer> {
                 "frame",
                 CubeListBuilder.create()
                         .texOffs(0, 0)
-                        .addBox(3.5F, -5.5F, -4.5F, 2.0F, 4.0F, 1.0F, new CubeDeformation(0.0F)),
+                        .addBox(-3.0F, -5.5F, -4.0F, 6.0F, 4.0F, 0.2F, new CubeDeformation(0.0F))
+                        .texOffs(0, 5)
+                        .addBox(3.0F, -5.5F, -4.0F, 0.4F, 4.0F, 0.2F, new CubeDeformation(0.0F)),
                 PartPose.ZERO
         );
         return LayerDefinition.create(mesh, 16, 16);

--- a/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameRenderLayer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameRenderLayer.java
@@ -1,6 +1,7 @@
 package com.thunder.wildernessodysseyapi.Client;
 
 import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.config.CurioRenderConfig;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Minecraft;
@@ -38,6 +39,9 @@ public class NeuralFrameRenderLayer extends RenderLayer<AbstractClientPlayer, Pl
                        float netHeadYaw,
                        float headPitch) {
         if (!player.getItemBySlot(EquipmentSlot.HEAD).isEmpty()) {
+            return;
+        }
+        if (!CurioRenderConfig.RENDER_NEURAL_FRAME.get()) {
             return;
         }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -23,6 +23,7 @@ import com.thunder.wildernessodysseyapi.command.StructurePlacementDebugCommand;
 import com.thunder.wildernessodysseyapi.command.TideInfoCommand;
 import com.thunder.wildernessodysseyapi.config.ConfigRegistrationValidator;
 import com.thunder.wildernessodysseyapi.config.CloakChipConfig;
+import com.thunder.wildernessodysseyapi.config.CurioRenderConfig;
 import com.thunder.wildernessodysseyapi.config.StructureBlockConfig;
 import com.thunder.wildernessodysseyapi.item.ModCreativeTabs;
 import com.thunder.wildernessodysseyapi.item.ModItems;
@@ -121,6 +122,8 @@ public class WildernessOdysseyAPIMainModClass {
                 CONFIG_FOLDER + "wildernessodysseyapi-structures.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.CLIENT, DonationReminderConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-donations-client.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.CLIENT, CurioRenderConfig.CONFIG_SPEC,
+                CONFIG_FOLDER + "wildernessodysseyapi-curio-rendering-client.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.CLIENT, TelemetryConsentConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-telemetry-client.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, AsyncThreadingConfig.CONFIG_SPEC,

--- a/src/main/java/com/thunder/wildernessodysseyapi/config/CurioRenderConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/config/CurioRenderConfig.java
@@ -1,0 +1,23 @@
+package com.thunder.wildernessodysseyapi.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public final class CurioRenderConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+    public static final ModConfigSpec.BooleanValue RENDER_NEURAL_FRAME;
+    public static final ModConfigSpec.BooleanValue RENDER_CHIP_SET;
+
+    static {
+        ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
+        builder.push("curio_rendering");
+        RENDER_NEURAL_FRAME = builder.comment("Render the neural frame on the player.")
+                .define("renderNeuralFrame", true);
+        RENDER_CHIP_SET = builder.comment("Render chip set curios on the player.")
+                .define("renderChipSet", true);
+        builder.pop();
+        CONFIG_SPEC = builder.build();
+    }
+
+    private CurioRenderConfig() {
+    }
+}


### PR DESCRIPTION
### Motivation
- Make the neural frame sit mostly inside the player’s head with a paper-thin protrusion on the right side to match the requested positioning. 
- Allow players to toggle rendering of the neural frame and chip-set curios via client config so these visuals can be enabled/disabled.

### Description
- Adjusted the neural frame model geometry so the bulk of the frame is inside the head and a thin piece protrudes from the right (`NeuralFrameModel`).
- Gate neural frame rendering behind the client config flag `renderNeuralFrame` in the render layer (`NeuralFrameRenderLayer`).
- Added a new client config `CurioRenderConfig` with boolean values `renderNeuralFrame` and `renderChipSet` and registered it with `ConfigRegistrationValidator` in the mod initializer (`WildernessOdysseyAPIMainModClass`).
- Added a Curios curio renderer `ChipSetCurioRenderer` and registered it on client setup via `ChipSetRendererRegistration` so the chip set render can be toggled with `renderChipSet`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982261d1bf48328b214e4a46d25ca46)