### PR TITLE
Add resilience4j runtime dependency for local model client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,8 @@ dependencies {
     // Bundle third-party libraries into the final mod jar (Jar-in-Jar) to avoid missing-class errors at runtime.
     jarJar(implementation('com.squareup.okhttp3:okhttp:4.12.0'))
     jarJar(implementation('com.squareup.okio:okio:3.9.0'))
-    jarJar(implementation('io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'))
+    implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
+    jarJar 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
     jarJar(implementation('com.github.luben:zstd-jni:1.5.7-6'))
 
     additionalRuntimeClasspath 'org.yaml:snakeyaml:2.2'


### PR DESCRIPTION
### Motivation
- Startup crash logs showed a `NoClassDefFoundError` for `io.github.resilience4j.circuitbreaker.CallNotPermittedException` when `LocalModelClient` initialized, indicating the circuit-breaker library was missing at runtime.
- The change ensures the resilience4j library is available on the runtime classpath while preserving the existing jar-in-jar packaging to avoid missing-class issues across environments.

### Description
- Added `implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'` to the `dependencies` block in `build.gradle`.
- Kept the `jarJar 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'` entry so the dependency remains bundled into the final mod jar.
- No source code changes were made to Java classes.

### Testing
- No automated tests were executed for this change.
- A follow-up build/run (for example `./gradlew build` or launching the dev run) is recommended to validate the runtime resolution of the resilience4j classes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698612f1db5c8328a0dcb70d6b9deadb)