### PR TITLE
Add channel-aware global chat and Discord relay bridge

### DIFF
--- a/docs/global-chat.md
+++ b/docs/global-chat.md
@@ -39,9 +39,13 @@ The global chat system lets multiple Wilderness Odyssey servers share messages t
   ```
   /globalchat optin true
   ```
-- Send a message once opted in:
+- Send a message once opted in (default `global` channel):
   ```
   /globalchat send <message>
+  ```
+- Send to a specific channel (`global`, `help`, `staff`):
+  ```
+  /globalchat sendchannel <channel> <message>
   ```
 - Use `/globalchat status` to see your opt-in flag along with relay connectivity.
 
@@ -76,6 +80,28 @@ Moderation commands require a valid token (set via `/globalchat moderationtoken 
        com.thunder.wildernessodysseyapi.globalchat.server.GlobalChatRelayServer <port>
   ```
   Non-Minecraft clients must connect from a whitelisted IP and identify as `external` during the handshake or they will be dropped.
+
+
+## Discord bridge for help/staff channels
+You can map `help` and/or `staff` channel traffic to Discord and ingest Discord replies back into Minecraft.
+
+### Outbound (Minecraft -> Discord)
+Set webhook URLs per channel on the relay host:
+```bash
+-Dwilderness.globalchat.discord.channels.help.webhook=<discord-webhook-url>
+-Dwilderness.globalchat.discord.channels.staff.webhook=<discord-webhook-url>
+```
+Messages sent in those channels are posted to the matching webhook using the Minecraft sender name.
+
+### Inbound (Discord -> Minecraft)
+To ingest replies from Discord into Minecraft, also configure:
+```bash
+-Dwilderness.globalchat.discord.botToken=<discord-bot-token>
+-Dwilderness.globalchat.discord.channels.help.channelId=<discord-channel-id>
+-Dwilderness.globalchat.discord.channels.staff.channelId=<discord-channel-id>
+-Dwilderness.globalchat.discord.pollSeconds=4
+```
+The relay polls channel messages and re-broadcasts them into global chat with source `discord`. In Minecraft they render with a blue `[discord]` prefix followed by the Discord username and message text.
 
 ## Persisted settings
 `config/wildernessodysseyapi/global-chat.json` stores:

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/GlobalChatCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/GlobalChatCommand.java
@@ -41,6 +41,10 @@ public class GlobalChatCommand {
                 .then(Commands.literal("send")
                         .then(Commands.argument("message", StringArgumentType.greedyString())
                                 .executes(GlobalChatCommand::send)))
+                .then(Commands.literal("sendchannel")
+                        .then(Commands.argument("channel", StringArgumentType.word())
+                                .then(Commands.argument("message", StringArgumentType.greedyString())
+                                        .executes(GlobalChatCommand::sendChannel))))
                 .then(Commands.literal("startserver")
                         .requires(source -> source.hasPermission(2))
                         .then(Commands.argument("port", IntegerArgumentType.integer(1, 65535))
@@ -140,8 +144,30 @@ public class GlobalChatCommand {
             return 0;
         }
         String message = StringArgumentType.getString(ctx, "message");
-        GlobalChatManager.getInstance().sendChat(player.getGameProfile().getName(), message);
+        GlobalChatManager.getInstance().sendChat(player.getGameProfile().getName(), "global", message);
         ctx.getSource().sendSuccess(() -> Component.literal("Sent to global chat."), false);
+        return 1;
+    }
+
+
+    private static int sendChannel(CommandContext<CommandSourceStack> ctx) {
+        ServerPlayer player = ctx.getSource().getPlayer();
+        if (player == null) {
+            ctx.getSource().sendFailure(Component.literal("Global chat messages must be sent by a player."));
+            return 0;
+        }
+        if (!GlobalChatOptIn.isOptedIn(player)) {
+            ctx.getSource().sendFailure(Component.literal("You must opt into global chat before sending messages."));
+            return 0;
+        }
+        String channel = StringArgumentType.getString(ctx, "channel").toLowerCase();
+        if (!("global".equals(channel) || "help".equals(channel) || "staff".equals(channel))) {
+            ctx.getSource().sendFailure(Component.literal("Unknown channel. Allowed: global, help, staff."));
+            return 0;
+        }
+        String message = StringArgumentType.getString(ctx, "message");
+        GlobalChatManager.getInstance().sendChat(player.getGameProfile().getName(), channel, message);
+        ctx.getSource().sendSuccess(() -> Component.literal("Sent to #" + channel + "."), false);
         return 1;
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatPacket.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatPacket.java
@@ -18,6 +18,9 @@ public class GlobalChatPacket {
     public Type type;
     public String sender;
     public String message;
+    public String channel;
+    public String source;
+    public String messageId;
     public String serverId;
     public long timestamp;
     public String clientType;

--- a/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatServerProcess.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatServerProcess.java
@@ -1,6 +1,8 @@
 package com.thunder.wildernessodysseyapi.globalchat;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Launches the external relay server using the same classpath as the running JVM.
@@ -14,14 +16,30 @@ public class GlobalChatServerProcess {
             return;
         }
         String classpath = System.getProperty("java.class.path");
-        ProcessBuilder builder = new ProcessBuilder("java",
-                "-Dwilderness.globalchat.token=" + moderationToken,
-                "-Dwilderness.globalchat.clustertoken=" + clusterToken,
-                "-cp", classpath,
-                "com.thunder.wildernessodysseyapi.globalchat.server.GlobalChatRelayServer",
-                String.valueOf(port));
+        List<String> command = new ArrayList<>();
+        command.add("java");
+        command.add("-Dwilderness.globalchat.token=" + moderationToken);
+        command.add("-Dwilderness.globalchat.clustertoken=" + clusterToken);
+        passThroughProperty(command, "wilderness.globalchat.discord.botToken");
+        passThroughProperty(command, "wilderness.globalchat.discord.pollSeconds");
+        passThroughProperty(command, "wilderness.globalchat.discord.channels.help.webhook");
+        passThroughProperty(command, "wilderness.globalchat.discord.channels.staff.webhook");
+        passThroughProperty(command, "wilderness.globalchat.discord.channels.help.channelId");
+        passThroughProperty(command, "wilderness.globalchat.discord.channels.staff.channelId");
+        command.add("-cp");
+        command.add(classpath);
+        command.add("com.thunder.wildernessodysseyapi.globalchat.server.GlobalChatRelayServer");
+        command.add(String.valueOf(port));
+        ProcessBuilder builder = new ProcessBuilder(command);
         builder.redirectErrorStream(true);
         process = builder.start();
+    }
+
+    private void passThroughProperty(List<String> command, String key) {
+        String value = System.getProperty(key, "");
+        if (value != null && !value.isBlank()) {
+            command.add("-D" + key + "=" + value);
+        }
     }
 
     public void stop() {

--- a/src/main/java/com/thunder/wildernessodysseyapi/globalchat/server/DiscordBridgeService.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/globalchat/server/DiscordBridgeService.java
@@ -1,0 +1,247 @@
+package com.thunder.wildernessodysseyapi.globalchat.server;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.thunder.wildernessodysseyapi.globalchat.GlobalChatPacket;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Minimal Discord bridge for selected global chat channels.
+ */
+public class DiscordBridgeService {
+
+    private static final Gson GSON = new Gson();
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+
+    private final String botToken;
+    private final long pollIntervalSeconds;
+    private final Consumer<GlobalChatPacket> inboundConsumer;
+    private final Map<String, ChannelBridge> channels = new HashMap<>();
+    private final Map<String, String> lastSeenMessageIds = new HashMap<>();
+    private ScheduledExecutorService scheduler;
+    private String botUserId;
+
+    public DiscordBridgeService(String botToken,
+                                long pollIntervalSeconds,
+                                Map<String, ChannelBridge> channels,
+                                Consumer<GlobalChatPacket> inboundConsumer) {
+        this.botToken = botToken == null ? "" : botToken.trim();
+        this.pollIntervalSeconds = Math.max(2, pollIntervalSeconds);
+        this.inboundConsumer = inboundConsumer;
+        this.channels.putAll(channels);
+    }
+
+    public static DiscordBridgeService fromSystemProperties(Consumer<GlobalChatPacket> inboundConsumer) {
+        String botToken = System.getProperty("wilderness.globalchat.discord.botToken", "");
+        long interval = Long.parseLong(System.getProperty("wilderness.globalchat.discord.pollSeconds", "4"));
+        Map<String, ChannelBridge> channels = new HashMap<>();
+        for (String channel : List.of("help", "staff")) {
+            String webhook = System.getProperty("wilderness.globalchat.discord.channels." + channel + ".webhook", "").trim();
+            String channelId = System.getProperty("wilderness.globalchat.discord.channels." + channel + ".channelId", "").trim();
+            if (!webhook.isEmpty() || !channelId.isEmpty()) {
+                channels.put(channel, new ChannelBridge(channel, webhook, channelId));
+            }
+        }
+        return new DiscordBridgeService(botToken, interval, channels, inboundConsumer);
+    }
+
+    public boolean isEnabled() {
+        return !channels.isEmpty() && (!botToken.isBlank() || channels.values().stream().anyMatch(c -> !c.webhookUrl.isBlank()));
+    }
+
+    public void start() {
+        if (!isEnabled()) {
+            return;
+        }
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+        if (!botToken.isBlank()) {
+            botUserId = fetchBotUserId();
+            scheduler.scheduleWithFixedDelay(this::pollDiscord, 2, pollIntervalSeconds, TimeUnit.SECONDS);
+        }
+        System.out.println("[GlobalChatRelayServer] Discord bridge enabled for channels " + channels.keySet());
+    }
+
+    public void stop() {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+    }
+
+    public void relayMinecraftToDiscord(GlobalChatPacket packet) {
+        if (packet == null || packet.message == null) {
+            return;
+        }
+        String channel = normalizeChannel(packet.channel);
+        ChannelBridge bridge = channels.get(channel);
+        if (bridge == null || bridge.webhookUrl.isBlank()) {
+            return;
+        }
+        JsonObject payload = new JsonObject();
+        payload.addProperty("username", packet.sender == null || packet.sender.isBlank() ? "minecraft" : packet.sender);
+        payload.addProperty("content", packet.message);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(bridge.webhookUrl))
+                .header("Content-Type", "application/json")
+                .timeout(Duration.ofSeconds(5))
+                .POST(HttpRequest.BodyPublishers.ofString(GSON.toJson(payload)))
+                .build();
+        try {
+            httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+        } catch (IOException | InterruptedException ignored) {
+        }
+    }
+
+    private void pollDiscord() {
+        for (ChannelBridge bridge : channels.values()) {
+            if (bridge.channelId.isBlank()) {
+                continue;
+            }
+            try {
+                List<DiscordMessage> messages = fetchRecentMessages(bridge.channelId, 15);
+                messages.sort(Comparator.comparing(m -> m.id));
+                String lastSeen = lastSeenMessageIds.get(bridge.channel);
+                for (DiscordMessage msg : messages) {
+                    if (lastSeen != null && compareSnowflake(msg.id, lastSeen) <= 0) {
+                        continue;
+                    }
+                    if (msg.authorBot && Objects.equals(msg.authorId, botUserId)) {
+                        continue;
+                    }
+                    GlobalChatPacket packet = new GlobalChatPacket();
+                    packet.type = GlobalChatPacket.Type.CHAT;
+                    packet.channel = bridge.channel;
+                    packet.source = "discord";
+                    packet.sender = msg.authorName;
+                    packet.message = msg.content;
+                    packet.timestamp = System.currentTimeMillis();
+                    packet.messageId = "discord:" + msg.id;
+                    inboundConsumer.accept(packet);
+                    lastSeenMessageIds.put(bridge.channel, msg.id);
+                }
+                if (!messages.isEmpty() && !lastSeenMessageIds.containsKey(bridge.channel)) {
+                    lastSeenMessageIds.put(bridge.channel, messages.get(messages.size() - 1).id);
+                }
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private List<DiscordMessage> fetchRecentMessages(String channelId, int limit) throws IOException, InterruptedException {
+        String uri = "https://discord.com/api/v10/channels/" + URLEncoder.encode(channelId, StandardCharsets.UTF_8)
+                + "/messages?limit=" + Math.max(1, Math.min(limit, 50));
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(uri))
+                .header("Authorization", "Bot " + botToken)
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            return List.of();
+        }
+        JsonElement parsed = JsonParser.parseString(response.body());
+        if (!(parsed instanceof JsonArray arr)) {
+            return List.of();
+        }
+        List<DiscordMessage> out = new ArrayList<>();
+        for (JsonElement el : arr) {
+            if (!(el instanceof JsonObject obj)) {
+                continue;
+            }
+            String id = getString(obj, "id");
+            String content = getString(obj, "content");
+            JsonObject author = obj.getAsJsonObject("author");
+            String authorName = author == null ? "discord" : getString(author, "global_name");
+            if (authorName == null || authorName.isBlank()) {
+                authorName = author == null ? "discord" : getString(author, "username");
+            }
+            String authorId = author == null ? "" : getString(author, "id");
+            boolean authorBot = author != null && author.has("bot") && author.get("bot").getAsBoolean();
+            if (id == null || id.isBlank() || content == null || content.isBlank()) {
+                continue;
+            }
+            out.add(new DiscordMessage(id, content, authorName == null ? "discord" : authorName, authorId, authorBot));
+        }
+        return out;
+    }
+
+    private String fetchBotUserId() {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://discord.com/api/v10/users/@me"))
+                    .header("Authorization", "Bot " + botToken)
+                    .timeout(Duration.ofSeconds(5))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                return null;
+            }
+            JsonObject obj = JsonParser.parseString(response.body()).getAsJsonObject();
+            return getString(obj, "id");
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static String normalizeChannel(String channel) {
+        if (channel == null || channel.isBlank()) {
+            return "global";
+        }
+        return channel.toLowerCase(Locale.ROOT);
+    }
+
+    private static String getString(JsonObject obj, String key) {
+        if (obj == null || !obj.has(key) || obj.get(key).isJsonNull()) {
+            return null;
+        }
+        return obj.get(key).getAsString();
+    }
+
+    private static int compareSnowflake(String a, String b) {
+        if (a.length() != b.length()) {
+            return Integer.compare(a.length(), b.length());
+        }
+        return a.compareTo(b);
+    }
+
+    public static class ChannelBridge {
+        private final String channel;
+        private final String webhookUrl;
+        private final String channelId;
+
+        public ChannelBridge(String channel, String webhookUrl, String channelId) {
+            this.channel = channel;
+            this.webhookUrl = webhookUrl == null ? "" : webhookUrl;
+            this.channelId = channelId == null ? "" : channelId;
+        }
+    }
+
+    private record DiscordMessage(String id, String content, String authorName, String authorId, boolean authorBot) {
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide per-channel global chat (`global`, `help`, `staff`) and allow mapping `help`/`staff` traffic to Discord webhooks so staff/help requests can be handled in Discord. 
- Support inbound Discord replies being rebroadcast into Minecraft and visually distinguish Discord-origin messages in-game with a blue `[discord]` prefix.

### Description
- Add channel metadata and provenance to the wire format by adding `channel`, `source`, and `messageId` to `GlobalChatPacket` and using them when sending and rendering messages (`src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatPacket.java`).
- Update the in-server client to send channel-aware packets and render Discord-origin messages with a blue `[discord]` prefix and username styling (`src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatManager.java`).
- Add a player command `sendchannel` and keep `send` as the default global channel; validate allowed channels (`global`, `help`, `staff`) in `GlobalChatCommand` (`src/main/java/com/thunder/wildernessodysseyapi/command/GlobalChatCommand.java`).
- Implement a relay-side `DiscordBridgeService` that posts Minecraft `help`/`staff` messages to configured Discord webhooks and polls Discord channels with a bot token to rebroadcast replies as `source=discord` (`src/main/java/com/thunder/wildernessodysseyapi/globalchat/server/DiscordBridgeService.java`).
- Wire the Discord bridge into the relay lifecycle and broadcast flow so Minecraft -> Discord outbound uses webhooks and Discord -> Minecraft inbound is re-broadcast to connected servers (`src/main/java/com/thunder/wildernessodysseyapi/globalchat/server/GlobalChatRelayServer.java`).
- Make the sidecar launcher pass Discord-related JVM properties through when starting the relay from the server JVM (`src/main/java/com/thunder/wildernessodysseyapi/globalchat/GlobalChatServerProcess.java`).
- Document the new `sendchannel` command and relay Discord configuration in `docs/global-chat.md`.

### Testing
- Attempted to validate by running `./gradlew compileJava -x test` to check compilation, but the build failed in this environment due to an external dependency fetch error from Cursemaven (HTTP 403), blocking full compile validation.
- No automated tests were executed in this run (`-x test` was used) and unit/integration tests were not run due to the dependency issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b92d22efc8328bf783aca6968da90)