### PR TITLE
Docs: Add modpack NBT staging workflow and datapack scaffold guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Impact zones are fully data pack driven. The bundled `impact_zone` structure, st
 
 Multiple impact zones can now exist—add more structure set entries via datapack to control how many spawn and where.
 
+Modpack Structure Staging (drop-in NBT)
+-----------------------------------------
+For a step-by-step flow that starts from `config/wildernessodysseyapi/modpack_structures/*.nbt` and scaffolds a full datapack layout, see `docs/modpack-structure-registry.md`.
+
 Using Data Pack Structures
 --------------------------
 The mod now loads vanilla structure templates from data packs using the

--- a/docs/modpack-structure-registry.md
+++ b/docs/modpack-structure-registry.md
@@ -1,17 +1,31 @@
 # Modpack Structure Folder (NBT auto-registration)
 
-You can drop structure templates in:
+This workflow lets pack authors treat loose `.nbt` files like a staging datapack:
+
+1. Drop structure templates into a config folder.
+2. Let the mod auto-register them for commands/testing.
+3. Generate a scaffold datapack from those templates.
+4. Copy scaffold output into your real modpack datapack.
+
+## 1) Drop `.nbt` files into the modpack structure folder
+
+Use this directory on the server or single-player instance:
 
 `config/wildernessodysseyapi/modpack_structures`
 
-On server start (or `/modpackstructures reload`), the mod will:
+Example:
+
+- `config/wildernessodysseyapi/modpack_structures/crashed_pod.nbt`
+- `config/wildernessodysseyapi/modpack_structures/abandoned_outpost.nbt`
+
+On server start (or when you run reload), the mod will:
 
 1. Discover every `*.nbt` file in that folder.
 2. Auto-create a matching `<name>.json` config if missing.
 3. Register a runtime structure entry with an id (default: `wildernessodysseyapi:modpack/<name>`).
 4. Allow listing and placement through commands.
 
-## Per-structure config
+## 2) Configure each structure with optional JSON
 
 For each `my_base.nbt`, create (or edit) `my_base.json` in the same folder:
 
@@ -30,34 +44,85 @@ For each `my_base.nbt`, create (or edit) `my_base.json` in the same folder:
 }
 ```
 
-### Fields
+### Field reference
 
-- `enabled`: whether this structure should be loaded.
-- `structureId`: command id used by placement commands and scaffold output.
-- `displayName`: optional note for pack authors.
-- `alignToSurface`: default placement mode for `/modpackstructures place` when no override is passed.
-- `biomeTag`, `generationStep`, `terrainAdaptation`, `spacing`, `separation`, `salt`: used by scaffold generation for worldgen json templates.
+- `enabled`: load/unload a structure without deleting files.
+- `structureId`: namespaced id used by placement commands and scaffold output.
+- `displayName`: pack-author note shown in list output.
+- `alignToSurface`: default placement mode for `/modpackstructures place`.
+- `biomeTag`: biome tag used in generated `has_structure` biome tag file.
+- `generationStep`: worldgen step for generated structure JSON.
+- `terrainAdaptation`: structure terrain adaptation mode in generated JSON.
+- `spacing`, `separation`, `salt`: structure set placement parameters in generated JSON.
 
-## Commands
+## 3) Reload and test in-game
+
+Commands:
 
 - `/modpackstructures reload`
 - `/modpackstructures list`
 - `/modpackstructures place <id> [x y z] [alignToSurface]`
 - `/modpackstructures scaffold [id]`
 
-`alignToSurface=true` uses anchored placement.
+Tips:
 
-## Worldgen scaffold generation
+- Use `list` after adding files to verify ids were registered.
+- Use `place` to validate rotation/offset and marker blocks before worldgen integration.
+- `alignToSurface=true` uses anchored placement.
 
-Use `/modpackstructures scaffold` to generate a datapack template at:
+## 4) Generate datapack scaffolding
+
+Run:
+
+- `/modpackstructures scaffold` (all structures)
+- `/modpackstructures scaffold wildernessodysseyapi:modpack/my_base` (single structure)
+
+Output path:
 
 `config/wildernessodysseyapi/modpack_structures/generated_datapack`
 
-For each structure id, it writes:
+For each structure id, scaffold writes:
 
-- `data/<namespace>/structures/<path>.nbt` (copy of your source template)
+- `data/<namespace>/structures/<path>.nbt` (copy of source template)
 - `data/<namespace>/worldgen/structure/<path>.json`
 - `data/<namespace>/worldgen/structure_set/<path>.json`
 - `data/<namespace>/tags/worldgen/biome/has_structure/<path>.json`
 
-This gives you a ready-to-edit base to move into your real datapack/modpack pack for actual worldgen registration.
+## 5) Move scaffold output into your modpack datapack
+
+In your pack, copy from `generated_datapack` into your actual datapack folder, e.g.:
+
+`<instance>/saves/<world>/datapacks/<your_pack>/`
+
+or for dedicated servers:
+
+`<server>/world/datapacks/<your_pack>/`
+
+Keep/edit the generated files as needed (spacing, biomes, step, etc.), then reload datapacks:
+
+- `/reload`
+
+## Recommended pack-author workflow
+
+1. Build/export structure in NBT format.
+2. Drop `.nbt` into `modpack_structures`.
+3. Run `/modpackstructures reload`.
+4. Run `/modpackstructures place ...` until it looks correct.
+5. Run `/modpackstructures scaffold`.
+6. Copy scaffold into your real datapack.
+7. Tune JSON and test worldgen in a fresh world or unexplored chunks.
+
+## Troubleshooting
+
+- Structure missing from `list`:
+  - Confirm the file extension is `.nbt`.
+  - Re-run `/modpackstructures reload`.
+  - Check if `<name>.json` has `enabled: false`.
+- Datapack generates files but nothing spawns naturally:
+  - Verify the datapack is enabled (`/datapack list`).
+  - Verify biome tag and spacing/separation are reasonable.
+  - Test in new terrain/chunks.
+- Command id mismatch:
+  - Ensure `structureId` in JSON matches what you pass to `place`/`scaffold`.
+
+This gives you a modpack-friendly bridge: fast local NBT iteration with commands, then clean vanilla-style datapack worldgen artifacts for release.


### PR DESCRIPTION
### Motivation
- Make it easy for modpack authors to iterate on structure templates by treating loose `.nbt` files as a staging datapack and scaffolding proper datapack artifacts automatically.
- Document the in-game validation commands and the recommended pack-author workflow so authors can test placement before committing to worldgen registration.
- Provide troubleshooting and copy instructions to reduce friction when moving from local testing to production datapacks.

### Description
- Expanded `docs/modpack-structure-registry.md` into a step-by-step workflow that covers dropping `.nbt` files into `config/wildernessodysseyapi/modpack_structures`, optional per-structure JSON tuning, scaffold output layout, and troubleshooting.
- Added a short discoverability note in `README.md` linking to the new guide at `docs/modpack-structure-registry.md`.
- Clarified the scaffold output contents (`data/<namespace>/structures/*.nbt`, `worldgen/structure/*.json`, `worldgen/structure_set/*.json`, and `tags/worldgen/biome/has_structure/*.json`) and the recommended copy-and-reload flow for datapacks.
- This is a documentation-only change with no runtime code modifications.

### Testing
- Reviewed the textual changes with `git diff` to confirm the intended edits to `docs/modpack-structure-registry.md` and `README.md` succeeded.
- Previewed the updated files using `nl` and `sed` to validate insertion points and formatting.
- No runtime or unit tests were required because the change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bfdc6d9d08328ad46736550358b6c)