### PR TITLE
Add anomaly-zone biome variants with hard-coded spawn control and client effects

### DIFF
--- a/docs/anomaly-zone.md
+++ b/docs/anomaly-zone.md
@@ -1,0 +1,44 @@
+# Anomaly Zone biomes
+
+This mod now registers four anomaly-zone biome variants:
+
+- `wildernessodysseyapi:anomaly_plains`
+- `wildernessodysseyapi:anomaly_desert`
+- `wildernessodysseyapi:anomaly_tundra`
+- `wildernessodysseyapi:anomaly_rainforest`
+
+## Mob control (hard-coded)
+
+All spawn lists are hard-coded in:
+
+- `com.thunder.wildernessodysseyapi.WorldGen.biome.AnomalyBiomeMobSettings`
+
+You can edit each biome method to control exactly which vanilla mobs and custom mobs can spawn:
+
+- `addPlainsSpawns`
+- `addDesertSpawns`
+- `addTundraSpawns`
+- `addRainforestSpawns`
+
+Custom mob example already included:
+
+- `ModEntities.PURPLE_STORM_MONSTER`
+
+## Biome visual effect behavior
+
+Client-only anomaly effects are in:
+
+- `com.thunder.wildernessodysseyapi.client.biome.AnomalyZoneClientEffects`
+
+Current behavior while player is inside an anomaly biome:
+
+- Purple-biased fog tint
+- Distortion-like portal particles
+- Occasional electric spark "cracks"
+
+Effects disable automatically when the player leaves anomaly biomes.
+
+## Note on world generation
+
+The biomes are registered and tagged for overworld classification.
+If you want these to generate naturally in your world seed, wire them into your biome source/world preset (datapack or TerraBlender region).

--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -16,6 +16,7 @@ import com.thunder.wildernessodysseyapi.feedback.FeedbackConfig;
 import com.thunder.wildernessodysseyapi.WorldGen.blocks.CryoTubeBlock;
 import com.thunder.wildernessodysseyapi.WorldGen.configurable.StructureConfig;
 import com.thunder.wildernessodysseyapi.WorldGen.processor.ModProcessors;
+import com.thunder.wildernessodysseyapi.WorldGen.biome.ModBiomes;
 import com.thunder.wildernessodysseyapi.WorldGen.modpack.ModpackStructureRegistry;
 import com.thunder.wildernessodysseyapi.async.AsyncTaskManager;
 import com.thunder.wildernessodysseyapi.async.AsyncThreadingConfig;
