### PR TITLE
Split tide amplitude and config parsing; add TideAmplitudeHelper and TideConfigParsers

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideAmplitudeHelper.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideAmplitudeHelper.java
@@ -1,0 +1,76 @@
+package com.thunder.wildernessodysseyapi.ModPackPatches.Ocean.tide;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.BiomeTags;
+import net.minecraft.world.level.biome.Biome;
+
+import java.util.Map;
+
+final class TideAmplitudeHelper {
+    private TideAmplitudeHelper() {
+    }
+
+    static double getLocalAmplitude(ServerLevel level, BlockPos pos, TideConfig.TideConfigValues config) {
+        Holder<Biome> biomeHolder = level.getBiome(pos);
+        double amplitude;
+        if (biomeHolder.is(BiomeTags.IS_OCEAN)) {
+            amplitude = config.oceanAmplitudeBlocks();
+        } else if (biomeHolder.is(BiomeTags.IS_RIVER)) {
+            amplitude = config.riverAmplitudeBlocks() * computeRiverOceanFactor(level, pos, config);
+        } else {
+            amplitude = 0.0D;
+        }
+        amplitude *= TideAstronomy.getMoonPhaseAmplitudeFactor(level);
+        amplitude *= getDimensionMultiplier(level, config.dimensionAmplitudeOverrides());
+        amplitude *= getBiomeMultiplier(biomeHolder, config.biomeAmplitudeOverrides());
+        return amplitude;
+    }
+
+    private static double getDimensionMultiplier(ServerLevel level, Map<String, Double> overrides) {
+        if (overrides.isEmpty()) {
+            return 1.0D;
+        }
+        return overrides.getOrDefault(level.dimension().location().toString(), 1.0D);
+    }
+
+    private static double getBiomeMultiplier(Holder<Biome> biomeHolder, Map<String, Double> overrides) {
+        if (overrides.isEmpty()) {
+            return 1.0D;
+        }
+        return biomeHolder.unwrapKey()
+                .map(resourceKey -> overrides.getOrDefault(resourceKey.location().toString(), 1.0D))
+                .orElse(1.0D);
+    }
+
+    private static double computeRiverOceanFactor(ServerLevel level, BlockPos pos, TideConfig.TideConfigValues config) {
+        int radius = config.riverOceanSearchRadius();
+        if (radius <= 0) {
+            return 1.0D;
+        }
+        int step = Math.max(4, config.riverOceanSearchStep());
+        int radiusSq = radius * radius;
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        int closestSq = Integer.MAX_VALUE;
+        for (int dx = -radius; dx <= radius; dx += step) {
+            for (int dz = -radius; dz <= radius; dz += step) {
+                int distanceSq = dx * dx + dz * dz;
+                if (distanceSq > radiusSq) {
+                    continue;
+                }
+                cursor.set(pos.getX() + dx, pos.getY(), pos.getZ() + dz);
+                Holder<Biome> nearbyBiome = level.getBiome(cursor);
+                if (nearbyBiome.is(BiomeTags.IS_OCEAN)) {
+                    closestSq = Math.min(closestSq, distanceSq);
+                }
+            }
+        }
+        if (closestSq == Integer.MAX_VALUE) {
+            return config.riverInlandMinFactor();
+        }
+        double distance = Math.sqrt(closestSq);
+        double factor = 1.0D - (distance / radius);
+        return Math.max(config.riverInlandMinFactor(), factor);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideAstronomy.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideAstronomy.java
@@ -1,0 +1,53 @@
+package com.thunder.wildernessodysseyapi.ModPackPatches.Ocean.tide;
+
+import net.minecraft.server.level.ServerLevel;
+
+import static java.lang.Math.PI;
+
+public final class TideAstronomy {
+    private TideAstronomy() {
+    }
+
+    public static double getMoonPhaseAmplitudeFactor(ServerLevel level) {
+        return switch (level.getMoonPhase()) {
+            case 0 -> 1.2D;
+            case 1, 7 -> 1.1D;
+            case 2, 6 -> 1.0D;
+            case 3, 5 -> 0.9D;
+            case 4 -> 0.8D;
+            default -> 1.0D;
+        };
+    }
+
+    static TideSample computeTideSample(long dayTime, ServerLevel level, TideConfig.TideConfigValues config) {
+        long cycleTicks = Math.max(1L, config.cycleTicks());
+        long adjustedTime = (dayTime + config.phaseOffsetTicks()) % cycleTicks;
+        double phase = (adjustedTime / (double) cycleTicks) * 2.0D * PI;
+        double lunar = Math.sin(phase);
+        double harmonic = Math.sin(2.0D * phase) * config.harmonicWeight();
+        long solarCycleTicks = Math.max(1L, Math.round(cycleTicks * config.solarCycleRatio()));
+        long solarAdjustedTime = (dayTime + config.phaseOffsetTicks()) % solarCycleTicks;
+        double solarPhase = (solarAdjustedTime / (double) solarCycleTicks) * 2.0D * PI;
+        double solar = Math.sin(solarPhase) * config.solarWeight();
+        double weightTotal = 1.0D + Math.abs(config.harmonicWeight()) + Math.abs(config.solarWeight());
+        double combined = (lunar + harmonic + solar) / weightTotal;
+        if (level.isThundering()) {
+            combined += config.thunderOffsetNormalized();
+        } else if (level.isRaining()) {
+            combined += config.rainOffsetNormalized();
+        }
+        combined = clamp(combined, -1.0D, 1.0D);
+        double lunarRate = Math.cos(phase) * (2.0D * PI / cycleTicks);
+        double harmonicRate = Math.cos(2.0D * phase) * (4.0D * PI / cycleTicks) * config.harmonicWeight();
+        double solarRate = Math.cos(solarPhase) * (2.0D * PI / solarCycleTicks) * config.solarWeight();
+        double changePerTick = (lunarRate + harmonicRate + solarRate) / weightTotal;
+        return new TideSample(combined, changePerTick);
+    }
+
+    private static double clamp(double value, double min, double max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    record TideSample(double height, double changePerTick) {
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideConfig.java
@@ -2,6 +2,9 @@ package com.thunder.wildernessodysseyapi.ModPackPatches.Ocean.tide;
 
 import net.neoforged.neoforge.common.ModConfigSpec;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Configuration for the tide simulation.
  */
@@ -13,6 +16,16 @@ public final class TideConfig {
     public static final ModConfigSpec.DoubleValue OCEAN_AMPLITUDE_BLOCKS;
     public static final ModConfigSpec.DoubleValue RIVER_AMPLITUDE_BLOCKS;
     public static final ModConfigSpec.DoubleValue PHASE_OFFSET_MINUTES;
+    public static final ModConfigSpec.DoubleValue SOLAR_WEIGHT;
+    public static final ModConfigSpec.DoubleValue SOLAR_CYCLE_RATIO;
+    public static final ModConfigSpec.DoubleValue HARMONIC_WEIGHT;
+    public static final ModConfigSpec.DoubleValue RAIN_OFFSET_NORMALIZED;
+    public static final ModConfigSpec.DoubleValue THUNDER_OFFSET_NORMALIZED;
+    public static final ModConfigSpec.IntValue RIVER_OCEAN_SEARCH_RADIUS;
+    public static final ModConfigSpec.IntValue RIVER_OCEAN_SEARCH_STEP;
+    public static final ModConfigSpec.DoubleValue RIVER_INLAND_MIN_FACTOR;
+    public static final ModConfigSpec.ConfigValue<List<? extends String>> DIMENSION_AMPLITUDE_MULTIPLIERS;
+    public static final ModConfigSpec.ConfigValue<List<? extends String>> BIOME_AMPLITUDE_MULTIPLIERS;
     public static final ModConfigSpec.DoubleValue CURRENT_STRENGTH;
     public static final ModConfigSpec.DoubleValue PLAYER_PROXIMITY_BLOCKS;
 
@@ -36,6 +49,36 @@ public final class TideConfig {
         PHASE_OFFSET_MINUTES = BUILDER.comment("Optional offset to desynchronize tide peaks from the day/night cycle.")
                 .defineInRange("phaseOffsetMinutes", 0.0D, 0.0D, 240.0D);
 
+        SOLAR_WEIGHT = BUILDER.comment("Weight of a secondary solar tide component blended with the primary lunar tide.")
+                .defineInRange("solarWeight", 0.35D, 0.0D, 2.0D);
+
+        SOLAR_CYCLE_RATIO = BUILDER.comment("Cycle length multiplier for the solar tide component relative to the main tide cycle.")
+                .defineInRange("solarCycleRatio", 1.08D, 0.5D, 2.0D);
+
+        HARMONIC_WEIGHT = BUILDER.comment("Weight of a harmonic (overtide) term to better emulate mixed semidiurnal tides.")
+                .defineInRange("harmonicWeight", 0.2D, 0.0D, 2.0D);
+
+        RAIN_OFFSET_NORMALIZED = BUILDER.comment("Normalized tide offset applied during rain (scaled to the tide's [-1, 1] range).")
+                .defineInRange("rainOffsetNormalized", 0.05D, -0.5D, 0.5D);
+
+        THUNDER_OFFSET_NORMALIZED = BUILDER.comment("Normalized tide offset applied during thunderstorms (scaled to the tide's [-1, 1] range).")
+                .defineInRange("thunderOffsetNormalized", 0.1D, -0.5D, 0.5D);
+
+        RIVER_OCEAN_SEARCH_RADIUS = BUILDER.comment("Max distance (in blocks) to search for nearby ocean biomes to attenuate river tides.")
+                .defineInRange("riverOceanSearchRadius", 128, 0, 1024);
+
+        RIVER_OCEAN_SEARCH_STEP = BUILDER.comment("Search step size (in blocks) when scanning for nearby ocean biomes.")
+                .defineInRange("riverOceanSearchStep", 16, 4, 64);
+
+        RIVER_INLAND_MIN_FACTOR = BUILDER.comment("Minimum tide multiplier for inland rivers that never find an ocean biome.")
+                .defineInRange("riverInlandMinFactor", 0.2D, 0.0D, 1.0D);
+
+        DIMENSION_AMPLITUDE_MULTIPLIERS = BUILDER.comment("Per-dimension amplitude multipliers: \"namespace:dimension=multiplier\".")
+                .define("dimensionAmplitudeMultipliers", List.of());
+
+        BIOME_AMPLITUDE_MULTIPLIERS = BUILDER.comment("Per-biome amplitude multipliers: \"namespace:biome=multiplier\".")
+                .define("biomeAmplitudeMultipliers", List.of());
+
         CURRENT_STRENGTH = BUILDER.comment("Vertical force multiplier applied to entities in water to reflect rising/falling tides.")
                 .defineInRange("currentStrength", 0.004D, 0.0D, 0.05D);
 
@@ -57,6 +100,16 @@ public final class TideConfig {
                 OCEAN_AMPLITUDE_BLOCKS.get(),
                 RIVER_AMPLITUDE_BLOCKS.get(),
                 PHASE_OFFSET_MINUTES.get(),
+                SOLAR_WEIGHT.get(),
+                SOLAR_CYCLE_RATIO.get(),
+                HARMONIC_WEIGHT.get(),
+                RAIN_OFFSET_NORMALIZED.get(),
+                THUNDER_OFFSET_NORMALIZED.get(),
+                RIVER_OCEAN_SEARCH_RADIUS.get(),
+                RIVER_OCEAN_SEARCH_STEP.get(),
+                RIVER_INLAND_MIN_FACTOR.get(),
+                TideConfigParsers.parseMultiplierMap(DIMENSION_AMPLITUDE_MULTIPLIERS.get()),
+                TideConfigParsers.parseMultiplierMap(BIOME_AMPLITUDE_MULTIPLIERS.get()),
                 CURRENT_STRENGTH.get(),
                 PLAYER_PROXIMITY_BLOCKS.get()
         );
@@ -72,6 +125,16 @@ public final class TideConfig {
                 OCEAN_AMPLITUDE_BLOCKS.getDefault(),
                 RIVER_AMPLITUDE_BLOCKS.getDefault(),
                 PHASE_OFFSET_MINUTES.getDefault(),
+                SOLAR_WEIGHT.getDefault(),
+                SOLAR_CYCLE_RATIO.getDefault(),
+                HARMONIC_WEIGHT.getDefault(),
+                RAIN_OFFSET_NORMALIZED.getDefault(),
+                THUNDER_OFFSET_NORMALIZED.getDefault(),
+                RIVER_OCEAN_SEARCH_RADIUS.getDefault(),
+                RIVER_OCEAN_SEARCH_STEP.getDefault(),
+                RIVER_INLAND_MIN_FACTOR.getDefault(),
+                TideConfigParsers.parseMultiplierMap(DIMENSION_AMPLITUDE_MULTIPLIERS.getDefault()),
+                TideConfigParsers.parseMultiplierMap(BIOME_AMPLITUDE_MULTIPLIERS.getDefault()),
                 CURRENT_STRENGTH.getDefault(),
                 PLAYER_PROXIMITY_BLOCKS.getDefault()
         );
@@ -86,6 +149,16 @@ public final class TideConfig {
             double oceanAmplitudeBlocks,
             double riverAmplitudeBlocks,
             double phaseOffsetMinutes,
+            double solarWeight,
+            double solarCycleRatio,
+            double harmonicWeight,
+            double rainOffsetNormalized,
+            double thunderOffsetNormalized,
+            int riverOceanSearchRadius,
+            int riverOceanSearchStep,
+            double riverInlandMinFactor,
+            Map<String, Double> dimensionAmplitudeOverrides,
+            Map<String, Double> biomeAmplitudeOverrides,
             double currentStrength,
             double playerProximityBlocks
     ) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideConfigParsers.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/Ocean/tide/TideConfigParsers.java
@@ -1,0 +1,38 @@
+package com.thunder.wildernessodysseyapi.ModPackPatches.Ocean.tide;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+final class TideConfigParsers {
+    private TideConfigParsers() {
+    }
+
+    static Map<String, Double> parseMultiplierMap(List<? extends String> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Double> results = new HashMap<>();
+        for (String entry : entries) {
+            if (entry == null || entry.isBlank()) {
+                continue;
+            }
+            String trimmed = entry.trim();
+            String[] parts = trimmed.split("=", 2);
+            if (parts.length != 2) {
+                ModConstants.LOGGER.warn("Invalid tide multiplier entry '{}'; expected format namespace:id=value", trimmed);
+                continue;
+            }
+            String key = parts[0].trim();
+            try {
+                double value = Double.parseDouble(parts[1].trim());
+                results.put(key, value);
+            } catch (NumberFormatException ex) {
+                ModConstants.LOGGER.warn("Invalid tide multiplier value '{}' in entry '{}'", parts[1], trimmed);
+            }
+        }
+        return Map.copyOf(results);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/TideInfoCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/TideInfoCommand.java
@@ -2,6 +2,7 @@ package com.thunder.wildernessodysseyapi.command;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
+import com.thunder.wildernessodysseyapi.ModPackPatches.Ocean.tide.TideAstronomy;
 import com.thunder.wildernessodysseyapi.ModPackPatches.Ocean.tide.TideManager;
 import com.thunder.wildernessodysseyapi.ModPackPatches.Ocean.tide.TideManager.TideSnapshot;
 import net.minecraft.commands.CommandSourceStack;
@@ -31,7 +32,7 @@ public final class TideInfoCommand {
         BlockPos pos = BlockPos.containing(source.getPosition());
 
         double amplitude = TideManager.getLocalAmplitude(level, pos);
-        double moonFactor = TideManager.getMoonPhaseAmplitudeFactor(level);
+        double moonFactor = TideAstronomy.getMoonPhaseAmplitudeFactor(level);
         double tideHeight = snapshot.normalizedHeight() * amplitude;
         double trendPerTick = snapshot.verticalChangePerTick() * amplitude;
         int moonPhase = level.getMoonPhase();


### PR DESCRIPTION
### Motivation
- Reduce responsibilities in `TideManager` by extracting biome/dimension/river amplitude logic so the manager focuses on state and sampling orchestration.
- Centralize astronomy and sampling math into a reusable helper so other consumers can call tide sampling and moon-phase logic without duplication.
- Allow per-dimension and per-biome amplitude multipliers to be provided as simple string lists in config and parsed into maps.

### Description
- Added `TideAmplitudeHelper` to encapsulate local amplitude calculation (biome checks, river->ocean attenuation, moon factor, and overrides) and wired `TideManager.getLocalAmplitude` to delegate to it.
- Added `TideConfigParsers` to parse list-based multiplier entries into `Map<String,Double>` and updated `TideConfig` to expose new config entries and parsed maps for dimensions and biomes.
- Added/kept `TideAstronomy` tide sampling logic and updated `TideManager` to use `TideAstronomy.computeTideSample(...)` and store both normalized height and `changePerTick` from the sample.
- Updated `TideInfoCommand` to use `TideAstronomy.getMoonPhaseAmplitudeFactor(...)` for reporting and adjusted manager state updates to accept the precomputed `changePerTick`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698243fd6b388328baeb5439435a1795)