### PR TITLE
Fix AnomalyBiomes API mismatches with NeoForge 1.21 biome builders

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/biome/AnomalyBiomes.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/biome/AnomalyBiomes.java
@@ -1,6 +1,8 @@
 package com.thunder.wildernessodysseyapi.WorldGen.biome;
 
 import net.minecraft.data.worldgen.BiomeDefaultFeatures;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.sounds.Music;
 import net.minecraft.sounds.Musics;
 import net.minecraft.world.level.biome.AmbientMoodSettings;
@@ -8,6 +10,8 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeGenerationSettings;
 import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.biome.MobSpawnSettings;
+import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
 public final class AnomalyBiomes {
     private static final int ANOMALY_SKY_COLOR = 0x7A59C7;
@@ -22,7 +26,7 @@ public final class AnomalyBiomes {
         MobSpawnSettings.Builder spawns = new MobSpawnSettings.Builder();
         AnomalyBiomeMobSettings.addPlainsSpawns(spawns);
 
-        BiomeGenerationSettings.Builder generation = new BiomeGenerationSettings.Builder();
+        BiomeGenerationSettings.Builder generation = generationBuilder();
         BiomeDefaultFeatures.addDefaultCarversAndLakes(generation);
         BiomeDefaultFeatures.addDefaultCrystalFormations(generation);
         BiomeDefaultFeatures.addDefaultMonsterRoom(generation);
@@ -34,7 +38,7 @@ public final class AnomalyBiomes {
         BiomeDefaultFeatures.addPlainGrass(generation);
         BiomeDefaultFeatures.addPlainVegetation(generation);
         BiomeDefaultFeatures.addDefaultMushrooms(generation);
-        BiomeDefaultFeatures.addDefaultExtraVegetation(generation, true);
+        BiomeDefaultFeatures.addDefaultExtraVegetation(generation);
 
         return baseBiome(true, 0.8F, 0.4F, spawns, generation);
     }
@@ -43,7 +47,7 @@ public final class AnomalyBiomes {
         MobSpawnSettings.Builder spawns = new MobSpawnSettings.Builder();
         AnomalyBiomeMobSettings.addDesertSpawns(spawns);
 
-        BiomeGenerationSettings.Builder generation = new BiomeGenerationSettings.Builder();
+        BiomeGenerationSettings.Builder generation = generationBuilder();
         BiomeDefaultFeatures.addFossilDecoration(generation);
         BiomeDefaultFeatures.addDefaultCarversAndLakes(generation);
         BiomeDefaultFeatures.addDefaultCrystalFormations(generation);
@@ -64,7 +68,7 @@ public final class AnomalyBiomes {
         MobSpawnSettings.Builder spawns = new MobSpawnSettings.Builder();
         AnomalyBiomeMobSettings.addTundraSpawns(spawns);
 
-        BiomeGenerationSettings.Builder generation = new BiomeGenerationSettings.Builder();
+        BiomeGenerationSettings.Builder generation = generationBuilder();
         BiomeDefaultFeatures.addDefaultCarversAndLakes(generation);
         BiomeDefaultFeatures.addDefaultCrystalFormations(generation);
         BiomeDefaultFeatures.addDefaultMonsterRoom(generation);
@@ -77,7 +81,7 @@ public final class AnomalyBiomes {
         BiomeDefaultFeatures.addDefaultFlowers(generation);
         BiomeDefaultFeatures.addTaigaGrass(generation);
         BiomeDefaultFeatures.addDefaultMushrooms(generation);
-        BiomeDefaultFeatures.addDefaultExtraVegetation(generation, false);
+        BiomeDefaultFeatures.addDefaultExtraVegetation(generation);
 
         return baseBiome(true, -0.45F, 0.8F, spawns, generation);
     }
@@ -86,7 +90,7 @@ public final class AnomalyBiomes {
         MobSpawnSettings.Builder spawns = new MobSpawnSettings.Builder();
         AnomalyBiomeMobSettings.addRainforestSpawns(spawns);
 
-        BiomeGenerationSettings.Builder generation = new BiomeGenerationSettings.Builder();
+        BiomeGenerationSettings.Builder generation = generationBuilder();
         BiomeDefaultFeatures.addDefaultCarversAndLakes(generation);
         BiomeDefaultFeatures.addDefaultCrystalFormations(generation);
         BiomeDefaultFeatures.addDefaultMonsterRoom(generation);
@@ -132,5 +136,11 @@ public final class AnomalyBiomes {
 
     private static Music defaultMusic() {
         return Musics.GAME;
+    }
+
+    private static BiomeGenerationSettings.Builder generationBuilder() {
+        HolderGetter<PlacedFeature> placedFeatures = BuiltInRegistries.PLACED_FEATURE.asLookup();
+        HolderGetter<ConfiguredWorldCarver<?>> worldCarvers = BuiltInRegistries.CONFIGURED_CARVER.asLookup();
+        return new BiomeGenerationSettings.Builder(placedFeatures, worldCarvers);
     }
 }


### PR DESCRIPTION
### Motivation
- The project failed to compile because `BiomeGenerationSettings.Builder` now requires registry-backed `HolderGetter` arguments and `BiomeDefaultFeatures.addDefaultExtraVegetation` has a changed signature in the target NeoForge/Minecraft API.

### Description
- Replaced no-arg `new BiomeGenerationSettings.Builder()` calls with a shared `generationBuilder()` helper that constructs `BiomeGenerationSettings.Builder(HolderGetter<PlacedFeature>, HolderGetter<ConfiguredWorldCarver<?>>)` using `BuiltInRegistries`.
- Removed the obsolete boolean parameter from `BiomeDefaultFeatures.addDefaultExtraVegetation(...)` calls to match the single-argument signature.
- Added imports for `HolderGetter`, `BuiltInRegistries`, `PlacedFeature`, and `ConfiguredWorldCarver` in `AnomalyBiomes.java`.
- Updated all biome factory methods (`anomalyPlains`, `anomalyDesert`, `anomalyTundra`, `anomalyRainforest`) to use the new helper and adjusted feature calls accordingly.

### Testing
- Ran `./gradlew compileJava --no-daemon`, which failed during the NeoForge/Mojang metadata download due to an external TLS certificate trust error (`SSLHandshakeException` / PKIX path building failed) and not because of Java source syntax.
- The original constructor- and signature-related compile errors reported for `AnomalyBiomes.java` are addressed by the code changes and no longer present in the source.
- No additional automated tests were run in this environment beyond the attempted `compileJava` step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995fe3fa53483289daa27b897a82f12)