@@ -115,6 +116,7 @@ public class WildernessOdysseyAPIMainModClass {
         modEventBus.addListener(this::onConfigLoaded);
         modEventBus.addListener(this::onConfigReloaded);
         ModProcessors.PROCESSORS.register(modEventBus);
+        ModBiomes.BIOMES.register(modEventBus);
         ModCreativeTabs.register(modEventBus);
         ModAttachments.ATTACHMENTS.register(modEventBus);
         ModEntities.ENTITY_TYPES.register(modEventBus);

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/biome/AnomalyBiomeMobSettings.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/biome/AnomalyBiomeMobSettings.java
@@ -1,0 +1,54 @@
+package com.thunder.wildernessodysseyapi.WorldGen.biome;
+
+import com.thunder.wildernessodysseyapi.entity.ModEntities;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.level.biome.MobSpawnSettings;
+
+public final class AnomalyBiomeMobSettings {
+    private AnomalyBiomeMobSettings() {
+    }
+
+    public static void addPlainsSpawns(MobSpawnSettings.Builder builder) {
+        builder.creatureGenerationProbability(0.12F);
+        builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(EntityType.SHEEP, 12, 4, 4));
+        builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(EntityType.PIG, 10, 4, 4));
+        builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(EntityType.CHICKEN, 10, 4, 4));
+        builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(EntityType.COW, 8, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.SPIDER, 100, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.ZOMBIE, 95, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.SKELETON, 100, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(ModEntities.PURPLE_STORM_MONSTER.get(), 8, 1, 2));
+    }
+
+    public static void addDesertSpawns(MobSpawnSettings.Builder builder) {
+        builder.creatureGenerationProbability(0.08F);
+        builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(EntityType.RABBIT, 10, 2, 3));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.HUSK, 80, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.ZOMBIE, 19, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.SPIDER, 100, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(ModEntities.PURPLE_STORM_MONSTER.get(), 10, 1, 2));
+    }
+
+    public static void addTundraSpawns(MobSpawnSettings.Builder builder) {
+        builder.creatureGenerationProbability(0.1F);
+        builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(EntityType.RABBIT, 4, 2, 3));
+        builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(EntityType.POLAR_BEAR, 2, 1, 2));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.STRAY, 80, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.SKELETON, 20, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.SPIDER, 100, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(ModEntities.PURPLE_STORM_MONSTER.get(), 12, 1, 2));
+    }
+
+    public static void addRainforestSpawns(MobSpawnSettings.Builder builder) {
+        builder.creatureGenerationProbability(0.14F);
+        builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(EntityType.PARROT, 40, 1, 2));
+        builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(EntityType.OCELOT, 2, 1, 3));
+        builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(EntityType.PIG, 8, 4, 4));
+        builder.addSpawn(MobCategory.CREATURE, new MobSpawnSettings.SpawnerData(EntityType.CHICKEN, 10, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.ZOMBIE, 95, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.SPIDER, 100, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(EntityType.SKELETON, 100, 4, 4));
+        builder.addSpawn(MobCategory.MONSTER, new MobSpawnSettings.SpawnerData(ModEntities.PURPLE_STORM_MONSTER.get(), 14, 1, 2));
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/biome/AnomalyBiomes.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/biome/AnomalyBiomes.java
@@ -1,0 +1,136 @@
+package com.thunder.wildernessodysseyapi.WorldGen.biome;
+
+import net.minecraft.data.worldgen.BiomeDefaultFeatures;
+import net.minecraft.sounds.Music;
+import net.minecraft.sounds.Musics;
+import net.minecraft.world.level.biome.AmbientMoodSettings;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeGenerationSettings;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
+import net.minecraft.world.level.biome.MobSpawnSettings;
+
+public final class AnomalyBiomes {
+    private static final int ANOMALY_SKY_COLOR = 0x7A59C7;
+    private static final int ANOMALY_FOG_COLOR = 0x7A59C7;
+    private static final int ANOMALY_WATER_COLOR = 0x6D4FC8;
+    private static final int ANOMALY_WATER_FOG_COLOR = 0x4D2C88;
+
+    private AnomalyBiomes() {
+    }
+
+    public static Biome anomalyPlains() {
+        MobSpawnSettings.Builder spawns = new MobSpawnSettings.Builder();
+        AnomalyBiomeMobSettings.addPlainsSpawns(spawns);
+
+        BiomeGenerationSettings.Builder generation = new BiomeGenerationSettings.Builder();
+        BiomeDefaultFeatures.addDefaultCarversAndLakes(generation);
+        BiomeDefaultFeatures.addDefaultCrystalFormations(generation);
+        BiomeDefaultFeatures.addDefaultMonsterRoom(generation);
+        BiomeDefaultFeatures.addDefaultUndergroundVariety(generation);
+        BiomeDefaultFeatures.addDefaultSprings(generation);
+        BiomeDefaultFeatures.addSurfaceFreezing(generation);
+        BiomeDefaultFeatures.addDefaultOres(generation);
+        BiomeDefaultFeatures.addDefaultSoftDisks(generation);
+        BiomeDefaultFeatures.addPlainGrass(generation);
+        BiomeDefaultFeatures.addPlainVegetation(generation);
+        BiomeDefaultFeatures.addDefaultMushrooms(generation);
+        BiomeDefaultFeatures.addDefaultExtraVegetation(generation, true);
+
+        return baseBiome(true, 0.8F, 0.4F, spawns, generation);
+    }
+
+    public static Biome anomalyDesert() {
+        MobSpawnSettings.Builder spawns = new MobSpawnSettings.Builder();
+        AnomalyBiomeMobSettings.addDesertSpawns(spawns);
+
+        BiomeGenerationSettings.Builder generation = new BiomeGenerationSettings.Builder();
+        BiomeDefaultFeatures.addFossilDecoration(generation);
+        BiomeDefaultFeatures.addDefaultCarversAndLakes(generation);
+        BiomeDefaultFeatures.addDefaultCrystalFormations(generation);
+        BiomeDefaultFeatures.addDefaultMonsterRoom(generation);
+        BiomeDefaultFeatures.addDefaultUndergroundVariety(generation);
+        BiomeDefaultFeatures.addDefaultSprings(generation);
+        BiomeDefaultFeatures.addSurfaceFreezing(generation);
+        BiomeDefaultFeatures.addDefaultOres(generation);
+        BiomeDefaultFeatures.addDefaultSoftDisks(generation);
+        BiomeDefaultFeatures.addDesertVegetation(generation);
+        BiomeDefaultFeatures.addDesertExtraVegetation(generation);
+        BiomeDefaultFeatures.addDesertExtraDecoration(generation);
+
+        return baseBiome(false, 2.0F, 0.0F, spawns, generation);
+    }
+
+    public static Biome anomalyTundra() {
+        MobSpawnSettings.Builder spawns = new MobSpawnSettings.Builder();
+        AnomalyBiomeMobSettings.addTundraSpawns(spawns);
+
+        BiomeGenerationSettings.Builder generation = new BiomeGenerationSettings.Builder();
+        BiomeDefaultFeatures.addDefaultCarversAndLakes(generation);
+        BiomeDefaultFeatures.addDefaultCrystalFormations(generation);
+        BiomeDefaultFeatures.addDefaultMonsterRoom(generation);
+        BiomeDefaultFeatures.addDefaultUndergroundVariety(generation);
+        BiomeDefaultFeatures.addDefaultSprings(generation);
+        BiomeDefaultFeatures.addSurfaceFreezing(generation);
+        BiomeDefaultFeatures.addDefaultOres(generation);
+        BiomeDefaultFeatures.addDefaultSoftDisks(generation);
+        BiomeDefaultFeatures.addSnowyTrees(generation);
+        BiomeDefaultFeatures.addDefaultFlowers(generation);
+        BiomeDefaultFeatures.addTaigaGrass(generation);
+        BiomeDefaultFeatures.addDefaultMushrooms(generation);
+        BiomeDefaultFeatures.addDefaultExtraVegetation(generation, false);
+
+        return baseBiome(true, -0.45F, 0.8F, spawns, generation);
+    }
+
+    public static Biome anomalyRainforest() {
+        MobSpawnSettings.Builder spawns = new MobSpawnSettings.Builder();
+        AnomalyBiomeMobSettings.addRainforestSpawns(spawns);
+
+        BiomeGenerationSettings.Builder generation = new BiomeGenerationSettings.Builder();
+        BiomeDefaultFeatures.addDefaultCarversAndLakes(generation);
+        BiomeDefaultFeatures.addDefaultCrystalFormations(generation);
+        BiomeDefaultFeatures.addDefaultMonsterRoom(generation);
+        BiomeDefaultFeatures.addDefaultUndergroundVariety(generation);
+        BiomeDefaultFeatures.addDefaultSprings(generation);
+        BiomeDefaultFeatures.addSurfaceFreezing(generation);
+        BiomeDefaultFeatures.addDefaultOres(generation);
+        BiomeDefaultFeatures.addDefaultSoftDisks(generation);
+        BiomeDefaultFeatures.addBambooVegetation(generation);
+        BiomeDefaultFeatures.addLightBambooVegetation(generation);
+        BiomeDefaultFeatures.addJungleTrees(generation);
+        BiomeDefaultFeatures.addWarmFlowers(generation);
+        BiomeDefaultFeatures.addJungleGrass(generation);
+        BiomeDefaultFeatures.addDefaultMushrooms(generation);
+        BiomeDefaultFeatures.addJungleVines(generation);
+
+        return baseBiome(true, 0.95F, 0.9F, spawns, generation);
+    }
+
+    private static Biome baseBiome(boolean hasPrecipitation, float temperature, float downfall,
+                                   MobSpawnSettings.Builder spawns, BiomeGenerationSettings.Builder generation) {
+        return new Biome.BiomeBuilder()
+                .hasPrecipitation(hasPrecipitation)
+                .temperature(temperature)
+                .downfall(downfall)
+                .specialEffects(new BiomeSpecialEffects.Builder()
+                        .waterColor(ANOMALY_WATER_COLOR)
+                        .waterFogColor(ANOMALY_WATER_FOG_COLOR)
+                        .fogColor(ANOMALY_FOG_COLOR)
+                        .skyColor(ANOMALY_SKY_COLOR)
+                        .grassColorOverride(0x6E4FA7)
+                        .foliageColorOverride(0x7C57B7)
+                        .ambientMoodSound(AmbientMoodSettings.LEGACY_CAVE_SETTINGS)
+                        .backgroundMusic(defaultMusic())
+                        .build())
+                .mobSpawnSettings(spawns.build())
+                .generationSettings(generation.build())
+                .temperatureAdjustment(temperature < 0.0F
+                        ? Biome.TemperatureModifier.FROZEN
+                        : Biome.TemperatureModifier.NONE)
+                .build();
+    }
+
+    private static Music defaultMusic() {
+        return Musics.GAME;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/biome/ModBiomes.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/biome/ModBiomes.java
@@ -1,0 +1,30 @@
+package com.thunder.wildernessodysseyapi.WorldGen.biome;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.biome.Biome;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+public final class ModBiomes {
+    private ModBiomes() {
+    }
+
+    public static final DeferredRegister<Biome> BIOMES = DeferredRegister.create(Registries.BIOME, ModConstants.MOD_ID);
+
+    public static final ResourceKey<Biome> ANOMALY_PLAINS_KEY = ResourceKey.create(Registries.BIOME,
+            ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "anomaly_plains"));
+    public static final ResourceKey<Biome> ANOMALY_DESERT_KEY = ResourceKey.create(Registries.BIOME,
+            ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "anomaly_desert"));
+    public static final ResourceKey<Biome> ANOMALY_TUNDRA_KEY = ResourceKey.create(Registries.BIOME,
+            ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "anomaly_tundra"));
+    public static final ResourceKey<Biome> ANOMALY_RAINFOREST_KEY = ResourceKey.create(Registries.BIOME,
+            ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "anomaly_rainforest"));
+
+    public static final DeferredHolder<Biome, Biome> ANOMALY_PLAINS = BIOMES.register("anomaly_plains", AnomalyBiomes::anomalyPlains);
+    public static final DeferredHolder<Biome, Biome> ANOMALY_DESERT = BIOMES.register("anomaly_desert", AnomalyBiomes::anomalyDesert);
+    public static final DeferredHolder<Biome, Biome> ANOMALY_TUNDRA = BIOMES.register("anomaly_tundra", AnomalyBiomes::anomalyTundra);
+    public static final DeferredHolder<Biome, Biome> ANOMALY_RAINFOREST = BIOMES.register("anomaly_rainforest", AnomalyBiomes::anomalyRainforest);
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/client/biome/AnomalyZoneClientEffects.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/client/biome/AnomalyZoneClientEffects.java
@@ -1,0 +1,74 @@
+package com.thunder.wildernessodysseyapi.client.biome;
+
+import com.thunder.wildernessodysseyapi.Core.ModConstants;
+import com.thunder.wildernessodysseyapi.WorldGen.biome.ModBiomes;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+import net.neoforged.neoforge.client.event.ViewportEvent;
+
+@EventBusSubscriber(modid = ModConstants.MOD_ID, value = Dist.CLIENT)
+public final class AnomalyZoneClientEffects {
+    private AnomalyZoneClientEffects() {
+    }
+
+    @SubscribeEvent
+    public static void onFogColor(ViewportEvent.ComputeFogColor event) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.level == null || minecraft.player == null || !isInAnomalyBiome(minecraft.level, minecraft.player.blockPosition())) {
+            return;
+        }
+
+        event.setRed(event.getRed() * 0.75F + 0.25F);
+        event.setGreen(event.getGreen() * 0.45F);
+        event.setBlue(Math.min(1.0F, event.getBlue() * 0.85F + 0.2F));
+    }
+
+    @SubscribeEvent
+    public static void onClientTick(ClientTickEvent.Post event) {
+        Minecraft minecraft = Minecraft.getInstance();
+        Level level = minecraft.level;
+        if (level == null || minecraft.player == null) {
+            return;
+        }
+
+        BlockPos playerPos = minecraft.player.blockPosition();
+        if (!isInAnomalyBiome(level, playerPos)) {
+            return;
+        }
+
+        RandomSource random = level.getRandom();
+
+        // Constant distortion/ripple-like ambience.
+        for (int i = 0; i < 4; i++) {
+            double x = playerPos.getX() + random.nextDouble() * 12.0D - 6.0D;
+            double y = playerPos.getY() + random.nextDouble() * 2.0D + 0.5D;
+            double z = playerPos.getZ() + random.nextDouble() * 12.0D - 6.0D;
+            level.addParticle(ParticleTypes.PORTAL, x, y, z, 0.0D, 0.03D, 0.0D);
+        }
+
+        // Occasional lightning-like cracks.
+        if (random.nextInt(120) == 0) {
+            double x = playerPos.getX() + random.nextDouble() * 24.0D - 12.0D;
+            double y = playerPos.getY() + random.nextDouble() * 8.0D + 6.0D;
+            double z = playerPos.getZ() + random.nextDouble() * 24.0D - 12.0D;
+            level.addParticle(ParticleTypes.ELECTRIC_SPARK, x, y, z, 0.0D, -0.25D, 0.0D);
+        }
+    }
+
+    private static boolean isInAnomalyBiome(Level level, BlockPos pos) {
+        Holder<Biome> biome = level.getBiome(pos);
+        return biome.is(ModBiomes.ANOMALY_PLAINS_KEY)
+                || biome.is(ModBiomes.ANOMALY_DESERT_KEY)
+                || biome.is(ModBiomes.ANOMALY_TUNDRA_KEY)
+                || biome.is(ModBiomes.ANOMALY_RAINFOREST_KEY);
+    }
+}

