### PR TITLE
Fix lore book loot condition builder usage

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/lorebook/LoreBookEvents.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/lorebook/LoreBookEvents.java
@@ -6,7 +6,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.entries.LootItem;
-import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
 import net.minecraft.world.level.storage.loot.predicates.LootItemRandomChanceCondition;
 import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -28,7 +27,7 @@ public class LoreBookEvents {
                 .setRolls(ConstantValue.exactly(1))
                 .add(LootItem.lootTableItem(Items.WRITTEN_BOOK)
                         .when(LootItemRandomChanceCondition.randomChance(chance))
-                        .when((LootItemCondition.Builder) new LoreBookAvailableCondition())
+                        .when(LoreBookAvailableCondition.builder())
                         .apply(LoreBookLootFunction.builder()))
                 .build();
         event.getTable().addPool(pool);

--- a/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/LoreBookAvailableCondition.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/lorebook/loot/LoreBookAvailableCondition.java
@@ -11,6 +11,10 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
 public class LoreBookAvailableCondition implements LootItemCondition {
     public static final MapCodec<LoreBookAvailableCondition> CODEC = MapCodec.unit(LoreBookAvailableCondition::new);
 
+    public static LootItemCondition.Builder builder() {
+        return LoreBookAvailableCondition::new;
+    }
+
     @Override
     public LootItemConditionType getType() {
         return ModLootConditions.LORE_BOOK_AVAILABLE.get();


### PR DESCRIPTION
### Motivation
- Prevent a `ClassCastException` during loot table setup by removing an unsafe cast and providing a proper `LootItemCondition.Builder` for the lore book condition.

### Description
- Add a static `builder()` helper `LoreBookAvailableCondition.builder()` that returns a `LootItemCondition.Builder`, and update `LoreBookEvents` to call `LoreBookAvailableCondition.builder()` instead of casting an instance to `LootItemCondition.Builder`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698610f5edec832885a33ebc25b006a7)