### PR TITLE
Add lore book loot progression system

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -9,6 +9,7 @@ import com.thunder.wildernessodysseyapi.ModPackPatches.ModListTracker.commands.M
 import com.thunder.wildernessodysseyapi.command.GlobalChatCommand;
 import com.thunder.wildernessodysseyapi.command.GlobalChatOptToggleCommand;
 import com.thunder.wildernessodysseyapi.command.ChangelogCommand;
+import com.thunder.wildernessodysseyapi.command.LoreBookCommand;
 import com.thunder.wildernessodysseyapi.feedback.FeedbackCommand;
 import com.thunder.wildernessodysseyapi.feedback.FeedbackConfig;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
@@ -27,6 +28,9 @@ import com.thunder.wildernessodysseyapi.config.CurioRenderConfig;
 import com.thunder.wildernessodysseyapi.config.StructureBlockConfig;
 import com.thunder.wildernessodysseyapi.item.ModCreativeTabs;
 import com.thunder.wildernessodysseyapi.item.ModItems;
+import com.thunder.wildernessodysseyapi.lorebook.LoreBookEvents;
+import com.thunder.wildernessodysseyapi.lorebook.loot.ModLootConditions;
+import com.thunder.wildernessodysseyapi.lorebook.loot.ModLootFunctions;
 import com.thunder.wildernessodysseyapi.util.StructureBlockSettings;
 import com.thunder.wildernessodysseyapi.AI.AI_story.AIChatListener;
 import com.thunder.wildernessodysseyapi.donations.config.DonationReminderConfig;
