### PR TITLE
Fix cloak chip model texture path and neural frame UV atlas size

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameModel.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameModel.java
@@ -38,7 +38,7 @@ public class NeuralFrameModel extends EntityModel<AbstractClientPlayer> {
                         .addBox(3.0F, -5.5F, -4.0F, 0.4F, 4.0F, 0.2F, new CubeDeformation(0.0F)),
                 PartPose.offset(0.0F, 0.0F, 2.0F)
         );
-        return LayerDefinition.create(mesh, 16, 16);
+        return LayerDefinition.create(mesh, 128, 128);
     }
 
     @Override

--- a/src/main/resources/assets/wildernessodysseyapi/models/item/cloak_chip.json
+++ b/src/main/resources/assets/wildernessodysseyapi/models/item/cloak_chip.json
@@ -3,7 +3,7 @@
 	"credit": "Made with Blockbench",
 	"texture_size": [32, 32],
 	"textures": {
-		"0": "block/cloak_chip"
+		"0": "item/cloak_chip"
 	},
 	"elements": [
 		{


### PR DESCRIPTION
### Motivation
- Resolve missing/broken textures by aligning model texture references and UV atlas size with the actual texture assets so in-game rendering samples the correct regions.

### Description
- Update `src/main/resources/assets/wildernessodysseyapi/models/item/cloak_chip.json` to reference the correct texture path `item/cloak_chip` matching the texture file location.
- Update `src/main/java/com/thunder/wildernessodysseyapi/Client/NeuralFrameModel.java` to use a `128x128` layer atlas instead of `16x16` so the model's UVs map correctly to `textures/entity/neural_frame.png`.

### Testing
- Parsed `cloak_chip.json` with a Python `json.load` check which succeeded.
- Attempted `./gradlew classes`; the build failed due to an external SSL certificate trust error while downloading Mojang metadata, which is an environment issue and not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fe84c56ac83289ffe85848d1747e0)