### PR TITLE
Expand chunk failure diagnostics to global generation and upgrade pipeline

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/worldupgrade/WorldUpgradeManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/worldupgrade/WorldUpgradeManager.java
@@ -2,6 +2,7 @@ package com.thunder.wildernessodysseyapi.ModPackPatches.worldupgrade;
 
 import com.thunder.wildernessodysseyapi.core.ModAttachments;
 import com.thunder.wildernessodysseyapi.capabilities.ChunkDataCapability;
+import com.thunder.wildernessodysseyapi.util.ChunkErrorReporter;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
@@ -103,7 +104,12 @@ public final class WorldUpgradeManager {
                 migrated = migrateChunk(level, chunk, state.getTargetVersion());
             } catch (Exception exception) {
                 failed = true;
-                LOGGER.error("World upgrade failed at {} {}", task.dimension().location(), task.pos(), exception);
+                ServerLevel failedLevel = server.getLevel(task.dimension());
+                if (failedLevel != null) {
+                    ChunkErrorReporter.reportChunkError("upgrade", failedLevel, task.pos(), exception);
+                } else {
+                    LOGGER.error("World upgrade failed at {} {}", task.dimension().location(), task.pos(), exception);
+                }
             }
             state.onChunkProcessed(migrated, failed);
             processed++;

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/ChunkMapGenerationErrorMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/ChunkMapGenerationErrorMixin.java
@@ -1,0 +1,50 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.mojang.datafixers.util.Either;
+import com.thunder.wildernessodysseyapi.util.ChunkErrorReporter;
+import net.minecraft.server.level.ChunkHolder;
+import net.minecraft.server.level.ChunkMap;
+import net.minecraft.server.level.GenerationChunkHolder;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.StaticCache2D;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.status.ChunkStep;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Captures global chunk generation pipeline failures and logs full diagnostics with suspected mod hints.
+ */
+@Mixin(ChunkMap.class)
+public abstract class ChunkMapGenerationErrorMixin {
+    @Shadow @Final
+    private ServerLevel level;
+
+    @Inject(method = "applyStep", at = @At("RETURN"), cancellable = true)
+    private void wildernessodysseyapi$reportChunkGenerationFailures(GenerationChunkHolder holder,
+                                                                    ChunkStep step,
+                                                                    StaticCache2D<GenerationChunkHolder> cache,
+                                                                    boolean loading,
+                                                                    CallbackInfoReturnable<CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>>> cir) {
+        CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> original = cir.getReturnValue();
+        if (original == null) {
+            return;
+        }
+
+        ChunkPos chunkPos = holder.getPos();
+        CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> wrapped = original.whenComplete((result, throwable) -> {
+            if (throwable == null) {
+                return;
+            }
+            ChunkErrorReporter.reportChunkError("generation/%s".formatted(step), this.level, chunkPos, throwable);
+        });
+        cir.setReturnValue(wrapped);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/ChunkMapGenerationErrorMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/ChunkMapGenerationErrorMixin.java
@@ -1,14 +1,11 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
-import com.mojang.datafixers.util.Either;
 import com.thunder.wildernessodysseyapi.util.ChunkErrorReporter;
-import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.GenerationChunkHolder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.StaticCache2D;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.status.ChunkStep;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -32,14 +29,14 @@ public abstract class ChunkMapGenerationErrorMixin {
                                                                     ChunkStep step,
                                                                     StaticCache2D<GenerationChunkHolder> cache,
                                                                     boolean loading,
-                                                                    CallbackInfoReturnable<CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>>> cir) {
-        CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> original = cir.getReturnValue();
+                                                                    CallbackInfoReturnable<CompletableFuture<?>> cir) {
+        CompletableFuture<?> original = cir.getReturnValue();
         if (original == null) {
             return;
         }
 
         ChunkPos chunkPos = holder.getPos();
-        CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> wrapped = original.whenComplete((result, throwable) -> {
+        CompletableFuture<?> wrapped = original.whenComplete((result, throwable) -> {
             if (throwable == null) {
                 return;
             }

--- a/src/main/java/com/thunder/wildernessodysseyapi/util/ChunkErrorReporter.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/util/ChunkErrorReporter.java
@@ -1,0 +1,118 @@
+package com.thunder.wildernessodysseyapi.util;
+
+import com.thunder.wildernessodysseyapi.core.ModConstants;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
+import net.neoforged.fml.ModList;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Centralized logging helper for chunk generation/upgrade failures.
+ */
+public final class ChunkErrorReporter {
+    private static final Set<String> FRAMEWORK_PACKAGES = Set.of(
+            "java.", "javax.", "jdk.", "sun.", "com.sun.",
+            "net.minecraft.", "com.mojang.", "org.spongepowered.", "net.neoforged.",
+            "com.thunder.wildernessodysseyapi."
+    );
+
+    private ChunkErrorReporter() {
+    }
+
+    public static void reportChunkError(String operation,
+                                        ServerLevel level,
+                                        ChunkPos chunkPos,
+                                        Throwable throwable) {
+        ResourceLocation dimension = level.dimension().location();
+        String suspectedMods = formatSuspectedMods(throwable);
+        Throwable rootCause = rootCause(throwable);
+
+        ModConstants.LOGGER.error(
+                "Chunk {} failed in [{}] at chunk {} (block {}). Suspected mods: {}. Root cause: {}: {}",
+                operation,
+                dimension,
+                chunkPos,
+                chunkPos.getWorldPosition(),
+                suspectedMods,
+                rootCause.getClass().getName(),
+                rootCause.getMessage(),
+                throwable
+        );
+    }
+
+    private static String formatSuspectedMods(Throwable throwable) {
+        Set<String> knownMods = ModList.get().getMods().stream()
+                .map(info -> info.getModId().toLowerCase(Locale.ROOT))
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+
+        Set<String> matches = new LinkedHashSet<>();
+        Throwable cursor = throwable;
+        while (cursor != null && matches.size() < 6) {
+            for (StackTraceElement frame : cursor.getStackTrace()) {
+                String className = frame.getClassName();
+                if (isFrameworkClass(className)) {
+                    continue;
+                }
+
+                String lowerName = className.toLowerCase(Locale.ROOT);
+                for (String modId : knownMods) {
+                    if (matches.size() >= 6) {
+                        break;
+                    }
+                    if (containsModHint(lowerName, modId)) {
+                        matches.add(modId);
+                    }
+                }
+
+                if (matches.size() >= 6) {
+                    break;
+                }
+            }
+            cursor = cursor.getCause();
+            if (cursor == throwable) {
+                break;
+            }
+        }
+
+        if (matches.isEmpty()) {
+            return "unknown";
+        }
+
+        List<String> sorted = new ArrayList<>(matches);
+        sorted.sort(Comparator.naturalOrder());
+        return String.join(", ", sorted);
+    }
+
+    private static boolean containsModHint(String className, String modId) {
+        String normalized = modId.replace('-', '_');
+        return className.contains('.' + modId + '.')
+                || className.contains('.' + normalized + '.')
+                || className.contains("/" + modId + "/")
+                || className.endsWith('.' + modId)
+                || className.endsWith('.' + normalized);
+    }
+
+    private static boolean isFrameworkClass(String className) {
+        for (String prefix : FRAMEWORK_PACKAGES) {
+            if (className.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Throwable rootCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        return current;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/structure/NBTStructurePlacer.java
@@ -1,6 +1,7 @@
 package com.thunder.wildernessodysseyapi.worldgen.structure;
 
 import com.thunder.wildernessodysseyapi.core.ModConstants;
+import com.thunder.wildernessodysseyapi.util.ChunkErrorReporter;
 import com.thunder.wildernessodysseyapi.worldgen.configurable.StructureConfig;
 import com.thunder.wildernessodysseyapi.worldgen.structure.StructurePlacementDebugger.PlacementAttempt;
 import com.thunder.wildernessodysseyapi.worldgen.structure.TerrainReplacerEngine.SurfaceSample;
@@ -15,6 +16,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
@@ -168,75 +170,75 @@ public class NBTStructurePlacer {
                                                 TemplateData data,
                                                 PlacementFoundation foundation,
                                                 PlacementAttempt attempt) {
-        LargeStructurePlacementOptimizer.preparePlacement(level, foundation.origin(), data.size());
-        if (LargeStructurePlacementOptimizer.exceedsStructureBlockLimit(data.size())) {
-            int estimated = LargeStructurePlacementOptimizer.estimateAffectedBlocks(data.size());
-            ModConstants.LOGGER.warn("Placing structure {} will touch approximately {} blocks, exceeding the recommended limit of {}.",
-                    id, estimated, StructureUtils.STRUCTURE_BLOCK_LIMIT);
-        }
+        try {
+            LargeStructurePlacementOptimizer.preparePlacement(level, foundation.origin(), data.size());
+            if (LargeStructurePlacementOptimizer.exceedsStructureBlockLimit(data.size())) {
+                int estimated = LargeStructurePlacementOptimizer.estimateAffectedBlocks(data.size());
+                ModConstants.LOGGER.warn("Placing structure {} will touch approximately {} blocks, exceeding the recommended limit of {}.",
+                        id, estimated, StructureUtils.STRUCTURE_BLOCK_LIMIT);
+            }
 
-        BoundingBox placementBox = expandPlacementBox(foundation.origin(), data.size(), data.template());
-        if (isStarterBunker()) {
-            clearColumnsForStarterBunker(level, foundation.origin(), data.size());
-        }
-        StructurePlaceSettings settings = new StructurePlaceSettings()
-                // We already know the template dimensions, so skip the expensive shape discovery pass.
-                .setKnownShape(true)
-                // Supplying the bounds up-front prevents the vanilla placer from bailing out when it cannot
-                // infer them (which resulted in the template refusing to place while terrain markers still
-                // ran).
-                .setBoundingBox(placementBox)
-                // Preserve entities baked into the template (e.g., Create super glue and contraptions) so
-                // complex machines such as elevators remain assembled after placement.
-                .setIgnoreEntities(false);
-        for (StructureProcessor processor : extraProcessors) {
-            settings.addProcessor(processor);
-        }
-        boolean placed = data.template().placeInWorld(level, foundation.origin(), foundation.origin(), settings, level.random, 2);
-        if (!placed) {
-            StructurePlacementDebugger.markFailure(attempt, "template refused placement");
+            BoundingBox placementBox = expandPlacementBox(foundation.origin(), data.size(), data.template());
+            if (isStarterBunker()) {
+                clearColumnsForStarterBunker(level, foundation.origin(), data.size());
+            }
+            StructurePlaceSettings settings = new StructurePlaceSettings()
+                    .setKnownShape(true)
+                    .setBoundingBox(placementBox)
+                    .setIgnoreEntities(false);
+            for (StructureProcessor processor : extraProcessors) {
+                settings.addProcessor(processor);
+            }
+            boolean placed = data.template().placeInWorld(level, foundation.origin(), foundation.origin(), settings, level.random, 2);
+            if (!placed) {
+                StructurePlacementDebugger.markFailure(attempt, "template refused placement");
+                return null;
+            }
+
+            if (isStarterBunker()) {
+                clearTerrainInsideStructure(level, foundation.origin(), data.size(), data.template());
+                replaceStarterBunkerSurfaceBlocks(level, foundation.origin(), data.size(), placementBox);
+            }
+
+            int autoBlended = 0;
+            if (StructureConfig.ENABLE_AUTO_TERRAIN_BLEND.get()) {
+                int maxDepth = StructureConfig.AUTO_TERRAIN_BLEND_MAX_DEPTH.get();
+                int radius = resolveAutoBlendRadius(data.size());
+                TerrainReplacerEngine.AutoBlendMask mask = TerrainReplacerEngine.AutoBlendMask.allowAll();
+                if (!isStarterBunker() && StructureConfig.ENABLE_SMART_AUTO_TERRAIN_BLEND.get()) {
+                    mask = buildAutoBlendMask(data.template(), foundation.origin(), data.size());
+                }
+                autoBlended = TerrainReplacerEngine.applyAutoBlend(level, placementBox, maxDepth, radius, mask);
+            }
+
+            if (data.levelingOffset() != null && foundation.levelingReplacement() != null) {
+                BlockPos markerWorldPos = foundation.origin().offset(data.levelingOffset());
+                BlockState markerReplacement = normalizeLevelingReplacement(foundation.levelingReplacement());
+                level.setBlock(markerWorldPos, markerReplacement, 2);
+            }
+
+            Vec3i size = data.size();
+            AABB bounds = LargeStructurePlacementOptimizer.createBounds(foundation.origin(), size);
+            List<AABB> chunkSlices = LargeStructurePlacementOptimizer.computeChunkSlices(foundation.origin(), size);
+
+            activateCreateElevators(level, foundation.origin(), data.elevatorPulleyOffsets());
+
+            List<BlockPos> cryoOffsets = data.cryoOffsets();
+            List<BlockPos> cryoPositions = new ArrayList<>(cryoOffsets.size());
+            for (BlockPos offset : cryoOffsets) {
+                cryoPositions.add(foundation.origin().offset(offset));
+            }
+
+            StructurePlacementDebugger.markSuccess(attempt,
+                    "placed with %s auto-blended blocks and %s cryo tubes"
+                            .formatted(autoBlended, cryoPositions.size()));
+
+            return new PlacementResult(foundation.origin(), bounds, cryoPositions, List.copyOf(chunkSlices));
+        } catch (Exception exception) {
+            StructurePlacementDebugger.markFailure(attempt, "exception: " + exception.getClass().getSimpleName());
+            ChunkErrorReporter.reportChunkError("generation", level, new ChunkPos(foundation.origin()), exception);
             return null;
         }
-
-        if (isStarterBunker()) {
-            clearTerrainInsideStructure(level, foundation.origin(), data.size(), data.template());
-            replaceStarterBunkerSurfaceBlocks(level, foundation.origin(), data.size(), placementBox);
-        }
-
-        int autoBlended = 0;
-        if (StructureConfig.ENABLE_AUTO_TERRAIN_BLEND.get()) {
-            int maxDepth = StructureConfig.AUTO_TERRAIN_BLEND_MAX_DEPTH.get();
-            int radius = resolveAutoBlendRadius(data.size());
-            TerrainReplacerEngine.AutoBlendMask mask = TerrainReplacerEngine.AutoBlendMask.allowAll();
-            if (!isStarterBunker() && StructureConfig.ENABLE_SMART_AUTO_TERRAIN_BLEND.get()) {
-                mask = buildAutoBlendMask(data.template(), foundation.origin(), data.size());
-            }
-            autoBlended = TerrainReplacerEngine.applyAutoBlend(level, placementBox, maxDepth, radius, mask);
-        }
-
-        if (data.levelingOffset() != null && foundation.levelingReplacement() != null) {
-            BlockPos markerWorldPos = foundation.origin().offset(data.levelingOffset());
-            BlockState markerReplacement = normalizeLevelingReplacement(foundation.levelingReplacement());
-            level.setBlock(markerWorldPos, markerReplacement, 2);
-        }
-
-        Vec3i size = data.size();
-        AABB bounds = LargeStructurePlacementOptimizer.createBounds(foundation.origin(), size);
-        List<AABB> chunkSlices = LargeStructurePlacementOptimizer.computeChunkSlices(foundation.origin(), size);
-
-        activateCreateElevators(level, foundation.origin(), data.elevatorPulleyOffsets());
-
-        List<BlockPos> cryoOffsets = data.cryoOffsets();
-        List<BlockPos> cryoPositions = new ArrayList<>(cryoOffsets.size());
-        for (BlockPos offset : cryoOffsets) {
-            cryoPositions.add(foundation.origin().offset(offset));
-        }
-
-        StructurePlacementDebugger.markSuccess(attempt,
-                "placed with %s auto-blended blocks and %s cryo tubes"
-                        .formatted(autoBlended, cryoPositions.size()));
-
-        return new PlacementResult(foundation.origin(), bounds, cryoPositions, List.copyOf(chunkSlices));
     }
 
     /** Returns the template id used by this placer. */

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "refmap": "mixins.wildernessodysseyapi.refmap.json",
   "mixins": [
+    "ChunkMapGenerationErrorMixin",
     "CreatePathsMixin",
     "BlockEntityMixin",
     "DayNightCycleMixin",


### PR DESCRIPTION
### Motivation
- Make chunk failure diagnostics global so both the central chunk generation pipeline and the separate world-upgrade flow emit rich, consistent diagnostics for easier debugging.  
- Capture full stack traces, root causes, chunk coordinates and a short heuristic list of suspected mod IDs to help maintainers quickly identify offenders.  

### Description
- Add a new mixin `ChunkMapGenerationErrorMixin` that hooks `ChunkMap.applyStep` and wraps the returned completion future to report any async generation exceptions via `ChunkErrorReporter` (new file: `src/main/java/com/thunder/wildernessodysseyapi/mixin/ChunkMapGenerationErrorMixin.java`).  
- Improve `ChunkErrorReporter` to walk the throwable cause chain when scanning stack frames for suspected mod hints, and log the root cause plus the full throwable and chunk metadata (updated: `src/main/java/com/thunder/wildernessodysseyapi/util/ChunkErrorReporter.java`).  
- Route world-upgrade failures through the shared reporter in `WorldUpgradeManager.runTick` so upgrade exceptions emit the same diagnostics when the failing `ServerLevel` is available (updated: `src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/worldupgrade/WorldUpgradeManager.java`).  
- Wrap structure placement execution in `NBTStructurePlacer.placeWithFoundation` with a `try/catch` that marks the placement attempt as failed and reports generation exceptions through the reporter (updated: `src/main/java/com/thunder/wildernessodysseyapi/worldgen/structure/NBTStructurePlacer.java`).  
- Register the new mixin in the mixin configuration (`src/main/resources/mixins.wildernessodysseyapi.json`).  

### Testing
- Ran `./gradlew compileJava` to validate compilation and integration; the build run failed in this environment during NeoForge/Mojang artifact metadata download with an SSL/TLS trust error (`SSLHandshakeException: PKIX path building failed`) before compilation could complete, so no successful compile was produced.  
- No other automated tests were executed in this environment due to the external TLS download failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df0c4aebc832880af7ce229fb546d)