### PR TITLE
Bundle resilience4j circuitbreaker with jar-in-jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,8 +168,7 @@ dependencies {
     // Bundle third-party libraries into the final mod jar (Jar-in-Jar) to avoid missing-class errors at runtime.
     jarJar(implementation('com.squareup.okhttp3:okhttp:4.12.0'))
     jarJar(implementation('com.squareup.okio:okio:3.9.0'))
-    implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
-    jarJar 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
+    jarJar(implementation('io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'))
     jarJar(implementation('com.github.luben:zstd-jni:1.5.7-6'))
 
     additionalRuntimeClasspath 'org.yaml:snakeyaml:2.2'


### PR DESCRIPTION
### Motivation
- Prevent runtime `NoClassDefFoundError` for resilience4j (missing `io.github.resilience4j.circuitbreaker.CallNotPermittedException`) by ensuring the library is bundled into the final mod jar.

### Description
- Replace the separate `implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'` + `jarJar` declaration with a single `jarJar(implementation('io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'))` entry in `build.gradle` so the dependency is included via the jar-in-jar bundling mechanism.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862fc06ecc8328b0a5377c4cc145ad)