### PR TITLE
Prevent neural frame unequip; use inventory item for curios equip; fix neural frame texture

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Client/ChipSetCurioRenderer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Client/ChipSetCurioRenderer.java
@@ -42,7 +42,7 @@ public class ChipSetCurioRenderer implements ICurioRenderer {
             humanoidModel.head.translateAndRotate(poseStack);
         }
 
-        poseStack.translate(0.35F, -0.2F, 0.0F);
+        poseStack.translate(0.35F, -0.2F, 0.25F);
         poseStack.scale(0.35F, 0.35F, 0.35F);
 
         Minecraft.getInstance().getItemRenderer().renderStatic(

--- a/src/main/java/com/thunder/wildernessodysseyapi/curios/CuriosIntegration.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/curios/CuriosIntegration.java
@@ -37,14 +37,40 @@ public final class CuriosIntegration {
 
         ICurioStacksHandler stacksHandler = stacksHandlerOptional.get();
         int slots = stacksHandler.getSlots();
+        int emptySlot = -1;
         for (int i = 0; i < slots; i++) {
             ItemStack existing = stacksHandler.getStacks().getStackInSlot(i);
             if (existing.isEmpty()) {
-                stacksHandler.getStacks().setStackInSlot(i, new ItemStack(item));
-                return true;
+                emptySlot = i;
+                break;
             }
         }
 
-        return false;
+        if (emptySlot == -1) {
+            return false;
+        }
+
+        ItemStack sourceStack = ItemStack.EMPTY;
+        int sourceIndex = -1;
+        for (int i = 0; i < player.getInventory().getContainerSize(); i++) {
+            ItemStack stack = player.getInventory().getItem(i);
+            if (stack.is(item)) {
+                sourceStack = stack;
+                sourceIndex = i;
+                break;
+            }
+        }
+
+        if (sourceStack.isEmpty() || sourceIndex == -1) {
+            return false;
+        }
+
+        ItemStack equippedStack = sourceStack.split(1);
+        if (sourceStack.isEmpty()) {
+            player.getInventory().setItem(sourceIndex, ItemStack.EMPTY);
+        }
+
+        stacksHandler.getStacks().setStackInSlot(emptySlot, equippedStack);
+        return true;
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/curios/CuriosIntegration.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/curios/CuriosIntegration.java
@@ -3,6 +3,7 @@ package com.thunder.wildernessodysseyapi.curios;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.InteractionHand;
 import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.type.capability.ICuriosItemHandler;
 import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
@@ -72,5 +73,46 @@ public final class CuriosIntegration {
 
         stacksHandler.getStacks().setStackInSlot(emptySlot, equippedStack);
         return true;
+    }
+
+    public static boolean equipFromHand(Player player, InteractionHand hand, String slot) {
+        ItemStack heldStack = player.getItemInHand(hand);
+        if (heldStack.isEmpty()) {
+            return false;
+        }
+
+        Optional<ICuriosItemHandler> handlerOptional = CuriosApi.getCuriosInventory(player);
+        if (handlerOptional.isEmpty()) {
+            return false;
+        }
+
+        ICuriosItemHandler handler = handlerOptional.get();
+        if (handler.isEquipped(heldStack.getItem())) {
+            return false;
+        }
+
+        Optional<ICurioStacksHandler> stacksHandlerOptional = handler.getStacksHandler(slot);
+        if (stacksHandlerOptional.isEmpty()) {
+            return false;
+        }
+
+        ICurioStacksHandler stacksHandler = stacksHandlerOptional.get();
+        int slots = stacksHandler.getSlots();
+        for (int i = 0; i < slots; i++) {
+            ItemStack existing = stacksHandler.getStacks().getStackInSlot(i);
+            if (!existing.isEmpty()) {
+                continue;
+            }
+
+            ItemStack equippedStack = heldStack.split(1);
+            if (heldStack.isEmpty()) {
+                player.setItemInHand(hand, ItemStack.EMPTY);
+            }
+
+            stacksHandler.getStacks().setStackInSlot(i, equippedStack);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/chip/ChipSetItem.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/chip/ChipSetItem.java
@@ -1,15 +1,21 @@
 package com.thunder.wildernessodysseyapi.item.chip;
 
 import com.thunder.wildernessodysseyapi.item.ModItemTags;
+import com.thunder.wildernessodysseyapi.curios.CuriosIntegration;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 public class ChipSetItem extends Item implements ICurioItem {
+    public static final String CHIP_SET_SLOT = "chip_set";
     private static final int NAUSEA_DURATION_TICKS = 20 * 20;
     private static final float CHIP_DAMAGE = 2.0F;
 
@@ -25,6 +31,20 @@ public class ChipSetItem extends Item implements ICurioItem {
     @Override
     public void onUnequip(SlotContext slotContext, ItemStack newStack, ItemStack stack) {
         applyChipSetEffects(slotContext, stack);
+    }
+
+    @Override
+    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
+        if (level.isClientSide) {
+            return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), true);
+        }
+
+        boolean equipped = CuriosIntegration.equipFromHand(player, hand, CHIP_SET_SLOT);
+        if (equipped) {
+            return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), false);
+        }
+
+        return InteractionResultHolder.pass(player.getItemInHand(hand));
     }
 
     private void applyChipSetEffects(SlotContext slotContext, ItemStack stack) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/neural/NeuralFrameItem.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/neural/NeuralFrameItem.java
@@ -14,7 +14,7 @@ public class NeuralFrameItem extends Item implements ICurioItem {
 
     @Override
     public boolean canUnequip(SlotContext slotContext, ItemStack stack) {
-        return true;
+        return false;
     }
 
     @Override

--- a/src/main/resources/assets/wildernessodysseyapi/models/item/neural_frame.json
+++ b/src/main/resources/assets/wildernessodysseyapi/models/item/neural_frame.json
@@ -3,7 +3,7 @@
 	"credit": "Made with Blockbench",
 	"texture_size": [64, 64],
 	"textures": {
-		"0": "block/neural_frame"
+		"0": "entity/neural_frame"
 	},
 	"elements": [
 		{


### PR DESCRIPTION
### Motivation
- Ensure the neural frame cannot be removed once equipped so players cannot unequip it without dying.  
- Avoid auto-spawning duplicate neural frames by moving an existing item from the player's inventory into a Curios slot.  
- Fix the item model to reference the correct texture path so the item renders using the entity texture.

### Description
- Update `CuriosIntegration.equipIfMissing` to locate the first empty slot in the requested Curios `slot`, find a matching `ItemStack` in the player's inventory, `split(1)` from that stack and place the single unit into the Curios slot, and return early when no slot or source item is found.  
- Change `src/main/java/com/thunder/wildernessodysseyapi/item/neural/NeuralFrameItem.java` so `canUnequip` returns `false` to disallow unequipping the neural frame.  
- Keep `onUnequip` intact to apply the fatal damage source if an unequip is somehow processed server-side.  
- Update `src/main/resources/assets/wildernessodysseyapi/models/item/neural_frame.json` to use the `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a52d69ff08328a51fab3b1c675766)