@@ -106,6 +110,8 @@ public class WildernessOdysseyAPIMainModClass {
         ModProcessors.PROCESSORS.register(modEventBus);
         ModCreativeTabs.register(modEventBus);
         ModAttachments.ATTACHMENTS.register(modEventBus);
+        ModLootFunctions.LOOT_FUNCTIONS.register(modEventBus);
+        ModLootConditions.LOOT_CONDITIONS.register(modEventBus);
 
         // Register global events
         NeoForge.EVENT_BUS.register(this);
@@ -114,6 +120,7 @@ public class WildernessOdysseyAPIMainModClass {
         NeoForge.EVENT_BUS.register(PlayerTelemetryReporter.class);
         NeoForge.EVENT_BUS.register(EventTelemetryReporter.class);
         NeoForge.EVENT_BUS.register(TelemetryQueueProcessor.class);
+        NeoForge.EVENT_BUS.register(LoreBookEvents.class);
 
         CryoTubeBlock.register(modEventBus);
         ModItems.register(modEventBus);
@@ -192,6 +199,7 @@ public class WildernessOdysseyAPIMainModClass {
         StructurePlacementDebugCommand.register(event.getDispatcher());
         GlobalChatCommand.register(dispatcher);
         GlobalChatOptToggleCommand.register(dispatcher);
+        LoreBookCommand.register(dispatcher);
         TideInfoCommand.register(dispatcher);
         TelemetryConsentCommand.register(dispatcher);
         TelemetryQueueStatsCommand.register(dispatcher);

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/LoreBookCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/LoreBookCommand.java
@@ -1,0 +1,102 @@
+package com.thunder.wildernessodysseyapi.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.thunder.wildernessodysseyapi.lorebook.LoreBookConfig;
+import com.thunder.wildernessodysseyapi.lorebook.LoreBookManager;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.List;
+import java.util.Optional;
+
+public class LoreBookCommand {
+    private static final SuggestionProvider<CommandSourceStack> LORE_ID_SUGGESTIONS = (context, builder) -> {
+        for (LoreBookConfig.LoreBookEntry entry : LoreBookManager.config().books()) {
+            if (entry.id() != null) {
+                builder.suggest(entry.id());
+            }
+        }
+        return builder.buildFuture();
+    };
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("lorebook")
+                .then(Commands.literal("retrieve")
+                        .then(Commands.argument("id", StringArgumentType.string())
+                                .suggests(LORE_ID_SUGGESTIONS)
+                                .executes(context -> {
+                                    CommandSourceStack source = context.getSource();
+                                    if (!(source.getEntity() instanceof ServerPlayer player)) {
+                                        source.sendFailure(Component.literal("Players only."));
+                                        return 0;
+                                    }
+                                    String id = StringArgumentType.getString(context, "id");
+                                    if (!LoreBookManager.hasCollected(player, id)) {
+                                        source.sendFailure(Component.literal("You have not discovered that lore book yet."));
+                                        return 0;
+                                    }
+                                    Optional<LoreBookConfig.LoreBookEntry> entry = LoreBookManager.config().books().stream()
+                                            .filter(book -> id.equals(book.id()))
+                                            .findFirst();
+                                    if (entry.isEmpty()) {
+                                        source.sendFailure(Component.literal("Unknown lore book id."));
+                                        return 0;
+                                    }
+                                    giveBook(player, entry.get());
+                                    source.sendSuccess(() -> Component.literal("Lore book retrieved."), false);
+                                    return 1;
+                                })))
+                .then(Commands.literal("give")
+                        .requires(source -> source.hasPermission(2))
+                        .then(Commands.argument("targets", EntityArgument.players())
+                                .then(Commands.argument("id", StringArgumentType.string())
+                                        .suggests(LORE_ID_SUGGESTIONS)
+                                        .executes(context -> {
+                                            String id = StringArgumentType.getString(context, "id");
+                                            Optional<LoreBookConfig.LoreBookEntry> entry = LoreBookManager.config().books().stream()
+                                                    .filter(book -> id.equals(book.id()))
+                                                    .findFirst();
+                                            if (entry.isEmpty()) {
+                                                context.getSource().sendFailure(Component.literal("Unknown lore book id."));
+                                                return 0;
+                                            }
+                                            List<ServerPlayer> players = EntityArgument.getPlayers(context, "targets");
+                                            for (ServerPlayer player : players) {
+                                                giveBook(player, entry.get());
+                                            }
+                                            context.getSource().sendSuccess(() -> Component.literal("Lore book given."), true);
+                                            return players.size();
+                                        })))))
+                .then(Commands.literal("give_next")
+                        .requires(source -> source.hasPermission(2))
+                        .then(Commands.argument("targets", EntityArgument.players())
+                                .executes(context -> {
+                                    List<ServerPlayer> players = EntityArgument.getPlayers(context, "targets");
+                                    int given = 0;
+                                    for (ServerPlayer player : players) {
+                                        Optional<LoreBookConfig.LoreBookEntry> entry = LoreBookManager.nextEntry(player);
+                                        if (entry.isPresent()) {
+                                            giveBook(player, entry.get());
+                                            given++;
+                                        }
+                                    }
+                                    if (given == 0) {
+                                        context.getSource().sendFailure(Component.literal("No pending lore books for targets."));
+                                        return 0;
+                                    }
+                                    context.getSource().sendSuccess(() -> Component.literal("Next lore books delivered."), true);
+                                    return given;
+                                })))
+        );
+    }
+
+    private static void giveBook(ServerPlayer player, LoreBookConfig.LoreBookEntry entry) {
+        player.getInventory().placeItemBackInInventory(LoreBookManager.createBookStack(entry));
+        LoreBookManager.markCollected(player, entry.id());
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/lorebook/LoreBookConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/lorebook/LoreBookConfig.java
@@ -1,0 +1,77 @@
+package com.thunder.wildernessodysseyapi.lorebook;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.neoforged.fml.loading.FMLPaths;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LoreBookConfig {
+    public static final String CONFIG_NAME = "lore_books.json";
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private float chance = 0.03f;
+    private List<LoreBookEntry> books = new ArrayList<>();
+
+    public float chance() {
+        return chance;
+    }
+
+    public List<LoreBookEntry> books() {
+        return books;
+    }
+
+    public static LoreBookConfig load() {
+        Path configPath = FMLPaths.CONFIGDIR.get().resolve(ModConstants.MOD_ID).resolve(CONFIG_NAME);
+        ensureDefaultConfig(configPath);
+        if (!Files.exists(configPath)) {
+            return new LoreBookConfig();
+        }
+        try (BufferedReader reader = Files.newBufferedReader(configPath, StandardCharsets.UTF_8)) {
+            LoreBookConfig config = GSON.fromJson(reader, LoreBookConfig.class);
+            if (config == null) {
+                return new LoreBookConfig();
+            }
+            if (config.books == null) {
+                config.books = new ArrayList<>();
+            }
+            return config;
+        } catch (IOException | JsonParseException e) {
+            ModConstants.LOGGER.warn("Failed to read lore books config at {}.", configPath, e);
+            return new LoreBookConfig();
+        }
+    }
+
+    private static void ensureDefaultConfig(Path configPath) {
+        if (Files.exists(configPath)) {
+            return;
+        }
+        try {
+            Files.createDirectories(configPath.getParent());
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to create config directory for lore books.", e);
+            return;
+        }
+        try (InputStream in = LoreBookConfig.class.getResourceAsStream("/config/" + ModConstants.MOD_ID + "/" + CONFIG_NAME)) {
+            if (in == null) {
+                return;
+            }
+            Files.copy(in, configPath);
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed to seed default lore books config at {}.", configPath, e);
+        }
+    }
+
+    public record LoreBookEntry(String id, String title, String author, List<String> pages) {
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/lorebook/LoreBookEvents.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/lorebook/LoreBookEvents.java
@@ -1,0 +1,45 @@
+package com.thunder.wildernessodysseyapi.lorebook;
+
+import com.thunder.wildernessodysseyapi.lorebook.loot.LoreBookAvailableCondition;
+import com.thunder.wildernessodysseyapi.lorebook.loot.LoreBookLootFunction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.storage.loot.LootPool;
+import net.minecraft.world.level.storage.loot.entries.LootItem;
+import net.minecraft.world.level.storage.loot.predicates.LootItemRandomChanceCondition;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.neoforged.neoforge.event.LootTableLoadEvent;
+import net.neoforged.neoforge.event.tick.PlayerTickEvent;
+import net.neoforged.neoforge.eventbus.api.SubscribeEvent;
+
+public class LoreBookEvents {
+    @SubscribeEvent
+    public static void onLootTableLoad(LootTableLoadEvent event) {
+        ResourceLocation id = event.getName();
+        if (id == null || !id.getPath().startsWith("chests/")) {
+            return;
+        }
+        float chance = LoreBookManager.config().chance();
+        if (chance <= 0f) {
+            return;
+        }
+        LootPool pool = LootPool.lootPool()
+                .setRolls(ConstantValue.exactly(1))
+                .add(LootItem.lootTableItem(Items.WRITTEN_BOOK)
+                        .when(LootItemRandomChanceCondition.randomChance(chance))
+                        .when(new LoreBookAvailableCondition())
+                        .apply(LoreBookLootFunction.builder()))
+                .build();
+        event.getTable().addPool(pool);
+    }
+
+    @SubscribeEvent
+    public static void onPlayerTick(PlayerTickEvent.Post event) {
+        if (event.getEntity().level().isClientSide()) {
+            return;
+        }
+        if (event.getEntity() instanceof net.minecraft.server.level.ServerPlayer player) {
+            LoreBookManager.scanInventory(player);
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/lorebook/LoreBookManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/lorebook/LoreBookManager.java
@@ -1,0 +1,131 @@
+package com.thunder.wildernessodysseyapi.lorebook;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public final class LoreBookManager {
+    public static final String LORE_ID_TAG = ModConstants.MOD_ID + ":lore_id";
+    private static final String ROOT_TAG = ModConstants.MOD_ID + "_lore_books";
+    private static final String COLLECTED_TAG = "collected";
+    private static final String LAST_SCAN_TAG = "last_scan";
+    private static final long SCAN_INTERVAL_TICKS = 40L;
+
+    private static volatile LoreBookConfig cachedConfig;
+
+    private LoreBookManager() {
+    }
+
+    public static LoreBookConfig config() {
+        if (cachedConfig == null) {
+            cachedConfig = LoreBookConfig.load();
+        }
+        return cachedConfig;
+    }
+
+    public static Optional<LoreBookConfig.LoreBookEntry> nextEntry(ServerPlayer player) {
+        Set<String> collected = getCollected(player);
+        for (LoreBookConfig.LoreBookEntry entry : config().books()) {
+            if (entry.id() == null || entry.id().isBlank()) {
+                continue;
+            }
+            if (!collected.contains(entry.id())) {
+                return Optional.of(entry);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static boolean hasCollected(ServerPlayer player, String id) {
+        return getCollected(player).contains(id);
+    }
+
+    public static void markCollected(ServerPlayer player, String id) {
+        if (id == null || id.isBlank()) {
+            return;
+        }
+        CompoundTag root = player.getPersistentData().getCompound(ROOT_TAG);
+        ListTag list = root.getList(COLLECTED_TAG, StringTag.TAG_STRING);
+        for (int i = 0; i < list.size(); i++) {
+            if (id.equals(list.getString(i))) {
+                player.getPersistentData().put(ROOT_TAG, root);
+                return;
+            }
+        }
+        list.add(StringTag.valueOf(id));
+        root.put(COLLECTED_TAG, list);
+        player.getPersistentData().put(ROOT_TAG, root);
+    }
+
+    public static Set<String> getCollected(ServerPlayer player) {
+        CompoundTag root = player.getPersistentData().getCompound(ROOT_TAG);
+        ListTag list = root.getList(COLLECTED_TAG, StringTag.TAG_STRING);
+        Set<String> collected = new HashSet<>();
+        for (int i = 0; i < list.size(); i++) {
+            collected.add(list.getString(i));
+        }
+        return collected;
+    }
+
+    public static ItemStack createBookStack(LoreBookConfig.LoreBookEntry entry) {
+        ItemStack stack = new ItemStack(Items.WRITTEN_BOOK);
+        CompoundTag tag = stack.getOrCreateTag();
+        String title = entry.title() == null ? "Lore" : entry.title();
+        String author = entry.author() == null ? "Unknown" : entry.author();
+        tag.putString("title", title);
+        tag.putString("author", author);
+        ListTag pages = new ListTag();
+        if (entry.pages() != null) {
+            for (String page : entry.pages()) {
+                String safePage = page == null ? "" : page;
+                pages.add(StringTag.valueOf(Component.Serializer.toJson(Component.literal(safePage))));
+            }
+        }
+        tag.put("pages", pages);
+        String id = entry.id() == null ? "" : entry.id();
+        tag.putString(LORE_ID_TAG, id);
+        return stack;
+    }
+
+    public static Optional<String> loreIdFrom(ItemStack stack) {
+        if (!stack.is(Items.WRITTEN_BOOK)) {
+            return Optional.empty();
+        }
+        CompoundTag tag = stack.getTag();
+        if (tag == null || !tag.contains(LORE_ID_TAG)) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(tag.getString(LORE_ID_TAG));
+    }
+
+    public static void scanInventory(ServerPlayer player) {
+        CompoundTag root = player.getPersistentData().getCompound(ROOT_TAG);
+        long lastScan = root.getLong(LAST_SCAN_TAG);
+        long gameTime = player.level().getGameTime();
+        if (gameTime - lastScan < SCAN_INTERVAL_TICKS) {
+            return;
+        }
+        root.putLong(LAST_SCAN_TAG, gameTime);
+        player.getPersistentData().put(ROOT_TAG, root);
+
+        scanStacks(player.getInventory().items, player);
+        scanStacks(player.getInventory().armor, player);
+        scanStacks(player.getInventory().offhand, player);
+    }
+
+    private static void scanStacks(List<ItemStack> stacks, ServerPlayer player) {
+        for (ItemStack stack : stacks) {
+            loreIdFrom(stack).ifPresent(id -> markCollected(player, id));
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/LoreBookAvailableCondition.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/LoreBookAvailableCondition.java
@@ -1,0 +1,26 @@
+package com.thunder.wildernessodysseyapi.lorebook.loot;
+
+import com.mojang.serialization.MapCodec;
+import com.thunder.wildernessodysseyapi.lorebook.LoreBookManager;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+
+public class LoreBookAvailableCondition implements LootItemCondition {
+    public static final MapCodec<LoreBookAvailableCondition> CODEC = MapCodec.unit(LoreBookAvailableCondition::new);
+
+    @Override
+    public LootItemConditionType getType() {
+        return ModLootConditions.LORE_BOOK_AVAILABLE.get();
+    }
+
+    @Override
+    public boolean test(LootContext lootContext) {
+        if (!(lootContext.getParamOrNull(LootContextParams.THIS_ENTITY) instanceof ServerPlayer player)) {
+            return false;
+        }
+        return LoreBookManager.nextEntry(player).isPresent();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/LoreBookLootFunction.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/LoreBookLootFunction.java
@@ -1,0 +1,41 @@
+package com.thunder.wildernessodysseyapi.lorebook.loot;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.thunder.wildernessodysseyapi.lorebook.LoreBookManager;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.functions.LootItemConditionalFunction;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+
+public class LoreBookLootFunction extends LootItemConditionalFunction {
+    public static final MapCodec<LoreBookLootFunction> CODEC = RecordCodecBuilder.mapCodec(instance ->
+            commonFields(instance).apply(instance, LoreBookLootFunction::new)
+    );
+
+    protected LoreBookLootFunction(LootItemCondition[] conditions) {
+        super(conditions);
+    }
+
+    @Override
+    public LootItemFunctionType getType() {
+        return ModLootFunctions.LORE_BOOK.get();
+    }
+
+    @Override
+    protected ItemStack run(ItemStack stack, LootContext lootContext) {
+        if (!(lootContext.getParamOrNull(LootContextParams.THIS_ENTITY) instanceof ServerPlayer player)) {
+            return ItemStack.EMPTY;
+        }
+        return LoreBookManager.nextEntry(player)
+                .map(LoreBookManager::createBookStack)
+                .orElse(ItemStack.EMPTY);
+    }
+
+    public static Builder<?> builder() {
+        return simpleBuilder(LoreBookLootFunction::new);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/ModLootConditions.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/ModLootConditions.java
@@ -1,0 +1,18 @@
+package com.thunder.wildernessodysseyapi.lorebook.loot;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public final class ModLootConditions {
+    public static final DeferredRegister<LootItemConditionType> LOOT_CONDITIONS =
+            DeferredRegister.create(Registries.LOOT_CONDITION_TYPE, ModConstants.MOD_ID);
+
+    public static final DeferredHolder<LootItemConditionType, LootItemConditionType> LORE_BOOK_AVAILABLE =
+            LOOT_CONDITIONS.register("lore_book_available", () -> new LootItemConditionType(LoreBookAvailableCondition.CODEC));
+
+    private ModLootConditions() {
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/ModLootFunctions.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/ModLootFunctions.java
@@ -1,0 +1,18 @@
+package com.thunder.wildernessodysseyapi.lorebook.loot;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public final class ModLootFunctions {
+    public static final DeferredRegister<LootItemFunctionType> LOOT_FUNCTIONS =
+            DeferredRegister.create(Registries.LOOT_FUNCTION_TYPE, ModConstants.MOD_ID);
+
+    public static final DeferredHolder<LootItemFunctionType, LootItemFunctionType> LORE_BOOK =
+            LOOT_FUNCTIONS.register("lore_book", () -> new LootItemFunctionType(LoreBookLootFunction.CODEC));
+
+    private ModLootFunctions() {
+    }
+}

--- a/src/main/resources/config/wildernessodysseyapi/lore_books.json
+++ b/src/main/resources/config/wildernessodysseyapi/lore_books.json
@@ -1,0 +1,14 @@
+{
+  "chance": 0.03,
+  "books": [
+    {
+      "id": "lore_001",
+      "title": "Lore Book I",
+      "author": "Archivist",
+      "pages": [
+        "The first entry in the wilderness archive.",
+        "More pages can be added here to expand the story."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a configurable lore-book system that places rare, sequential lore books into chest loot so players discover the story in order.
- Allow server operators and players to retrieve lost lore books via command and prevent players from finding the same book multiple times.

### Description
- Added a configuration loader `LoreBookConfig` and a default config at `src/main/resources/config/wildernessodysseyapi/lore_books.json` to customize book content and spawn chance via `lore_books.json`.
- Implemented `LoreBookManager` to create written-book ItemStacks with a lore id, track per-player collection state in persistent player NBT, and provide `nextEntry` logic to enforce sequential discovery.
- Injected loot by adding `LoreBookEvents` which listens to `LootTableLoadEvent` and appends a WRITTEN_BOOK pool guarded by a rarity chance and a `LoreBookAvailableCondition`; added `LoreBookLootFunction` to produce the next undiscovered lore book for the looted player.
- Added registration helpers `ModLootFunctions` and `ModLootConditions` and wired everything into the mod main class (`WildernessOdysseyAPIMainModClass`) so the loot functions/conditions and `LoreBookEvents` are registered at startup.
- Added the `lorebook` command (`LoreBookCommand`) with subcommands `retrieve <id>` for players, and `give <targets> <id>` / `give_next <targets>` for admins to give specific or next lore books and to mark them collected.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69825868d3648328a576e956296605e6)