### PR TITLE
Fix debug overlay animation for NeoForge 1.21

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/DebugOverlayAnimationHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/DebugOverlayAnimationHandler.java
@@ -13,10 +13,7 @@ public final class DebugOverlayAnimationHandler {
     }
 
     @SubscribeEvent
-    public static void onClientTick(ClientTickEvent event) {
-        if (event.phase != TickEvent.Phase.END) {
-            return;
-        }
+    public static void onClientTick(ClientTickEvent.Post event) {
         DebugOverlayAnimator.tick(Minecraft.getInstance());
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/DebugOverlayAnimator.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/DebugOverlayAnimator.java
@@ -2,6 +2,7 @@ package com.thunder.wildernessodysseyapi.ModPackPatches.client;
 
 import com.thunder.wildernessodysseyapi.config.DebugOverlayConfig;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.DebugScreenOverlay;
 import net.minecraft.util.Mth;
 
 public final class DebugOverlayAnimator {
@@ -18,7 +19,12 @@ public final class DebugOverlayAnimator {
             return;
         }
 
-        boolean renderDebug = minecraft.options.renderDebug;
+        DebugScreenOverlay debugOverlay = minecraft.getDebugOverlay();
+        if (debugOverlay == null) {
+            return;
+        }
+
+        boolean renderDebug = debugOverlay.showDebugScreen();
         if (!DebugOverlayConfig.ENABLE_ANIMATION.get()) {
             progress = renderDebug ? 1f : 0f;
             targetVisible = renderDebug;
@@ -39,11 +45,11 @@ public final class DebugOverlayAnimator {
                 : Math.max(0f, progress - step);
 
         if (!targetVisible && progress > 0f && !renderDebug) {
-            setRenderDebug(minecraft, true);
+            setRenderDebug(debugOverlay, true);
         } else if (!targetVisible && progress <= 0f && renderDebug) {
-            setRenderDebug(minecraft, false);
+            setRenderDebug(debugOverlay, false);
         } else if (targetVisible && !renderDebug) {
-            setRenderDebug(minecraft, true);
+            setRenderDebug(debugOverlay, true);
         }
     }
 
@@ -54,10 +60,10 @@ public final class DebugOverlayAnimator {
         return Mth.clamp(progress, 0f, 1f);
     }
 
-    private static void setRenderDebug(Minecraft minecraft, boolean value) {
-        if (minecraft.options.renderDebug != value) {
+    private static void setRenderDebug(DebugScreenOverlay debugOverlay, boolean value) {
+        if (debugOverlay.showDebugScreen() != value) {
             suppressUpdate = true;
-            minecraft.options.renderDebug = value;
+            debugOverlay.toggleOverlay();
             lastRenderDebug = value;
         }
     }


### PR DESCRIPTION
### Motivation
- NeoForge / Minecraft 1.21 removed/changed the old `Options.renderDebug` usage and the client tick event shape, so the overlay animation code needed to follow the new API.
- The goal is to keep the debug overlay animation working by reading and toggling the overlay via the `DebugScreenOverlay` API and firing on the correct client tick event.

### Description
- Updated the tick handler to subscribe to `ClientTickEvent.Post` instead of inspecting a removed `phase` field on the tick event. 
- Replaced direct access to `minecraft.options.renderDebug` with `minecraft.getDebugOverlay().showDebugScreen()` and added a null guard for the overlay.
- Replaced assignment to the removed `renderDebug` field with `DebugScreenOverlay.toggleOverlay()` to toggle visibility, and adjusted the helper `setRenderDebug` signature accordingly.
- Added the required `DebugScreenOverlay` import and safe-guard checks to avoid NPEs when the overlay is not present.

### Testing
- Ran `./gradlew :compileJava --no-daemon` which failed due to an external SSL handshake error while downloading the Mojang version manifest (task `:createMinecraftArtifacts` failed with `SSLHandshakeException`), so the Java compilation could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a431c83e4832882654bb83129e053)