### PR TITLE
Use Registries keys with built-in lookup in AnomalyBiomes generationBuilder

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/biome/AnomalyBiomes.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/WorldGen/biome/AnomalyBiomes.java
@@ -1,9 +1,11 @@
 package com.thunder.wildernessodysseyapi.WorldGen.biome;
 
-import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.BiomeDefaultFeatures;
 import net.minecraft.core.HolderGetter;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.sounds.Music;
 import net.minecraft.sounds.Musics;
 import net.minecraft.world.level.biome.AmbientMoodSettings;
@@ -140,8 +142,17 @@ public final class AnomalyBiomes {
     }
 
     private static BiomeGenerationSettings.Builder generationBuilder() {
-        HolderGetter<PlacedFeature> placedFeatures = Registries.PLACED_FEATURE.asLookup();
-        HolderGetter<ConfiguredWorldCarver<?>> worldCarvers = Registries.CONFIGURED_CARVER.asLookup();
+        HolderGetter<PlacedFeature> placedFeatures = lookup(Registries.PLACED_FEATURE);
+        HolderGetter<ConfiguredWorldCarver<?>> worldCarvers = lookup(Registries.CONFIGURED_CARVER);
         return new BiomeGenerationSettings.Builder(placedFeatures, worldCarvers);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> HolderGetter<T> lookup(ResourceKey<? extends Registry<T>> registryKey) {
+        Registry<?> registry = BuiltInRegistries.REGISTRY.getValue(registryKey.location());
+        if (registry == null) {
+            throw new IllegalStateException("Missing built-in registry for " + registryKey.location());
+        }
+        return ((Registry<T>) registry).asLookup();
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure `AnomalyBiomes` uses the regular `Registries` resource keys (`Registries.PLACED_FEATURE` and `Registries.CONFIGURED_CARVER`) while obtaining the actual registry instances required by `BiomeGenerationSettings.Builder`.
- Avoid calling `asLookup()` on keys directly and provide a robust resolution path to the built-in registries.

### Description
- Changed `generationBuilder()` to call a helper: `lookup(Registries.PLACED_FEATURE)` and `lookup(Registries.CONFIGURED_CARVER)` instead of calling `asLookup()` on the keys.
- Added a generic helper `private static <T> HolderGetter<T> lookup(ResourceKey<? extends Registry<T>> registryKey)` that resolves the registry via `BuiltInRegistries.REGISTRY.getValue(registryKey.location())`, casts to `Registry<T>`, and returns `asLookup()`.
- Added imports for `Registry`, `ResourceKey`, and `Registries` to support the new lookup implementation.
- Throw a clear `IllegalStateException` when the expected built-in registry is missing.

### Testing
- Ran `./gradlew compileJava --no-daemon` to validate the change, but the build failed during artifact download due to an environment SSL trust-chain error (`PKIX path building failed`) before Java compilation could complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699600c91608832880431de90438ed49)