--- a/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
+++ b/src/main/resources/assets/wildernessodysseyapi/lang/en_us.json
@@ -85,5 +85,9 @@
   "item.wildernessodysseyapi.music_disc_dustwinds": "Music Disc: Don't Be So Serious",
   "item.wildernessodysseyapi.music_disc_starfall": "Music Disc: Outside the Box",
   "jukebox_song.wildernessodysseyapi.dont_be_so_serious": "Don't Be So Serious",
-  "jukebox_song.wildernessodysseyapi.outside_the_box": "Outside the Box"
+  "jukebox_song.wildernessodysseyapi.outside_the_box": "Outside the Box",
+  "biome.wildernessodysseyapi.anomaly_plains": "Anomaly Plains",
+  "biome.wildernessodysseyapi.anomaly_desert": "Anomaly Desert",
+  "biome.wildernessodysseyapi.anomaly_tundra": "Anomaly Tundra",
+  "biome.wildernessodysseyapi.anomaly_rainforest": "Anomaly Rainforest"
 }

--- a/src/main/resources/data/minecraft/tags/worldgen/biome/is_overworld.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/is_overworld.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "wildernessodysseyapi:anomaly_plains",
+    "wildernessodysseyapi:anomaly_desert",
+    "wildernessodysseyapi:anomaly_tundra",
+    "wildernessodysseyapi:anomaly_rainforest"
+  ]
+}

