### PR TITLE
Trigger client/server workflows after successful Build

### DIFF
--- a/.github/workflows/run-client.yml
+++ b/.github/workflows/run-client.yml
@@ -1,11 +1,14 @@
 name: Build and Run Client
 
 on:
-  push:
-  pull_request:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 
 jobs:
   run-client:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/run-server.yml
+++ b/.github/workflows/run-server.yml
@@ -1,11 +1,14 @@
 name: Build and Run Server
 
 on:
-  push:
-  pull_request:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 
 jobs:
   run-server:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Motivation
- Prevent the client and server run workflows from executing on every `push`/`pull_request` and instead run them only after the central `Build` workflow finishes. 
- Ensure the client and server jobs only run when the `Build` workflow completes successfully to avoid wasting CI resources. 

### Description
- Changed the triggers in `.github/workflows/run-client.yml` and `.github/workflows/run-server.yml` from `on: push` / `pull_request` to `on: workflow_run` with `workflows: ["Build"]` and `types: [completed]`.
- Added a job-level guard `if: ${{ github.event.workflow_run.conclusion == 'success' }}` to both `run-client` and `run-server` jobs so they only run when the `Build` workflow succeeds.
- Kept existing job steps (checkout, JDK/Gradle setup, `./gradlew build`, run client/server, and artifact upload) unchanged.

### Testing
- No automated tests were run because this change only modifies workflow triggers and guards. 
- The patch was added and committed locally and a PR description was prepared; CI will validate behavior when the `Build` workflow runs in GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69822fbc776c832885b2979202083c62)