### PR TITLE
Fix generic type mismatch in loot function registration

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/ModLootFunctions.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/ModLootFunctions.java
@@ -7,10 +7,10 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 public final class ModLootFunctions {
-    public static final DeferredRegister<LootItemFunctionType> LOOT_FUNCTIONS =
+    public static final DeferredRegister<LootItemFunctionType<?>> LOOT_FUNCTIONS =
             DeferredRegister.create(Registries.LOOT_FUNCTION_TYPE, ModConstants.MOD_ID);
 
-    public static final DeferredHolder<LootItemFunctionType, LootItemFunctionType> LORE_BOOK =
+    public static final DeferredHolder<LootItemFunctionType<?>, LootItemFunctionType<?>> LORE_BOOK =
             LOOT_FUNCTIONS.register("lore_book", () -> new LootItemFunctionType(LoreBookLootFunction.CODEC));
 
     private ModLootFunctions() {


### PR DESCRIPTION
### Motivation
- Resolve a Java type inference error when registering a loot function by matching the registry's wildcarded type `LootItemFunctionType<?>` expected by `Registries.LOOT_FUNCTION_TYPE`.

### Description
- Update `ModLootFunctions.java` to use `DeferredRegister<LootItemFunctionType<?>>` for `LOOT_FUNCTIONS` and `DeferredHolder<LootItemFunctionType<?>, LootItemFunctionType<?>>` for `LORE_BOOK`.

### Testing
- Ran `./gradlew compileJava -q`, but the build could not complete because the environment lacked a Java 21 toolchain and Gradle toolchain auto-provisioning failed (HTTP 503), so compilation could not be verified locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e8cfa8f88328a9fb45309b2dd820)