### PR TITLE
Fix custom music disc audio by tagging sounds as records

### DIFF
--- a/src/main/resources/assets/wildernessodysseyapi/sounds.json
+++ b/src/main/resources/assets/wildernessodysseyapi/sounds.json
@@ -1,5 +1,6 @@
 {
   "outside_the_box": {
+    "category": "records",
     "sounds": [
       {
         "name": "wildernessodysseyapi:music/outside_the_box",
@@ -8,6 +9,7 @@
     ]
   },
   "dont_be_so_serious": {
+    "category": "records",
     "sounds": [
       {
         "name": "wildernessodysseyapi:music/dont_be_so_serious",


### PR DESCRIPTION
### Motivation
- Jukebox/music-disc playback expects sounds in the `records` category, and the two custom tracks were not explicitly tagged which prevented audio from playing.

### Description
- Added `"category": "records"` for `outside_the_box` and `dont_be_so_serious` in `src/main/resources/assets/wildernessodysseyapi/sounds.json` so the custom sound events are routed to the records channel.

### Testing
- Verified `sounds.json` is valid JSON with `python -c "import json; json.load(open('src/main/resources/assets/wildernessodysseyapi/sounds.json'))"` which succeeded, and attempted `./gradlew compileJava` which could not finish due to an external SSL certificate trust error while NeoForm attempted to download Mojang metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fe7800b248328898d3c9c9e9ee9c3)