### PR TITLE
Harden global chat relay: timeouts, malformed-packet handling, per-IP rate limits, external whitelist

### DIFF
--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -3,7 +3,7 @@
 The global chat system lets multiple Wilderness Odyssey servers share messages through a lightweight relay process. This guide covers how to anchor the relay to a specific dedicated server, connect other servers, and use moderation/opt-in controls.
 
 ## Components
-- **Relay server**: External JVM process that accepts TCP connections, relays chat, enforces rate limits/bans, and handles admin actions.
+- **Relay server**: External JVM process that accepts TCP connections, relays chat, enforces per-server and per-IP rate limits, applies bans/timeouts, and handles admin actions.
 - **Embedded client**: Runs inside each Minecraft server JVM after you bind it to a relay host and port. It keeps a downtime history, tracks ping, and fans out messages only to opted-in players.
 - **Commands**: Registered under `/globalchat` for binding, status checks, opt-in, messaging, relay lifecycle, and moderation.
 
@@ -66,7 +66,8 @@ Moderation commands require a valid token (set via `/globalchat moderationtoken 
 - During the handshake, the relay rejects clients whose `HELLO` packets lack the matching `clusterToken`, ensuring only authorized servers and whitelisted external IPs can participate.
 
 ### Connection trust and whitelisting
-- The relay only accepts Minecraft clients by default. Each client performs a handshake declaring itself as a Minecraft node and is rejected if it skips this step.
+- The relay only accepts Minecraft clients by default. Each client performs a HELLO handshake declaring itself as a Minecraft node and is rejected if it skips this step.
+- Relay ingestion is hardened against malformed packets and idle connections (30s handshake/read timeout), reducing stale-socket and parser abuse risk.
 - If you need to let a non-Minecraft tool (for example, an external bot) talk in global chat, start the relay with a comma-separated whitelist of trusted IPs:
   ```bash
   java -Dwilderness.globalchat.token=<moderationToken> \


### PR DESCRIPTION
### Motivation
- Reduce attack surface and resource abuse of the standalone global chat relay by closing idle/stale sockets and rejecting malformed input early. 
- Prevent spam amplification from many connections behind one host by introducing an IP-level quota in addition to the existing per-client quota. 
- Allow trusted non-Minecraft clients via IP whitelist while keeping the default behavior locked to Minecraft server clients. 

### Description
- Added a 30s socket read timeout and explicit malformed-JSON handling in `GlobalChatRelayServer.handleClient` to close idle or bad connections quickly. (`socket.setSoTimeout(30_000)` and try/catch around `GSON.fromJson`).
- Introduced per-IP rate limiting with `MAX_MESSAGES_PER_IP_PER_MINUTE`, an `ipQuotas` map, and `QuotaWindow` to track and throttle IP-based message bursts; idle quota windows are cleaned up in `cleanupExpiredBans`.
- Added support for `clientType=external` handshakes but only allow them when the source IP is present in the relay whitelist (`wilderness.globalchat.whitelist`); non-whitelisted externals are rejected.
- Relaxed startup cluster token requirement so an empty cluster token is permitted at startup while still enforcing token checks during HELLO when a cluster token is configured.
- Minor imports and concurrency type adjustments (`SocketTimeoutException`, `ConcurrentMap`).
- Updated `docs/global-chat.md` to document per-IP throttling and handshake hardening (30s read timeout and malformed packet handling).

### Testing
- Ran `./gradlew compileJava --no-daemon` to validate compilation, which failed in this environment because a Java 21 toolchain could not be auto-provisioned (foojay provisioning unreachable), so compile could not complete.  
- No unit or integration tests were run in this environment due to the toolchain provisioning failure; the changes are limited to server-side relay ingress and should be safe to validate with a local Java 21 JDK by running `./gradlew compileJava` and exercising relay connections (Minecraft client HELLO, whitelisted external client, malformed packets, and high-rate message bursts).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d4b87b2c8328833194541ccde8c2)