### PR TITLE
Add resilience4j to local runtime classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,7 @@ dependencies {
     jarJar(implementation('com.github.luben:zstd-jni:1.5.7-6'))
 
     additionalRuntimeClasspath 'org.yaml:snakeyaml:2.2'
+    localRuntime 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.


### PR DESCRIPTION
### Motivation
- The dev/run environment was throwing `NoClassDefFoundError` for `io.github.resilience4j.circuitbreaker.CallNotPermittedException` during AI client initialization, so the circuitbreaker library must be present on the local runtime classpath.

### Description
- Add `localRuntime 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'` to the `dependencies` block in `build.gradle` so the resilience4j circuitbreaker classes are available during dev runs while keeping the library jar-bundled for the final mod.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986332edf148328ad10580c6a48b550)