### PR TITLE
Align ChunkMap mixin injection signature (remove stale loading param)

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/ChunkMapGenerationErrorMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/ChunkMapGenerationErrorMixin.java
@@ -28,7 +28,6 @@ public abstract class ChunkMapGenerationErrorMixin {
     private void wildernessodysseyapi$reportChunkGenerationFailures(GenerationChunkHolder holder,
                                                                     ChunkStep step,
                                                                     StaticCache2D<GenerationChunkHolder> cache,
-                                                                    boolean loading,
                                                                     CallbackInfoReturnable<CompletableFuture<?>> cir) {
         CompletableFuture<?> original = cir.getReturnValue();
         if (original == null) {


### PR DESCRIPTION
### Motivation
- The mixin injected into `ChunkMap.applyStep` used an outdated method descriptor that included a `boolean loading` parameter, causing an `InvalidInjectionException` and preventing the server from starting.
- The change ensures the injected callback matches the runtime signature on NeoForge/Minecraft 1.21.1 so the mixin can be applied without crashing.

### Description
- Removed the stale `boolean loading` parameter from the mixin callback method in `src/main/java/com/thunder/wildernessodysseyapi/mixin/ChunkMapGenerationErrorMixin.java` so the method descriptor matches the current `applyStep` signature.
- Preserved the existing behavior that wraps the returned `CompletableFuture` and reports chunk-generation exceptions via `ChunkErrorReporter`.
- Kept the injection point (`@Inject(method = "applyStep", at = @At("RETURN"), cancellable = true)`) and error-reporting logic unchanged aside from the signature fix.

### Testing
- Ran `./gradlew compileJava`; the build could not complete because NeoForm failed to download Mojang metadata due to an SSL certificate trust error (`SSLHandshakeException: PKIX path building failed`), so compilation verification is blocked by the environment rather than code errors.
- Performed local repository scans and a targeted diff to confirm the signature removal and that surrounding logic was unmodified; no automated unit tests were executed as part of this change due to the build blocker.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16afcf860832887be11b718a86627)