--- a/src/main/resources/data/wildernessodysseyapi/tags/worldgen/biome/anomaly_zone.json
+++ b/src/main/resources/data/wildernessodysseyapi/tags/worldgen/biome/anomaly_zone.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "wildernessodysseyapi:anomaly_plains",
+    "wildernessodysseyapi:anomaly_desert",
+    "wildernessodysseyapi:anomaly_tundra",
+    "wildernessodysseyapi:anomaly_rainforest"
+  ]
+}


### PR DESCRIPTION
### Motivation

- Provide an "anomaly zone" biome family that can act as copies of vanilla-style biomes (plains, desert, tundra, rainforest) but with anomaly visuals and controllable mob spawns. 
- Make it easy to hard-code which vanilla and custom mobs spawn in these biomes and to expose client-only visual effects for players inside the zone.

### Description

- Register a new biome DeferredRegister and four biome entries (`anomaly_plains`, `anomaly_desert`, `anomaly_tundra`, `anomaly_rainforest`) in `WorldGen.biome.ModBiomes` and wire the register into mod initialization. 
- Implement biome builders in `WorldGen.biome.AnomalyBiomes` that mirror vanilla feature sets while applying anomaly-tinted sky/fog/water and custom biome generation settings. 
- Add `WorldGen.biome.AnomalyBiomeMobSettings` with hard-coded spawn lists per biome (vanilla mobs + `ModEntities.PURPLE_STORM_MONSTER`) so spawn weights and categories can be edited in one place. 
- Add client-side localized visual behavior in `client.biome.AnomalyZoneClientEffects`, overworld/biome tags and English localization entries, and a `docs/anomaly-zone.md` implementation note.

### Testing

- `./gradlew --version` succeeded in the environment used for the change. 
- Attempted `./gradlew compileJava -x test`, but the build could not complete because NeoForge attempted to download Mojang metadata and the environment reported an external TLS certificate validation failure (`SSLHandshakeException`), so a full compile could not be validated here. 
- No automated tests were run as part of this change in this environment due to the external download failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f13e9c7c8328a9ab5c6c52f65462)