### PR TITLE
Replace resilience4j usage with local circuit breaker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,12 +168,9 @@ dependencies {
     // Bundle third-party libraries into the final mod jar (Jar-in-Jar) to avoid missing-class errors at runtime.
     jarJar(implementation('com.squareup.okhttp3:okhttp:4.12.0'))
     jarJar(implementation('com.squareup.okio:okio:3.9.0'))
-    jarJar(implementation('io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'))
     jarJar(implementation('com.github.luben:zstd-jni:1.5.7-6'))
 
     additionalRuntimeClasspath 'org.yaml:snakeyaml:2.2'
-    additionalRuntimeClasspath 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
-    additionalRuntimeClasspath 'io.github.resilience4j:resilience4j-core:2.2.0'
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.


### PR DESCRIPTION
### Motivation
- Prevent runtime `NoClassDefFoundError` for `io.github.resilience4j` by removing the external circuit-breaker dependency and providing an internal, minimal circuit-breaker implementation.

### Description
- Replace use of `resilience4j` in `LocalModelClient` with an embedded `SimpleCircuitBreaker` and a `CircuitBreakerOpenException` to preserve existing open-breaker control flow and logging behavior.
- Remove `resilience4j` entries from `build.gradle` so the project no longer depends on the external circuit-breaker library.
- Keep existing HTTP request handling and logging paths while mapping resilience actions (`tryAcquirePermission`, `onSuccess`, `onError`) to the new local implementation.
- Modified files: `src/main/java/com/thunder/wildernessodysseyapi/AI/AI_story/LocalModelClient.java` and `build.gradle`.

### Testing
- No automated tests were run as part of this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863764f508832887e30a0e761bf89e)