### PR TITLE
Apply moon phase to tide simulation

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideManager.java
@@ -100,7 +100,8 @@ public final class TideManager {
             }
             TideState state = TIDE_STATES.computeIfAbsent(level.dimension(), key -> new TideState());
             long dayTime = level.getDayTime();
-            double newHeight = computeNormalizedHeight(dayTime, cachedConfig);
+            double moonFactor = getMoonPhaseAmplitudeFactor(level);
+            double newHeight = computeNormalizedHeight(dayTime, cachedConfig) * moonFactor;
             state.update(dayTime, newHeight);
         }
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/TideInfoCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/TideInfoCommand.java
@@ -32,7 +32,6 @@ public final class TideInfoCommand {
 
         double amplitude = TideManager.getLocalAmplitude(level, pos);
         double moonFactor = TideManager.getMoonPhaseAmplitudeFactor(level);
-        amplitude *= moonFactor;
         double tideHeight = snapshot.normalizedHeight() * amplitude;
         double trendPerTick = snapshot.verticalChangePerTick() * amplitude;
         int moonPhase = level.getMoonPhase();


### PR DESCRIPTION
### Motivation
- Make the tidal simulation reflect lunar influence by applying the moon-phase amplitude when the tide state is updated so stored tide values represent real-world moon-driven variation.

### Description
- Multiply the normalized tide height by `getMoonPhaseAmplitudeFactor(level)` inside `onServerTick` in `src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideManager.java` so the saved `TideState` includes moon effects.
- Remove the redundant moon-factor multiplication from the `/tide` reporter in `src/main/java/com/thunder/wildernessodysseyapi/command/TideInfoCommand.java` to avoid double-applying the lunar amplitude when displaying values.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69823f50405c832893e48da48e0955b0)