### PR TITLE
Fix WorldVersionClientChecker world name lookup for NeoForge mappings

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/WorldVersionClientChecker.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/WorldVersionClientChecker.java
@@ -91,7 +91,7 @@ public class WorldVersionClientChecker {
                     .resolve("world_version.json");
         }
         if (mc.level != null) {
-            String worldName = mc.level.getLevelData().getLevelName();
+            String worldName = mc.level.dimension().location().getPath();
             return mc.gameDirectory.toPath()
                     .resolve("saves")
                     .resolve(worldName)


### PR DESCRIPTION
### Motivation
- Resolve a compile-time symbol error by replacing the removed `ClientLevelData#getLevelName()` call with an API-compatible lookup for the current NeoForge/mappings.

### Description
- Replaced `mc.level.getLevelData().getLevelName()` with `mc.level.dimension().location().getPath()` in `WorldVersionClientChecker#getWorldVersionPath()` to obtain the current world folder name.

### Testing
- Ran `./gradlew compileJava --no-daemon` to validate the change, but the build was blocked during `:createMinecraftArtifacts` by an SSL certificate/PKIX trust failure while downloading Mojang metadata, so compilation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b197246ecc832889a0d727963677ee)