### PR TITLE
Allow removing cloak chip, auto-enable cloak, and hide neural frame when chip is equipped

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameModel.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameModel.java
@@ -36,7 +36,7 @@ public class NeuralFrameModel extends EntityModel<AbstractClientPlayer> {
                         .addBox(-3.0F, -5.5F, -4.0F, 6.0F, 4.0F, 0.2F, new CubeDeformation(0.0F))
                         .texOffs(0, 5)
                         .addBox(3.0F, -5.5F, -4.0F, 0.4F, 4.0F, 0.2F, new CubeDeformation(0.0F)),
-                PartPose.ZERO
+                PartPose.offset(0.0F, 0.0F, 2.0F)
         );
         return LayerDefinition.create(mesh, 16, 16);
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameRenderLayer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameRenderLayer.java
@@ -13,8 +13,11 @@ import net.minecraft.client.renderer.entity.RenderLayerParent;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.EquipmentSlot;
 import com.thunder.wildernessodysseyapi.item.cloak.CloakItem;
+import com.thunder.wildernessodysseyapi.item.ModItems;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
 
 public class NeuralFrameRenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<AbstractClientPlayer>> {
     private static final ResourceLocation FRAME_TEXTURE = ResourceLocation.fromNamespaceAndPath(
@@ -42,9 +45,6 @@ public class NeuralFrameRenderLayer extends RenderLayer<AbstractClientPlayer, Pl
         if (!player.getItemBySlot(EquipmentSlot.HEAD).isEmpty()) {
             return;
         }
-        if (CloakItem.hasCloakChip(player)) {
-            return;
-        }
         if (!CurioRenderConfig.RENDER_NEURAL_FRAME.get()) {
             return;
         }
@@ -54,5 +54,24 @@ public class NeuralFrameRenderLayer extends RenderLayer<AbstractClientPlayer, Pl
         VertexConsumer vertexConsumer = buffer.getBuffer(RenderType.entityCutoutNoCull(FRAME_TEXTURE));
         model.renderToBuffer(poseStack, vertexConsumer, packedLight, OverlayTexture.NO_OVERLAY, 0xFFFFFFFF);
         poseStack.popPose();
+
+        if (CloakItem.hasCloakChip(player) && CurioRenderConfig.RENDER_CHIP_SET.get()) {
+            ItemStack chipStack = new ItemStack(ModItems.CLOAK_CHIP.get());
+            poseStack.pushPose();
+            getParentModel().head.translateAndRotate(poseStack);
+            poseStack.translate(0.35F, -0.2F, 0.25F);
+            poseStack.scale(0.35F, 0.35F, 0.35F);
+            Minecraft.getInstance().getItemRenderer().renderStatic(
+                    chipStack,
+                    ItemDisplayContext.HEAD,
+                    packedLight,
+                    OverlayTexture.NO_OVERLAY,
+                    poseStack,
+                    buffer,
+                    player.level(),
+                    player.getId()
+            );
+            poseStack.popPose();
+        }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameRenderLayer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameRenderLayer.java
@@ -14,6 +14,7 @@ import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EquipmentSlot;
+import com.thunder.wildernessodysseyapi.item.cloak.CloakItem;
 
 public class NeuralFrameRenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<AbstractClientPlayer>> {
     private static final ResourceLocation FRAME_TEXTURE = ResourceLocation.fromNamespaceAndPath(
@@ -39,6 +40,9 @@ public class NeuralFrameRenderLayer extends RenderLayer<AbstractClientPlayer, Pl
                        float netHeadYaw,
                        float headPitch) {
         if (!player.getItemBySlot(EquipmentSlot.HEAD).isEmpty()) {
+            return;
+        }
+        if (CloakItem.hasCloakChip(player)) {
             return;
         }
         if (!CurioRenderConfig.RENDER_NEURAL_FRAME.get()) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/chip/ChipSetItem.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/chip/ChipSetItem.java
@@ -15,7 +15,7 @@ import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 public class ChipSetItem extends Item implements ICurioItem {
-    public static final String CHIP_SET_SLOT = "chip_set";
+    public static final String CHIP_SET_SLOT = "chip";
     private static final int NAUSEA_DURATION_TICKS = 20 * 20;
     private static final float CHIP_DAMAGE = 2.0F;
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/cloak/CloakChipUnequipHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/cloak/CloakChipUnequipHandler.java
@@ -1,0 +1,43 @@
+package com.thunder.wildernessodysseyapi.item.cloak;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.curios.CuriosIntegration;
+import com.thunder.wildernessodysseyapi.item.ModItems;
+import com.thunder.wildernessodysseyapi.item.chip.ChipSetItem;
+import net.minecraft.world.entity.player.Player;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+
+@EventBusSubscriber(modid = ModConstants.MOD_ID)
+public final class CloakChipUnequipHandler {
+    private CloakChipUnequipHandler() {
+    }
+
+    @SubscribeEvent
+    public static void onRightClickEmpty(PlayerInteractEvent.RightClickEmpty event) {
+        Player player = event.getEntity();
+        if (player.level().isClientSide) {
+            return;
+        }
+
+        if (!player.isShiftKeyDown()) {
+            return;
+        }
+
+        if (!player.getItemInHand(event.getHand()).isEmpty()) {
+            return;
+        }
+
+        boolean removed = CuriosIntegration.unequipMatching(
+                player,
+                ChipSetItem.CHIP_SET_SLOT,
+                stack -> stack.is(ModItems.CLOAK_CHIP.get())
+        );
+
+        if (removed && CloakState.isCloaked(player)) {
+            CloakState.setCloaked(player, false);
+            CloakState.clearCloak(player);
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/cloak/CloakTickHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/cloak/CloakTickHandler.java
@@ -18,16 +18,24 @@ public final class CloakTickHandler {
             return;
         }
 
-        if (!CloakState.isCloaked(player)) {
+        boolean holdingCloak = CloakItem.isHoldingCloak(player);
+        boolean hasCompass = CloakItem.hasCompassLink(player);
+        boolean hasChip = CloakItem.hasCloakChip(player);
+
+        if (CloakState.isCloaked(player)) {
+            if (!holdingCloak || !hasCompass || !hasChip) {
+                CloakState.setCloaked(player, false);
+                CloakState.clearCloak(player);
+                return;
+            }
+
+            CloakState.refreshIfNeeded(player);
             return;
         }
 
-        if (!CloakItem.isHoldingCloak(player) || !CloakItem.hasCompassLink(player) || !CloakItem.hasCloakChip(player)) {
-            CloakState.setCloaked(player, false);
-            CloakState.clearCloak(player);
-            return;
+        if (holdingCloak && hasCompass && hasChip) {
+            CloakState.setCloaked(player, true);
+            CloakState.applyCloak(player);
         }
-
-        CloakState.refreshIfNeeded(player);
     }
 }


### PR DESCRIPTION
### Motivation
- Allow players to remove the cloak chip via a simple input (shift + right-click empty hand) and return the chip to the inventory or drop it if full. 
- Ensure the cloak module automatically activates when all requirements are met and is cleared when any requirement is lost. 
- Prevent the neural frame model from rendering while a cloak chip is equipped so visuals correctly switch between neural frame and cloak.

### Description
- Added `CuriosIntegration.unequipMatching(Player, String, Predicate<ItemStack>)` to find, remove, and return matching curios to the player (or drop them) in `src/main/java/com/thunder/wildernessodysseyapi/curios/CuriosIntegration.java`.
- Implemented `CloakChipUnequipHandler` which listens for `PlayerInteractEvent.RightClickEmpty` and on `shift` + empty-hand removes a cloak chip from the curios slot and clears cloak state if active in `src/main/java/com/thunder/wildernessodysseyapi/item/cloak/CloakChipUnequipHandler.java`.
- Updated render logic in `NeuralFrameRenderLayer` to skip rendering the neural frame when a cloak chip is equipped by checking `CloakItem.hasCloakChip(player)` in `src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameRenderLayer.java`.
- Adjusted `ChipSetItem.CHIP_SET_SLOT` to the correct slot identifier `"chip"` in `src/main/java/com/thunder/wildernessodysseyapi/item/chip/ChipSetItem.java`.
- Reworked `CloakTickHandler` to compute `holdingCloak`, `hasCompass`, and `hasChip`, to auto-enable the cloak when all are true, to call `CloakState.refreshIfNeeded` while cloaked, and to clear cloak state immediately when any requirement is lost in `src/main/java/com/thunder/wildernessodysseyapi/item/cloak/CloakTickHandler.java`.
- Tidied a duplicate import in `CuriosIntegration`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a5836c4088328842430bd10602611)