### PR TITLE
Add resilience4j to runtime classpath for dev runs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,8 @@ dependencies {
     jarJar(implementation('com.github.luben:zstd-jni:1.5.7-6'))
 
     additionalRuntimeClasspath 'org.yaml:snakeyaml:2.2'
+    additionalRuntimeClasspath 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
+    additionalRuntimeClasspath 'io.github.resilience4j:resilience4j-core:2.2.0'
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.


### PR DESCRIPTION
### Motivation
- Prevent `NoClassDefFoundError` / `ClassNotFoundException` for `io.github.resilience4j` classes that surface during development run-time (seen in server logs) by ensuring the resilience4j artifacts are available on the dev runtime classpath.

### Description
- Add `additionalRuntimeClasspath 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'` and `additionalRuntimeClasspath 'io.github.resilience4j:resilience4j-core:2.2.0'` to `build.gradle` so the resilience4j runtime classes are present for dev runs alongside the existing `jarJar` bundling.

### Testing
- No automated tests were run after this change (no `gradle` tasks or unit tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986359785cc8328ac084dfd9f94fb37)