### PR TITLE
Blend starter bunker perimeter into terrain and add terrain-integration checklist

### DIFF
--- a/docs/bunker-terrain-integration.md
+++ b/docs/bunker-terrain-integration.md
@@ -1,0 +1,38 @@
+# Starter bunker terrain-integration checklist
+
+Use this checklist when editing the `wildernessodysseyapi:bunker` template so the top floor blends into terrain more naturally.
+
+## 1) Edit the bunker NBT template
+
+- Put a **blue wool** leveling marker at the exact point where you want terrain contact to happen.
+  - Prefer a marker near the center of the bunker footprint.
+  - Keep it on the intended top-floor contact band (not on decorative roof details).
+- Shape the outer top-floor edge as a transition zone:
+  - Use irregular edges instead of a perfect rectangle.
+  - Add a 1-3 block-wide ring of terrain-friendly blocks around the exterior edge.
+  - Avoid thin floating lips at corners.
+
+## 2) Validate anchoring in-game
+
+Use placement commands while iterating on the NBT:
+
+- `/modpackstructures reload`
+- `/modpackstructures place wildernessodysseyapi:modpack/<your_bunker_id> <x> <y> <z> true`
+
+`alignToSurface=true` ensures anchored placement is used while testing.
+
+## 3) Tune terrain blending config for bunker tests
+
+In `serverconfig/wildernessodysseyapi-server.toml`:
+
+- `enableAutoTerrainBlend = true`
+- `enableSmartAutoTerrainBlend = true`
+- Start with:
+  - `autoTerrainBlendMaxDepth = 6`
+  - `autoTerrainBlendRadius = 2`
+
+If bunker edges still look abrupt, increase blend radius first, then max depth.
+
+## 4) What code now does automatically for the starter bunker
+
+When the starter bunker is placed, the placer now also runs a dedicated perimeter pass that blends surface blocks in a short ring (3 blocks wide) around the bunker footprint. This helps the top floor visually merge with surrounding terrain instead of ending in a hard border.

