### PR TITLE
Use Vec3.dot for campfire camera visibility check

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/CampfireBlockMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/CampfireBlockMixin.java
@@ -9,7 +9,6 @@ import net.minecraft.world.level.block.CampfireBlock;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3f;
-import org.joml.Vector3fc;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -56,7 +55,10 @@ public class CampfireBlockMixin {
             Vec3 cameraPos = minecraft.gameRenderer.getMainCamera().getPosition();
             Vector3f cameraLook = minecraft.gameRenderer.getMainCamera().getLookVector();
             Vec3 toCampfire = new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5).subtract(cameraPos);
-            if (distanceSq > 64 * 64 && cameraLook.dot((Vector3fc) toCampfire.normalize()) < 0.2) {
+            Vec3 normalizedToCampfire = toCampfire.normalize();
+            Vec3 cameraLookVec = new Vec3(cameraLook.x(), cameraLook.y(), cameraLook.z());
+            double lookDot = cameraLookVec.dot(normalizedToCampfire);
+            if (distanceSq > 64 * 64 && lookDot < 0.2) {
                 return;
             }
         }


### PR DESCRIPTION
### Motivation
- Avoid an invalid JOML cast and potential `ClassCastException` when comparing the camera look vector to the campfire direction in the campfire particle culling logic.
- Keep vector math consistent with Minecraft's `Vec3` API and make the face-check clearer and safer.

### Description
- Replace the JOML cast-based check with a `Vec3`-based dot product by converting the camera look `Vector3f` into a `Vec3` and calling `Vec3.dot` against a normalized campfire direction in `src/main/java/com/thunder/wildernessodysseyapi/mixin/CampfireBlockMixin.java`.
- Introduce `cameraLookVec` and `normalizedToCampfire` locals and compute `lookDot` via `cameraLookVec.dot(normalizedToCampfire)` and use that in the early-return visibility condition.
- Remove the now-unused `org.joml.Vector3fc` usage from the code path (and the invalid cast), keeping behavior equivalent but safer.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69822e5400708328b32b66a3ffcdb9ff)