### PR TITLE
Add `/locate lastdeath` alias redirecting to legacy `/locate last death`

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/command/LocateLastDeathAliasCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/LocateLastDeathAliasCommand.java
@@ -1,0 +1,31 @@
+package com.thunder.wildernessodysseyapi.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.tree.CommandNode;
+import net.minecraft.commands.CommandSourceStack;
+
+public final class LocateLastDeathAliasCommand {
+    private LocateLastDeathAliasCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        CommandNode<CommandSourceStack> locateNode = dispatcher.getRoot().getChild("locate");
+        if (locateNode == null || locateNode.getChild("lastdeath") != null) {
+            return;
+        }
+
+        CommandNode<CommandSourceStack> legacyLastDeathNode = locateNode.getChild("last");
+        if (legacyLastDeathNode != null) {
+            legacyLastDeathNode = legacyLastDeathNode.getChild("death");
+        }
+
+        if (legacyLastDeathNode == null) {
+            return;
+        }
+
+        locateNode.addChild(LiteralArgumentBuilder.<CommandSourceStack>literal("lastdeath")
+                .redirect(legacyLastDeathNode)
+                .build());
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
@@ -10,6 +10,7 @@ import com.thunder.wildernessodysseyapi.command.GlobalChatCommand;
 import com.thunder.wildernessodysseyapi.command.GlobalChatOptToggleCommand;
 import com.thunder.wildernessodysseyapi.command.ChangelogCommand;
 import com.thunder.wildernessodysseyapi.command.LoreBookCommand;
+import com.thunder.wildernessodysseyapi.command.LocateLastDeathAliasCommand;
 import com.thunder.wildernessodysseyapi.feedback.FeedbackCommand;
 import com.thunder.wildernessodysseyapi.command.WorldUpgradeCommand;
 import com.thunder.wildernessodysseyapi.feedback.FeedbackConfig;
@@ -224,6 +225,7 @@ public class WildernessOdysseyAPIMainModClass {
         FeedbackCommand.register(dispatcher);
         WorldUpgradeCommand.register(dispatcher);
         AIBackendCommand.register(dispatcher);
+        LocateLastDeathAliasCommand.register(dispatcher);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Provide a cleaner `/locate lastdeath` syntax by aliasing it to the existing legacy `/locate last death` node so users can use the expected single-token form without changing behavior.

### Description
- Add `LocateLastDeathAliasCommand` which inspects the dispatcher for a `/locate last death` node and registers a `/locate lastdeath` literal that redirects to the legacy node.
- Wire the alias into the command registration flow by importing and calling `LocateLastDeathAliasCommand.register(dispatcher)` in `WildernessOdysseyAPIMainModClass`.

### Testing
- Ran `./gradlew compileJava` to validate compilation, which failed in this environment due to an SSL certificate trust error while downloading Mojang metadata (`PKIX path building failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b457840bb48328b1666ecdaa6f29f6)