--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/structure/NBTStructurePlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/structure/NBTStructurePlacer.java
@@ -52,6 +52,8 @@ public class NBTStructurePlacer {
     private static final int MIN_LEVELING_MARKER_Y = 62;
     private static final int MAX_LEVELING_MARKER_Y = 65;
     private static final String[] PALETTE_BLOCK_FIELD_NAMES = {"blocks", "blockInfos", "blockInfoList"};
+    private static final int STARTER_BUNKER_PERIMETER_BLEND_RADIUS = 3;
+    private static final int STARTER_BUNKER_PERIMETER_BLEND_DEPTH = 2;
     private static final java.util.concurrent.ConcurrentMap<Class<?>, java.util.Optional<Field>> PALETTE_BLOCK_FIELDS =
             new java.util.concurrent.ConcurrentHashMap<>();
     private static boolean loggedPaletteFieldWarning = false;
@@ -198,6 +200,7 @@ public class NBTStructurePlacer {
             if (isStarterBunker()) {
                 clearTerrainInsideStructure(level, foundation.origin(), data.size(), data.template());
                 replaceStarterBunkerSurfaceBlocks(level, foundation.origin(), data.size(), placementBox);
+                blendStarterBunkerPerimeter(level, foundation.origin(), data.size(), placementBox);
             }
 
             int autoBlended = 0;
@@ -828,6 +831,81 @@ public class NBTStructurePlacer {
                 level.setBlock(cursor, replacement, 2);
             }
         }
+    }
+
+    private void blendStarterBunkerPerimeter(ServerLevel level,
+                                             BlockPos origin,
+                                             Vec3i size,
+                                             BoundingBox bounds) {
+        if (bounds == null) {
+            return;
+        }
+        int sizeX = size.getX();
+        int sizeZ = size.getZ();
+        if (sizeX <= 0 || sizeZ <= 0) {
+            return;
+        }
+
+        int minX = origin.getX() - STARTER_BUNKER_PERIMETER_BLEND_RADIUS;
+        int minZ = origin.getZ() - STARTER_BUNKER_PERIMETER_BLEND_RADIUS;
+        int maxX = origin.getX() + sizeX - 1 + STARTER_BUNKER_PERIMETER_BLEND_RADIUS;
+        int maxZ = origin.getZ() + sizeZ - 1 + STARTER_BUNKER_PERIMETER_BLEND_RADIUS;
+
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        for (int x = minX; x <= maxX; x++) {
+            for (int z = minZ; z <= maxZ; z++) {
+                int edgeDistance = distanceToBounds2D(x, z, bounds);
+                if (edgeDistance <= 0 || edgeDistance > STARTER_BUNKER_PERIMETER_BLEND_RADIUS) {
+                    continue;
+                }
+
+                int surfaceY = level.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, x, z) - 1;
+                cursor.set(x, surfaceY, z);
+                BlockState existing = level.getBlockState(cursor);
+                if (!isSurfaceReplacementCandidate(existing)) {
+                    continue;
+                }
+
+                TerrainReplacerEngine.SurfaceMaterial material =
+                        TerrainReplacerEngine.sampleSurfaceMaterialOutsideBounds(level, cursor, bounds);
+
+                int depth = Math.max(1, STARTER_BUNKER_PERIMETER_BLEND_DEPTH - (edgeDistance - 1));
+                int minY = surfaceY - (depth - 1);
+                for (int y = surfaceY; y >= minY; y--) {
+                    cursor.setY(y);
+                    BlockState stateAtY = level.getBlockState(cursor);
+                    if (!isSurfaceReplacementCandidate(stateAtY)) {
+                        break;
+                    }
+                    BlockState replacement = TerrainReplacerEngine.chooseReplacement(material, y);
+                    if (replacement != stateAtY) {
+                        level.setBlock(cursor, replacement, 2);
+                    }
+                }
+            }
+        }
+    }
+
+    private int distanceToBounds2D(int x, int z, BoundingBox bounds) {
+        int dx;
+        if (x < bounds.minX()) {
+            dx = bounds.minX() - x;
+        } else if (x > bounds.maxX()) {
+            dx = x - bounds.maxX();
+        } else {
+            dx = 0;
+        }
+
+        int dz;
+        if (z < bounds.minZ()) {
+            dz = bounds.minZ() - z;
+        } else if (z > bounds.maxZ()) {
+            dz = z - bounds.maxZ();
+        } else {
+            dz = 0;
+        }
+
+        return Math.max(dx, dz);
     }
 
     private boolean isSurfaceReplacementCandidate(BlockState state) {


### PR DESCRIPTION
### Motivation

- Make the starter bunker visually integrate with surrounding terrain by smoothing the immediate perimeter instead of leaving a hard border.
- Provide operators a short checklist for editing and validating the `wildernessodysseyapi:bunker` template so placement aligns with the automatic blending behavior.

### Description

- Add a new docs file `docs/bunker-terrain-integration.md` with a starter checklist covering marker placement, in-game validation commands, and recommended `serverconfig` tuning. 
- Introduce perimeter blending for the starter bunker in `NBTStructurePlacer` by adding constants `STARTER_BUNKER_PERIMETER_BLEND_RADIUS` and `STARTER_BUNKER_PERIMETER_BLEND_DEPTH`. 
- Call a new `blendStarterBunkerPerimeter` pass from the template placement flow to run a 3-block-wide ring blend around the bunker footprint and perform a short depth-aware sample-and-replace of surface blocks. 
- Add a helper `distanceToBounds2D` and use existing terrain sampling/choice logic (`TerrainReplacerEngine`) and `isSurfaceReplacementCandidate` to apply replacements only where appropriate.

### Testing

- Ran the project's automated checks with `./gradlew test` and `./gradlew check`, and the test suite completed successfully. 
- No additional automated tests were added for the new perimeter pass in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b60dcec8c88328bffc567b37209d3d)