### PR TITLE
Grant neural frame to players on login if missing

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/item/neural/NeuralFrameEquipHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/neural/NeuralFrameEquipHandler.java
@@ -16,7 +16,15 @@ public final class NeuralFrameEquipHandler {
     @SubscribeEvent
     public static void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
         if (event.getEntity() instanceof ServerPlayer player) {
-            CuriosIntegration.equipIfMissing(player, ModItems.NEURAL_FRAME.get(), "head");
+            if (!CuriosIntegration.isEquipped(player, ModItems.NEURAL_FRAME.get())) {
+                var neuralFrameStack = ModItems.NEURAL_FRAME.get().getDefaultInstance();
+                if (!player.getInventory().contains(neuralFrameStack)) {
+                    if (!player.addItem(neuralFrameStack)) {
+                        player.drop(neuralFrameStack, false);
+                    }
+                }
+                CuriosIntegration.equipIfMissing(player, ModItems.NEURAL_FRAME.get(), "head");
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure players who log in without a Neural Frame equipped receive one and have it auto-equipped into the Curios head slot.

### Description
- Add a guard using `CuriosIntegration.isEquipped(player, ModItems.NEURAL_FRAME.get())` to only apply logic when the item is not equipped.
- Create a `neuralFrameStack` via `ModItems.NEURAL_FRAME.get().getDefaultInstance()` and give it to the player with `player.addItem(...)`, falling back to `player.drop(...)` if adding fails.
- Call `CuriosIntegration.equipIfMissing(player, ModItems.NEURAL_FRAME.get(), "head")` after granting the item.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a723a470083289c5267c63b54e7df)