### PR TITLE
Add configurable True Darkness night-darkening (config + mixins)

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/config/TrueDarknessConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/config/TrueDarknessConfig.java
@@ -1,0 +1,38 @@
+package com.thunder.wildernessodysseyapi.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public final class TrueDarknessConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+    public static final ModConfigSpec.BooleanValue ENABLED;
+    public static final ModConfigSpec.DoubleValue DARKNESS_STRENGTH;
+    public static final ModConfigSpec.DoubleValue MOONLIGHT_INFLUENCE;
+    public static final ModConfigSpec.DoubleValue MIN_NIGHT_BRIGHTNESS;
+
+    static {
+        ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
+        builder.push("true_darkness");
+
+        ENABLED = builder
+                .comment("Enable darker nights similar to True Darkness.")
+                .define("enabled", true);
+
+        DARKNESS_STRENGTH = builder
+                .comment("How much darker night sky darkening becomes. 0.0 = vanilla, 1.0 = very dark.")
+                .defineInRange("darknessStrength", 0.8D, 0.0D, 1.0D);
+
+        MOONLIGHT_INFLUENCE = builder
+                .comment("How much moon phase reduces darkness. 0.0 = ignore moon, 1.0 = strongest moonlight impact.")
+                .defineInRange("moonlightInfluence", 0.55D, 0.0D, 1.0D);
+
+        MIN_NIGHT_BRIGHTNESS = builder
+                .comment("Minimum brightness multiplier at midnight. Lower values produce truer black nights.")
+                .defineInRange("minNightBrightness", 0.02D, 0.0D, 1.0D);
+
+        builder.pop();
+        CONFIG_SPEC = builder.build();
+    }
+
+    private TrueDarknessConfig() {
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
@@ -31,6 +31,7 @@ import com.thunder.wildernessodysseyapi.config.CloakChipConfig;
 import com.thunder.wildernessodysseyapi.config.CurioRenderConfig;
 import com.thunder.wildernessodysseyapi.config.DebugOverlayConfig;
 import com.thunder.wildernessodysseyapi.config.StructureBlockConfig;
+import com.thunder.wildernessodysseyapi.config.TrueDarknessConfig;
 import com.thunder.wildernessodysseyapi.item.ModCreativeTabs;
 import com.thunder.wildernessodysseyapi.entity.ModEntities;
 import com.thunder.wildernessodysseyapi.item.ModItems;
@@ -146,6 +147,8 @@ public class WildernessOdysseyAPIMainModClass {
                 CONFIG_FOLDER + "wildernessodysseyapi-telemetry-client.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.CLIENT, DebugOverlayConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-debug-overlay-client.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.CLIENT, TrueDarknessConfig.CONFIG_SPEC,
+                CONFIG_FOLDER + "wildernessodysseyapi-true-darkness-client.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, AsyncThreadingConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-async.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, StructureBlockConfig.CONFIG_SPEC,

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/ClientLevelTrueDarknessMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/ClientLevelTrueDarknessMixin.java
@@ -1,0 +1,65 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.thunder.wildernessodysseyapi.config.TrueDarknessConfig;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.util.Mth;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClientLevel.class)
+public class ClientLevelTrueDarknessMixin {
+
+    @Inject(method = "getSkyDarken", at = @At("RETURN"), cancellable = true)
+    private void wildernessodysseyapi$applyTrueDarkness(float partialTick, CallbackInfoReturnable<Float> cir) {
+        if (!TrueDarknessConfig.ENABLED.get()) {
+            return;
+        }
+
+        ClientLevel level = (ClientLevel) (Object) this;
+        if (!level.dimensionType().hasSkyLight()) {
+            return;
+        }
+
+        float nightFactor = getNightFactor(level.getDayTime());
+        if (nightFactor <= 0.0F) {
+            return;
+        }
+
+        float baseDarken = cir.getReturnValue();
+        float strength = TrueDarknessConfig.DARKNESS_STRENGTH.get().floatValue();
+        float moonlightInfluence = TrueDarknessConfig.MOONLIGHT_INFLUENCE.get().floatValue();
+
+        float moonVisibility = getMoonVisibility(level.getMoonPhase());
+        float moonlightLift = moonVisibility * moonlightInfluence * 0.35F;
+
+        float boostedDarken = baseDarken + (strength * nightFactor);
+        boostedDarken -= moonlightLift * nightFactor;
+
+        cir.setReturnValue(Mth.clamp(boostedDarken, 0.0F, 1.0F));
+    }
+
+    private static float getNightFactor(long gameTime) {
+        long dayTime = Math.floorMod(gameTime, 24000L);
+        if (dayTime < 12000L || dayTime > 23000L) {
+            return 0.0F;
+        }
+
+        if (dayTime <= 18000L) {
+            return (dayTime - 12000L) / 6000.0F;
+        }
+
+        return (23000L - dayTime) / 5000.0F;
+    }
+
+    private static float getMoonVisibility(int moonPhase) {
+        return switch (moonPhase) {
+            case 0 -> 1.0F;
+            case 1, 7 -> 0.8F;
+            case 2, 6 -> 0.55F;
+            case 3, 5 -> 0.3F;
+            default -> 0.1F;
+        };
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/LightTextureTrueDarknessMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/LightTextureTrueDarknessMixin.java
@@ -1,0 +1,76 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.thunder.wildernessodysseyapi.config.TrueDarknessConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.client.renderer.LightTexture;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(LightTexture.class)
+public class LightTextureTrueDarknessMixin {
+
+    @Inject(method = "getBrightness", at = @At("RETURN"), cancellable = true)
+    private static void wildernessodysseyapi$darkenLightmapAtNight(
+            DimensionType dimensionType,
+            int lightLevel,
+            CallbackInfoReturnable<Float> cir
+    ) {
+        if (!TrueDarknessConfig.ENABLED.get() || !dimensionType.hasSkyLight()) {
+            return;
+        }
+
+        Minecraft minecraft = Minecraft.getInstance();
+        ClientLevel level = minecraft.level;
+        if (level == null) {
+            return;
+        }
+
+        float nightFactor = getNightFactor(level.getDayTime());
+        if (nightFactor <= 0.0F) {
+            return;
+        }
+
+        float baseBrightness = cir.getReturnValue();
+        float strength = TrueDarknessConfig.DARKNESS_STRENGTH.get().floatValue();
+        float minNightBrightness = TrueDarknessConfig.MIN_NIGHT_BRIGHTNESS.get().floatValue();
+        float moonlightInfluence = TrueDarknessConfig.MOONLIGHT_INFLUENCE.get().floatValue();
+
+        float lightLevelFactor = 1.0F - (lightLevel / 15.0F);
+        float moonVisibility = getMoonVisibility(level.getMoonPhase());
+        float moonCompensation = moonVisibility * moonlightInfluence * 0.35F * nightFactor;
+
+        float reduction = strength * nightFactor * lightLevelFactor;
+        float darkened = baseBrightness * (1.0F - reduction);
+
+        float minimum = minNightBrightness + moonCompensation;
+        cir.setReturnValue(Mth.clamp(Math.max(darkened, minimum), 0.0F, 1.0F));
+    }
+
+    private static float getNightFactor(long gameTime) {
+        long dayTime = Math.floorMod(gameTime, 24000L);
+        if (dayTime < 12000L || dayTime > 23000L) {
+            return 0.0F;
+        }
+
+        if (dayTime <= 18000L) {
+            return (dayTime - 12000L) / 6000.0F;
+        }
+
+        return (23000L - dayTime) / 5000.0F;
+    }
+
+    private static float getMoonVisibility(int moonPhase) {
+        return switch (moonPhase) {
+            case 0 -> 1.0F;
+            case 1, 7 -> 0.8F;
+            case 2, 6 -> 0.55F;
+            case 3, 5 -> 0.3F;
+            default -> 0.1F;
+        };
+    }
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -26,6 +26,8 @@
     "MixinWorldCreationUiState",
     "OptionsScreenTelemetryButtonMixin",
     "StructureBlockRendererMixin",
-    "ClientLevelWeatherColorMixin"
+    "ClientLevelWeatherColorMixin",
+    "ClientLevelTrueDarknessMixin",
+    "LightTextureTrueDarknessMixin"
   ]
 }


### PR DESCRIPTION
### Motivation

- Provide an optional, configurable "True Darkness" effect to make nights darker and more atmospheric while allowing moon phase influence and a configurable minimum night brightness.
- Apply the effect on the client-side light calculations so it affects sky darkening and the lightmap without changing world generation or server logic.

### Description

- Add `TrueDarknessConfig` with `ENABLED`, `DARKNESS_STRENGTH`, `MOONLIGHT_INFLUENCE`, and `MIN_NIGHT_BRIGHTNESS` values and register it as a client config in `WildernessOdysseyAPIMainModClass` under `wildernessodysseyapi-true-darkness-client.toml`.
- Implement `ClientLevelTrueDarknessMixin` injecting into `ClientLevel.getSkyDarken` to boost night sky darkening based on a computed `nightFactor`, configured strength, and moon phase visibility with clamping.
- Implement `LightTextureTrueDarknessMixin` injecting into `LightTexture.getBrightness` to reduce the lightmap brightness at night based on configured strength, light level, minimum brightness and moon compensation.
- Register the two new mixins in `mixins.wildernessodysseyapi.json` under the `client` mixin list.

### Testing

- Ran a full project build with `./gradlew build`, which completed successfully and produced no compilation errors.
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a8e634988328b5c6830a0da248af)