### PR TITLE
Add deterministic fallback personas (A.E.T.H.E.R) and offline menu with config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Local LLM support is sidecar-based:
 - You can use `{model_path}`, `{model_name}`, and `{base_url}` placeholders in `start_command` / `bundled_server_args`.
 
 If the local model is unavailable, players can still address Aether to open a subsystem menu and route deterministic replies from Aegis, Eclipse, Terra, Helios, Enforcer, or Requiem via `ai_config.yaml`.
+Each subsystem can keep its own prompt library in a separate file under `src/main/resources/ai_fallback/`, referenced by `fallback.personas[].prompt_file`.
 
 Admin commands for sidecar operations:
 - `/atlasbackend status`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ These are pulled from Maven Central and can be used by any local or sidecar AI h
 Self-hosted AI chatbot (custom local LLM required)
 -------------------------------------
 AI purpose checklist: see `docs/ai-purpose-scope.md` for A.E.T.H.E.R core + subsystem scope, boundaries, and MVP definition.
-Atlas now requires a local custom LLM backend for runtime responses. There is no deterministic offline fallback path in chat mode.
+A.E.T.H.E.R. can use a local custom LLM backend for full runtime responses, and it now also supports deterministic fallback personas when players prefer a lighter-weight menu flow.
 
 Local LLM support is sidecar-based:
 - This repo does **not** bundle custom-trained LLM model weight files.
@@ -63,7 +63,7 @@ Local LLM support is sidecar-based:
 - For a better packaging workflow, you can set `model_download_url`, `model_download_sha256`, and `model_file_name` so the model artifact is bootstrapped into `config/wildernessodysseyapi/local-model/models/` at runtime.
 - You can use `{model_path}`, `{model_name}`, and `{base_url}` placeholders in `start_command` / `bundled_server_args`.
 
-If the local model is unavailable, Atlas returns a backend-unavailable message and instructs operators to restore the local model service.
+If the local model is unavailable, players can still address Aether to open a subsystem menu and route deterministic replies from Aegis, Eclipse, Terra, Helios, Enforcer, or Requiem via `ai_config.yaml`.
 
 Admin commands for sidecar operations:
 - `/atlasbackend status`

--- a/docs/ai-purpose-scope.md
+++ b/docs/ai-purpose-scope.md
@@ -44,7 +44,7 @@ Use this as the handoff checklist for anyone building or integrating AI features
   - Backend endpoint config (local sidecar or hosted service).
 - **Reliability behavior**
   - Timeouts, retries, and backoff for AI calls.
-  - Graceful backend-unavailable fallback messaging.
+  - Graceful backend-unavailable fallback messaging, including deterministic prompt-menu personas for lightweight mode.
 - **Performance safeguards**
   - Async execution only; never block server tick/world thread.
   - Queue limits/rate limiting to avoid lag spikes.
@@ -71,7 +71,7 @@ Use this as the handoff checklist for anyone building or integrating AI features
 - A.E.T.H.E.R responds in-world with consistent tone and roleplay behavior.
 - Subsystem routing is available (explicit or automatic) for the six domains.
 - Onboarding steps complete successfully with selectable options.
-- Backend failures return a friendly fallback message in-game.
+- Backend failures return a friendly fallback message in-game, with optional named persona prompt menus.
 - AI requests are async and do not degrade TPS under normal load.
 - Admin can verify backend status from commands/logs.
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIChatListener.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIChatListener.java
@@ -19,8 +19,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
- * Listens for chat messages that include the Atlas wake word or otherwise look
- * conversational and sends back lightweight AI replies using {@link AIClient}.
+ * Listens for chat messages that include the configured AI wake word or a named
+ * fallback persona and sends back AI replies using {@link AIClient}.
  */
 public class AIChatListener {
 
@@ -46,8 +46,7 @@ public class AIChatListener {
             return;
         }
 
-        String wakeWord = CLIENT.getWakeWord();
-        boolean mentionsWakeWord = message.toLowerCase(Locale.ROOT).contains(wakeWord);
+        boolean mentionsWakeWord = CLIENT.isAiInvocation(message);
         boolean sessionActive = ACTIVE_SESSIONS.contains(player.getUUID());
 
         boolean conversational = isConversational(message);
@@ -60,7 +59,7 @@ public class AIChatListener {
 
         String onboardingReply = CLIENT.handleOnboarding(player.getUUID(), message);
         if (onboardingReply != null && !onboardingReply.isBlank()) {
-            PENDING_REPLIES.add(new PendingReply(player.getUUID(), onboardingReply));
+            PENDING_REPLIES.add(new PendingReply(player.getUUID(), CLIENT.getDisplayName(), onboardingReply));
             return;
         }
 
@@ -71,7 +70,8 @@ public class AIChatListener {
         if (reply.text() == null || reply.text().isBlank()) {
             return;
         }
-        PENDING_REPLIES.add(new PendingReply(player.getUUID(), reply.text()));
+        String speaker = (reply.speaker() == null || reply.speaker().isBlank()) ? CLIENT.resolveSpeaker(message) : reply.speaker();
+        PENDING_REPLIES.add(new PendingReply(player.getUUID(), speaker, reply.text()));
     }
 
     @SubscribeEvent
@@ -94,7 +94,7 @@ public class AIChatListener {
         while ((pending = PENDING_REPLIES.poll()) != null) {
             ServerPlayer player = server.getPlayerList().getPlayer(pending.playerId());
             if (player != null) {
-                player.sendSystemMessage(Component.literal("[Atlas] " + pending.message()));
+                player.sendSystemMessage(Component.literal("[" + pending.speaker() + "] " + pending.message()));
             }
         }
     }
@@ -121,6 +121,6 @@ public class AIChatListener {
         return !stack.isEmpty() && stack.is(Items.RED_WOOL);
     }
 
-    private record PendingReply(UUID playerId, String message) {
+    private record PendingReply(UUID playerId, String speaker, String message) {
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIClient.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIClient.java
@@ -31,6 +31,7 @@ public class AIClient {
     private final MemoryStore memoryStore = new MemoryStore();
     private final AIKnowledgeStore knowledgeStore = new AIKnowledgeStore();
     private final AIOnboardingStore onboardingStore = new AIOnboardingStore();
+    private final AIFallbackResponder fallbackResponder = new AIFallbackResponder();
     private LocalModelClient localModelClient;
     private String localSystemPrompt;
     private boolean autoStartLocalServer;
@@ -59,8 +60,24 @@ public class AIClient {
         return settings.getWakeWord();
     }
 
+    public String getDisplayName() {
+        return settings.getPersonaName();
+    }
+
     public boolean isAtlasEnabled() {
         return settings.isAtlasEnabled();
+    }
+
+    public boolean isAiInvocation(String message) {
+        if (message == null || message.isBlank()) {
+            return false;
+        }
+        String lower = message.toLowerCase(Locale.ROOT);
+        return lower.contains(settings.getWakeWord()) || fallbackResponder.findMentionedPersonaName(message).isPresent();
+    }
+
+    public String resolveSpeaker(String message) {
+        return fallbackResponder.findMentionedPersonaName(message).orElse(settings.getPersonaName());
     }
 
     private void loadStory() {
@@ -71,6 +88,7 @@ public class AIClient {
         applySettings(config);
         configureLocalModel(config.getLocalModel());
         configureOnboarding(config.getOnboarding());
+        fallbackResponder.configure(config.getFallback(), settings.getPersonaName(), settings.getWakeWord());
     }
 
     public synchronized void scanGameData(MinecraftServer server) {
@@ -200,16 +218,17 @@ public class AIClient {
 
     public VoiceIntegration.VoiceResult sendMessageWithVoice(String world, String player, String message) {
         if (!settings.isAtlasEnabled()) {
-            return voiceIntegration.wrap("");
+            return voiceIntegration.wrap(settings.getPersonaName(), "");
         }
+        String speaker = resolveSpeaker(message);
         String learnedFact = knowledgeStore.extractLearnedFact(message);
         if (learnedFact != null) {
             boolean added = knowledgeStore.addFact(learnedFact);
             String reply = added
                     ? "Got it. I'll remember: " + learnedFact
                     : "I already have that logged: " + learnedFact;
-            memoryStore.addAiMessage(world, player, settings.getPersonaName(), reply);
-            return voiceIntegration.wrap(reply);
+            memoryStore.addAiMessage(world, player, speaker, reply);
+            return voiceIntegration.wrap(speaker, reply);
         }
         memoryStore.addPlayerMessage(world, player, message);
         String context = memoryStore.getRecentContext(world, player);
@@ -217,10 +236,18 @@ public class AIClient {
         if (!knowledgeContext.isBlank()) {
             context = context.isBlank() ? knowledgeContext : context + "\n" + knowledgeContext;
         }
+        var deterministicFallback = fallbackResponder.buildReply(message);
         if (localModelClient == null) {
-            String reply = buildModelUnavailableReply(false, false);
-            memoryStore.addAiMessage(world, player, settings.getPersonaName(), reply);
-            return voiceIntegration.wrap(reply);
+            String reply = deterministicFallback.map(AIFallbackResponder.FallbackReply::text)
+                    .orElseGet(() -> buildModelUnavailableReply(false, false, message));
+            memoryStore.addAiMessage(world, player, speaker, reply);
+            return voiceIntegration.wrap(speaker, reply);
+        }
+        if (deterministicFallback.isPresent()
+                && (!deterministicFallback.get().menu() || shouldPreferFallback(message))) {
+            String reply = deterministicFallback.get().text();
+            memoryStore.addAiMessage(world, player, deterministicFallback.get().speaker(), reply);
+            return voiceIntegration.wrap(deterministicFallback.get().speaker(), reply);
         }
         String prompt = formatSystemPrompt(localSystemPrompt);
         String localContext = buildLocalModelContext(world, context);
@@ -228,19 +255,20 @@ public class AIClient {
         var response = requestLocalReplyWithRetry(prompt, message, localContext);
         if (response.isPresent()) {
             String reply = response.get();
-            memoryStore.addAiMessage(world, player, settings.getPersonaName(), reply);
-            return voiceIntegration.wrap(reply);
+            memoryStore.addAiMessage(world, player, speaker, reply);
+            return voiceIntegration.wrap(speaker, reply);
         }
         RetryResult retry = retryLocalModelAfterStart(prompt, message, localContext);
         if (retry.response().isPresent()) {
             String reply = retry.response().get();
-            memoryStore.addAiMessage(world, player, settings.getPersonaName(), reply);
-            return voiceIntegration.wrap(reply);
+            memoryStore.addAiMessage(world, player, speaker, reply);
+            return voiceIntegration.wrap(speaker, reply);
         }
         startAttempted = startAttempted || retry.started();
-        String reply = buildModelUnavailableReply(true, startAttempted);
-        memoryStore.addAiMessage(world, player, settings.getPersonaName(), reply);
-        return voiceIntegration.wrap(reply);
+        String reply = deterministicFallback.map(AIFallbackResponder.FallbackReply::text)
+                .orElseGet(() -> buildModelUnavailableReply(true, startAttempted, message));
+        memoryStore.addAiMessage(world, player, speaker, reply);
+        return voiceIntegration.wrap(speaker, reply);
     }
 
     public String handleOnboarding(UUID playerId, String message) {
@@ -498,9 +526,22 @@ public class AIClient {
         return builder.toString().trim();
     }
 
-    private String buildModelUnavailableReply(boolean modelUnavailable, boolean startAttempted) {
+    private boolean shouldPreferFallback(String message) {
+        if (message == null || message.isBlank()) {
+            return false;
+        }
+        String lower = message.toLowerCase(Locale.ROOT);
+        return lower.contains("prompt")
+                || lower.contains("option")
+                || lower.contains("menu")
+                || lower.contains("fallback")
+                || lower.contains("preset")
+                || lower.contains("list");
+    }
+
+    private String buildModelUnavailableReply(boolean modelUnavailable, boolean startAttempted, String message) {
         StringBuilder reply = new StringBuilder();
-        reply.append("Local Atlas LLM is required and no offline fallback is enabled.");
+        reply.append("Local ").append(settings.getPersonaName()).append(" LLM is unavailable right now.");
         if (modelUnavailable) {
             reply.append(" I could not get a response from the configured local model backend");
             if (localModelBaseUrl != null && !localModelBaseUrl.isBlank()) {
@@ -515,6 +556,9 @@ public class AIClient {
         }
         if (localModelDownloadUrl != null && !localModelDownloadUrl.isBlank() && localModelFilePath == null) {
             reply.append(" Model bootstrap is configured but the artifact could not be prepared from model_download_url.");
+        }
+        if (!fallbackResponder.buildReply(message).isPresent()) {
+            return fallbackResponder.appendUnavailableHint(reply.toString());
         }
         return reply.toString();
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIConfig.java
@@ -13,6 +13,7 @@ public class AIConfig {
     private final Settings settings = new Settings();
     private final LocalModel localModel = new LocalModel();
     private final Onboarding onboarding = new Onboarding();
+    private final Fallback fallback = new Fallback();
 
     public List<String> getStory() {
         return story;
@@ -48,6 +49,10 @@ public class AIConfig {
 
     public Onboarding getOnboarding() {
         return onboarding;
+    }
+
+    public Fallback getFallback() {
+        return fallback;
     }
 
     public static class LocalModel {
@@ -178,7 +183,6 @@ public class AIConfig {
             this.modelFileName = modelFileName;
         }
     }
-
 
     public static class Personality {
         private String name;
@@ -312,6 +316,98 @@ public class AIConfig {
 
         public List<String> getResponses() {
             return responses;
+        }
+    }
+
+    public static class Fallback {
+        private Boolean enabled;
+        private String menuPrompt;
+        private String unavailableHint;
+        private final List<FallbackPersona> personas = new ArrayList<>();
+
+        public Boolean getEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getMenuPrompt() {
+            return menuPrompt;
+        }
+
+        public void setMenuPrompt(String menuPrompt) {
+            this.menuPrompt = menuPrompt;
+        }
+
+        public String getUnavailableHint() {
+            return unavailableHint;
+        }
+
+        public void setUnavailableHint(String unavailableHint) {
+            this.unavailableHint = unavailableHint;
+        }
+
+        public List<FallbackPersona> getPersonas() {
+            return personas;
+        }
+    }
+
+    public static class FallbackPersona {
+        private String name;
+        private String introduction;
+        private final List<String> aliases = new ArrayList<>();
+        private final List<FallbackPrompt> prompts = new ArrayList<>();
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getIntroduction() {
+            return introduction;
+        }
+
+        public void setIntroduction(String introduction) {
+            this.introduction = introduction;
+        }
+
+        public List<String> getAliases() {
+            return aliases;
+        }
+
+        public List<FallbackPrompt> getPrompts() {
+            return prompts;
+        }
+    }
+
+    public static class FallbackPrompt {
+        private String label;
+        private String response;
+        private final List<String> triggers = new ArrayList<>();
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public String getResponse() {
+            return response;
+        }
+
+        public void setResponse(String response) {
+            this.response = response;
+        }
+
+        public List<String> getTriggers() {
+            return triggers;
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIConfig.java
@@ -357,6 +357,7 @@ public class AIConfig {
     public static class FallbackPersona {
         private String name;
         private String introduction;
+        private String promptFile;
         private final List<String> aliases = new ArrayList<>();
         private final List<FallbackPrompt> prompts = new ArrayList<>();
 
@@ -374,6 +375,14 @@ public class AIConfig {
 
         public void setIntroduction(String introduction) {
             this.introduction = introduction;
+        }
+
+        public String getPromptFile() {
+            return promptFile;
+        }
+
+        public void setPromptFile(String promptFile) {
+            this.promptFile = promptFile;
         }
 
         public List<String> getAliases() {

--- a/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIConfigLoader.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIConfigLoader.java
@@ -129,6 +129,12 @@ public final class AIConfigLoader {
         }
         config.getOnboarding().getSteps().addAll(steps);
 
+        Map<String, Object> fallback = readStringObjectMap(root.get("fallback"));
+        config.getFallback().setEnabled(readBoolean(fallback.get("enabled")));
+        config.getFallback().setMenuPrompt(readStringValue(fallback.get("menu_prompt")));
+        config.getFallback().setUnavailableHint(readStringValue(fallback.get("unavailable_hint")));
+        config.getFallback().getPersonas().addAll(readFallbackPersonas(fallback.get("personas")));
+
         return config;
     }
 
@@ -264,6 +270,48 @@ public final class AIConfigLoader {
             results.put(entry.getKey().toString(), entry.getValue());
         }
         return results;
+    }
+
+
+    private static List<AIConfig.FallbackPersona> readFallbackPersonas(Object value) {
+        if (!(value instanceof Iterable<?> items)) {
+            return List.of();
+        }
+        List<AIConfig.FallbackPersona> personas = new ArrayList<>();
+        for (Object entry : items) {
+            if (!(entry instanceof Map<?, ?> map)) {
+                continue;
+            }
+            AIConfig.FallbackPersona persona = new AIConfig.FallbackPersona();
+            persona.setName(readStringValue(map.get("name")));
+            persona.setIntroduction(readStringValue(map.get("introduction")));
+            persona.getAliases().addAll(readStringList(map.get("aliases")));
+            persona.getPrompts().addAll(readFallbackPrompts(map.get("prompts")));
+            if (persona.getName() != null && !persona.getName().isBlank() && !persona.getPrompts().isEmpty()) {
+                personas.add(persona);
+            }
+        }
+        return personas;
+    }
+
+    private static List<AIConfig.FallbackPrompt> readFallbackPrompts(Object value) {
+        if (!(value instanceof Iterable<?> items)) {
+            return List.of();
+        }
+        List<AIConfig.FallbackPrompt> prompts = new ArrayList<>();
+        for (Object entry : items) {
+            if (!(entry instanceof Map<?, ?> map)) {
+                continue;
+            }
+            AIConfig.FallbackPrompt prompt = new AIConfig.FallbackPrompt();
+            prompt.setLabel(readStringValue(map.get("label")));
+            prompt.setResponse(readStringValue(map.get("response")));
+            prompt.getTriggers().addAll(readStringList(map.get("triggers")));
+            if (prompt.getLabel() != null && !prompt.getLabel().isBlank()) {
+                prompts.add(prompt);
+            }
+        }
+        return prompts;
     }
 
     private static List<AIConfig.OnboardingStep> readOnboardingSteps(Object value) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIConfigLoader.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIConfigLoader.java
@@ -134,6 +134,7 @@ public final class AIConfigLoader {
         config.getFallback().setMenuPrompt(readStringValue(fallback.get("menu_prompt")));
         config.getFallback().setUnavailableHint(readStringValue(fallback.get("unavailable_hint")));
         config.getFallback().getPersonas().addAll(readFallbackPersonas(fallback.get("personas")));
+        hydrateFallbackPromptFiles(config.getFallback().getPersonas());
 
         return config;
     }
@@ -285,13 +286,73 @@ public final class AIConfigLoader {
             AIConfig.FallbackPersona persona = new AIConfig.FallbackPersona();
             persona.setName(readStringValue(map.get("name")));
             persona.setIntroduction(readStringValue(map.get("introduction")));
+            persona.setPromptFile(readStringValue(map.get("prompt_file")));
             persona.getAliases().addAll(readStringList(map.get("aliases")));
             persona.getPrompts().addAll(readFallbackPrompts(map.get("prompts")));
-            if (persona.getName() != null && !persona.getName().isBlank() && !persona.getPrompts().isEmpty()) {
-                personas.add(persona);
+            if (persona.getName() != null && !persona.getName().isBlank()) {
+                boolean hasInlinePrompts = !persona.getPrompts().isEmpty();
+                boolean hasPromptFile = persona.getPromptFile() != null && !persona.getPromptFile().isBlank();
+                if (hasInlinePrompts || hasPromptFile) {
+                    personas.add(persona);
+                }
             }
         }
         return personas;
+    }
+
+    private static void hydrateFallbackPromptFiles(List<AIConfig.FallbackPersona> personas) {
+        if (personas == null || personas.isEmpty()) {
+            return;
+        }
+        for (AIConfig.FallbackPersona persona : personas) {
+            if (persona == null || persona.getPromptFile() == null || persona.getPromptFile().isBlank()) {
+                continue;
+            }
+            List<AIConfig.FallbackPrompt> filePrompts = loadPromptFilePrompts(persona.getPromptFile());
+            if (!filePrompts.isEmpty()) {
+                persona.getPrompts().addAll(filePrompts);
+            }
+        }
+    }
+
+    private static List<AIConfig.FallbackPrompt> loadPromptFilePrompts(String promptFile) {
+        if (promptFile == null || promptFile.isBlank()) {
+            return List.of();
+        }
+        String normalized = promptFile.startsWith("/") ? promptFile.substring(1) : promptFile;
+        String content = readPromptFileContent(normalized);
+        if (content == null || content.isBlank()) {
+            ModConstants.LOGGER.warn("Fallback prompt file {} is empty or unavailable.", normalized);
+            return List.of();
+        }
+        Map<?, ?> root = parseWithSnakeYaml(content);
+        if (root == null) {
+            root = parseSimpleYaml(content);
+        }
+        if (root == null) {
+            return List.of();
+        }
+        return readFallbackPrompts(root.get("prompts"));
+    }
+
+    private static String readPromptFileContent(String normalizedPath) {
+        Path externalPath = FMLPaths.CONFIGDIR.get().resolve(normalizedPath);
+        if (Files.exists(externalPath)) {
+            try {
+                return Files.readString(externalPath, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                ModConstants.LOGGER.warn("Failed reading fallback prompt file from config dir: {}", externalPath, e);
+            }
+        }
+        try (InputStream in = AIConfigLoader.class.getClassLoader().getResourceAsStream(normalizedPath)) {
+            if (in == null) {
+                return null;
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("Failed reading bundled fallback prompt file {}.", normalizedPath, e);
+            return null;
+        }
     }
 
     private static List<AIConfig.FallbackPrompt> readFallbackPrompts(Object value) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIFallbackResponder.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/AIFallbackResponder.java
@@ -1,0 +1,338 @@
+package com.thunder.wildernessodysseyapi.ai.AI_story;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Deterministic fallback menu that can answer a small set of prompt-driven
+ * requests when the local model is disabled, unavailable, or intentionally not used.
+ */
+public class AIFallbackResponder {
+
+    private static final Pattern NUMBER_PATTERN = Pattern.compile("(^|\\D)([1-9][0-9]?)(\\D|$)");
+
+    private final List<Persona> personas = new ArrayList<>();
+    private boolean enabled;
+    private String menuPrompt = "Available fallback prompts:";
+    private String unavailableHint = "If you want lightweight replies, say Aether and ask for prompts.";
+
+    public void configure(AIConfig.Fallback config, String defaultPersonaName, String defaultWakeWord) {
+        personas.clear();
+        enabled = config != null && Boolean.TRUE.equals(config.getEnabled());
+        if (config != null && config.getMenuPrompt() != null && !config.getMenuPrompt().isBlank()) {
+            menuPrompt = config.getMenuPrompt().trim();
+        }
+        if (config != null && config.getUnavailableHint() != null && !config.getUnavailableHint().isBlank()) {
+            unavailableHint = config.getUnavailableHint().trim();
+        }
+        if (config != null) {
+            for (AIConfig.FallbackPersona personaConfig : config.getPersonas()) {
+                Persona persona = fromConfig(personaConfig);
+                if (persona != null) {
+                    personas.add(persona);
+                }
+            }
+        }
+        if (personas.isEmpty()) {
+            personas.addAll(buildDefaultPersonas(defaultPersonaName, defaultWakeWord));
+        }
+    }
+
+    public Optional<String> findMentionedPersonaName(String message) {
+        if (message == null || message.isBlank()) {
+            return Optional.empty();
+        }
+        String lower = message.toLowerCase(Locale.ROOT);
+        Optional<Persona> aether = findAetherPersona();
+        if (aether.isPresent() && mentionsPersona(lower, aether.get())) {
+            Optional<Persona> routed = resolveSubsystemFromAether(lower, aether.get());
+            if (routed.isPresent()) {
+                return Optional.of(routed.get().name());
+            }
+            return Optional.of(aether.get().name());
+        }
+        return findMentionedPersona(lower).map(Persona::name);
+    }
+
+    public Optional<FallbackReply> buildReply(String message) {
+        if (!enabled || message == null || message.isBlank()) {
+            return Optional.empty();
+        }
+        String lower = message.toLowerCase(Locale.ROOT);
+        Optional<Persona> aether = findAetherPersona();
+        if (aether.isPresent() && mentionsPersona(lower, aether.get())) {
+            Optional<Persona> subsystem = resolveSubsystemFromAether(lower, aether.get());
+            if (subsystem.isPresent()) {
+                return buildPersonaReply(lower, subsystem.get());
+            }
+            return Optional.of(new FallbackReply(aether.get().name(), buildAetherSubsystemMenu(aether.get()), true));
+        }
+
+        Optional<Persona> personaMatch = findMentionedPersona(lower);
+        if (personaMatch.isEmpty()) {
+            return Optional.empty();
+        }
+        return buildPersonaReply(lower, personaMatch.get());
+    }
+
+    public String appendUnavailableHint(String baseReply) {
+        if (!enabled || unavailableHint == null || unavailableHint.isBlank()) {
+            return baseReply;
+        }
+        if (baseReply == null || baseReply.isBlank()) {
+            return unavailableHint;
+        }
+        return baseReply + " " + unavailableHint;
+    }
+
+    private Optional<FallbackReply> buildPersonaReply(String lower, Persona persona) {
+        if (shouldShowMenu(lower, persona)) {
+            return Optional.of(new FallbackReply(persona.name(), persona.buildMenu(menuPrompt), true));
+        }
+        for (Prompt prompt : persona.prompts()) {
+            if (prompt.matches(lower)) {
+                return Optional.of(new FallbackReply(persona.name(), prompt.response(), false));
+            }
+        }
+        return Optional.of(new FallbackReply(persona.name(), persona.buildMenu(menuPrompt), true));
+    }
+
+    private Optional<Persona> resolveSubsystemFromAether(String lower, Persona aether) {
+        List<Persona> subsystems = subsystemPersonas(aether);
+        for (Persona subsystem : subsystems) {
+            if (mentionsPersona(lower, subsystem) || containsToken(lower, subsystem.name().toLowerCase(Locale.ROOT))) {
+                return Optional.of(subsystem);
+            }
+        }
+        int selected = extractMenuNumber(lower);
+        if (selected > 0 && selected <= subsystems.size()) {
+            return Optional.of(subsystems.get(selected - 1));
+        }
+        return Optional.empty();
+    }
+
+    private int extractMenuNumber(String lower) {
+        Matcher matcher = NUMBER_PATTERN.matcher(lower);
+        if (!matcher.find()) {
+            return -1;
+        }
+        try {
+            return Integer.parseInt(matcher.group(2));
+        } catch (NumberFormatException ignored) {
+            return -1;
+        }
+    }
+
+    private List<Persona> subsystemPersonas(Persona aether) {
+        List<Persona> subsystems = new ArrayList<>();
+        for (Persona persona : personas) {
+            if (persona == aether) {
+                continue;
+            }
+            String lowerName = persona.name().toLowerCase(Locale.ROOT);
+            if (isSubsystemName(lowerName)) {
+                subsystems.add(persona);
+            }
+        }
+        return subsystems;
+    }
+
+    private boolean isSubsystemName(String lowerName) {
+        return "aegis".equals(lowerName)
+                || "eclipse".equals(lowerName)
+                || "terra".equals(lowerName)
+                || "helios".equals(lowerName)
+                || "enforcer".equals(lowerName)
+                || "requiem".equals(lowerName);
+    }
+
+    private Optional<Persona> findAetherPersona() {
+        for (Persona persona : personas) {
+            if ("aether".equals(persona.name().toLowerCase(Locale.ROOT))) {
+                return Optional.of(persona);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private String buildAetherSubsystemMenu(Persona aether) {
+        StringBuilder builder = new StringBuilder();
+        if (aether.introduction() != null && !aether.introduction().isBlank()) {
+            builder.append(aether.introduction().trim()).append(' ');
+        }
+        builder.append(menuPrompt == null || menuPrompt.isBlank() ? "Available subsystem prompts:" : menuPrompt.trim());
+        List<Persona> subsystems = subsystemPersonas(aether);
+        for (int i = 0; i < subsystems.size(); i++) {
+            Persona subsystem = subsystems.get(i);
+            builder.append(' ').append(i + 1).append(") ").append(subsystem.name());
+            if (subsystem.introduction() != null && !subsystem.introduction().isBlank()) {
+                builder.append(" - ").append(subsystem.introduction().trim());
+            }
+        }
+        return builder.toString().trim();
+    }
+
+    private boolean shouldShowMenu(String lower, Persona persona) {
+        if (lower == null || lower.isBlank()) {
+            return true;
+        }
+        for (String alias : persona.aliases()) {
+            String normalized = alias.toLowerCase(Locale.ROOT);
+            if (lower.equals(normalized)
+                    || lower.equals(normalized + "?")
+                    || lower.equals("hey " + normalized)
+                    || lower.equals("hi " + normalized)) {
+                return true;
+            }
+        }
+        return lower.contains("prompt")
+                || lower.contains("option")
+                || lower.contains("menu")
+                || lower.contains("help")
+                || lower.contains("what can you do")
+                || lower.contains("what do you do")
+                || lower.contains("list")
+                || lower.contains("subsystem");
+    }
+
+    private Optional<Persona> findMentionedPersona(String lower) {
+        for (Persona persona : personas) {
+            if (mentionsPersona(lower, persona)) {
+                return Optional.of(persona);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private boolean mentionsPersona(String lower, Persona persona) {
+        for (String alias : persona.aliases()) {
+            String normalized = alias.toLowerCase(Locale.ROOT);
+            if (containsToken(lower, normalized)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean containsToken(String haystack, String needle) {
+        if (needle == null || needle.isBlank()) {
+            return false;
+        }
+        if (haystack.equals(needle)) {
+            return true;
+        }
+        return haystack.matches(".*(^|[^a-z0-9])" + Pattern.quote(needle) + "([^a-z0-9]|$).*");
+    }
+
+    private Persona fromConfig(AIConfig.FallbackPersona personaConfig) {
+        if (personaConfig == null || personaConfig.getName() == null || personaConfig.getName().isBlank()) {
+            return null;
+        }
+        List<String> aliases = new ArrayList<>();
+        aliases.add(personaConfig.getName().trim());
+        for (String alias : personaConfig.getAliases()) {
+            if (alias != null && !alias.isBlank()) {
+                aliases.add(alias.trim());
+            }
+        }
+        List<Prompt> prompts = new ArrayList<>();
+        for (AIConfig.FallbackPrompt promptConfig : personaConfig.getPrompts()) {
+            if (promptConfig == null || promptConfig.getLabel() == null || promptConfig.getLabel().isBlank()) {
+                continue;
+            }
+            String response = promptConfig.getResponse() == null ? "" : promptConfig.getResponse().trim();
+            List<String> triggers = new ArrayList<>();
+            triggers.add(promptConfig.getLabel().trim());
+            for (String trigger : promptConfig.getTriggers()) {
+                if (trigger != null && !trigger.isBlank()) {
+                    triggers.add(trigger.trim());
+                }
+            }
+            prompts.add(new Prompt(promptConfig.getLabel().trim(), response, triggers));
+        }
+        if (prompts.isEmpty()) {
+            return null;
+        }
+        String introduction = personaConfig.getIntroduction() == null ? "" : personaConfig.getIntroduction().trim();
+        return new Persona(personaConfig.getName().trim(), introduction, aliases, prompts);
+    }
+
+    private List<Persona> buildDefaultPersonas(String defaultPersonaName, String defaultWakeWord) {
+        String name = (defaultPersonaName == null || defaultPersonaName.isBlank()) ? "Aether" : defaultPersonaName.trim();
+        String wakeWord = (defaultWakeWord == null || defaultWakeWord.isBlank()) ? name : defaultWakeWord.trim();
+        List<Persona> defaults = new ArrayList<>();
+        defaults.add(new Persona(
+                name,
+                "I route requests to A.E.T.H.E.R subsystems for lightweight responses.",
+                List.of(name, wakeWord, "aether core"),
+                List.of(new Prompt("Subsystem menu", "Select a subsystem: Aegis, Eclipse, Terra, Helios, Enforcer, or Requiem.",
+                        List.of("subsystem", "menu", "prompts")))));
+        defaults.add(new Persona("Aegis", "Health / Protection", List.of("aegis"),
+                List.of(new Prompt("Safety guidance",
+                        "Aegis: prioritize shelter safety checks, hazard prevention reminders, and defensive readiness before moving out.",
+                        List.of("safety", "health", "protection", "hazard prevention")))));
+        defaults.add(new Persona("Eclipse", "Rift / Anomaly", List.of("eclipse"),
+                List.of(new Prompt("Anomaly scan",
+                        "Eclipse: anomaly levels are unstable. Track rift signatures, classify risk, and follow safe response protocols.",
+                        List.of("rift", "anomaly", "risk", "scan")))));
+        defaults.add(new Persona("Terra", "Terrain / Restoration / Exploration", List.of("terra"),
+                List.of(new Prompt("Exploration routing",
+                        "Terra: use terrain-aware routing, avoid collapse zones, and prioritize restoration-ready pathways.",
+                        List.of("terrain", "exploration", "route", "restoration")))));
+        defaults.add(new Persona("Helios", "Energy / Machines / Atmospheric Stability", List.of("helios"),
+                List.of(new Prompt("Power and atmosphere",
+                        "Helios: stabilize energy demand, balance machine load, and monitor atmospheric conditions before expansion.",
+                        List.of("energy", "machines", "power", "atmosphere")))));
+        defaults.add(new Persona("Enforcer", "Combat / Security", List.of("enforcer"),
+                List.of(new Prompt("Security posture",
+                        "Enforcer: set combat readiness, prioritize threats, and reinforce perimeter security before engagement.",
+                        List.of("combat", "security", "threat", "defense")))));
+        defaults.add(new Persona("Requiem", "Archive / Memory / History", List.of("requiem"),
+                List.of(new Prompt("Archive continuity",
+                        "Requiem: maintain lore continuity, verify historical records, and preserve mission memory for future expeditions.",
+                        List.of("archive", "memory", "history", "lore")))));
+        return defaults;
+    }
+
+    public record FallbackReply(String speaker, String text, boolean menu) {
+    }
+
+    private record Persona(String name, String introduction, List<String> aliases, List<Prompt> prompts) {
+        private String buildMenu(String menuPrompt) {
+            StringBuilder builder = new StringBuilder();
+            if (introduction != null && !introduction.isBlank()) {
+                builder.append(introduction.trim()).append(' ');
+            }
+            builder.append(menuPrompt == null || menuPrompt.isBlank() ? "Available prompts:" : menuPrompt.trim());
+            for (int i = 0; i < prompts.size(); i++) {
+                builder.append(' ')
+                        .append(i + 1)
+                        .append(") ")
+                        .append(prompts.get(i).label());
+            }
+            return builder.toString().trim();
+        }
+    }
+
+    private record Prompt(String label, String response, List<String> triggers) {
+        private boolean matches(String lower) {
+            if (lower == null || lower.isBlank()) {
+                return false;
+            }
+            for (String trigger : triggers) {
+                if (trigger == null || trigger.isBlank()) {
+                    continue;
+                }
+                String normalized = trigger.toLowerCase(Locale.ROOT);
+                if (lower.contains(normalized)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/VoiceIntegration.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ai/AI_story/VoiceIntegration.java
@@ -5,7 +5,7 @@ package com.thunder.wildernessodysseyapi.ai.AI_story;
  */
 public class VoiceIntegration {
 
-    public record VoiceResult(String text, String voiceLine, boolean voiceQueued, boolean speechInputAllowed) {
+    public record VoiceResult(String speaker, String text, String voiceLine, boolean voiceQueued, boolean speechInputAllowed) {
     }
 
     private final AISettings settings;
@@ -14,7 +14,7 @@ public class VoiceIntegration {
         this.settings = settings;
     }
 
-    public VoiceResult wrap(String text) {
-        return new VoiceResult(text, null, false, settings.isSpeechRecognition());
+    public VoiceResult wrap(String speaker, String text) {
+        return new VoiceResult(speaker, text, null, false, settings.isSpeechRecognition());
     }
 }

--- a/src/main/resources/ai_config.yaml
+++ b/src/main/resources/ai_config.yaml
@@ -46,52 +46,31 @@ fallback:
     - name: "Aether"
       aliases: ["aether core", "central ai"]
       introduction: "A.E.T.H.E.R online. Choose a subsystem prompt and I will route it for a focused response."
-      prompts:
-        - label: "Subsystem menu"
-          triggers: ["subsystem", "prompt", "menu", "options"]
-          response: "Choose a subsystem: 1) Aegis 2) Eclipse 3) Terra 4) Helios 5) Enforcer 6) Requiem."
+      prompt_file: "ai_fallback/aether.yaml"
     - name: "Aegis"
       aliases: ["health ai", "protection ai"]
       introduction: "Health / Protection"
-      prompts:
-        - label: "Player safety guidance"
-          triggers: ["safety", "health", "protection", "hazard prevention"]
-          response: "Aegis response: maintain med reserves, rotate hazard checks, and keep defensive readiness active before entering unstable zones."
+      prompt_file: "ai_fallback/aegis.yaml"
     - name: "Eclipse"
       aliases: ["rift ai", "anomaly ai"]
       introduction: "Rift / Anomaly"
-      prompts:
-        - label: "Anomaly response"
-          triggers: ["rift", "anomaly", "risk", "safe response"]
-          response: "Eclipse response: classify rift intensity first, keep distance from unstable nodes, and only approach with marked fallback routes."
+      prompt_file: "ai_fallback/eclipse.yaml"
     - name: "Terra"
       aliases: ["terrain ai", "exploration ai"]
       introduction: "Terrain / World Restoration / Exploration"
-      prompts:
-        - label: "Exploration routing"
-          triggers: ["terrain", "world restoration", "exploration", "route"]
-          response: "Terra response: route along stable ridgelines, tag restoration candidates, and avoid crater-edge traversal during low visibility."
+      prompt_file: "ai_fallback/terra.yaml"
     - name: "Helios"
       aliases: ["energy ai", "machine ai", "atmosphere ai"]
       introduction: "Energy / Machines / Atmospheric Stability"
-      prompts:
-        - label: "Power and stability"
-          triggers: ["energy", "machines", "atmosphere", "stability", "power"]
-          response: "Helios response: balance machine load in phases, preserve backup power, and monitor atmospheric variance before scaling operations."
+      prompt_file: "ai_fallback/helios.yaml"
     - name: "Enforcer"
       aliases: ["combat ai", "security ai"]
       introduction: "Combat / Security"
-      prompts:
-        - label: "Threat prioritization"
-          triggers: ["combat", "security", "threat", "readiness"]
-          response: "Enforcer response: establish perimeter coverage, prioritize fast-moving threats first, and maintain staggered defensive positions."
+      prompt_file: "ai_fallback/enforcer.yaml"
     - name: "Requiem"
       aliases: ["archive ai", "memory ai", "history ai"]
       introduction: "Archive / Memory / History"
-      prompts:
-        - label: "Lore continuity"
-          triggers: ["archive", "memory", "history", "lore"]
-          response: "Requiem response: cross-check recovered records against field evidence and preserve chronology for expedition continuity."
+      prompt_file: "ai_fallback/requiem.yaml"
 onboarding:
   enabled: true
   completion_message: "Onboarding complete. I'm ready for full expedition chat support."

--- a/src/main/resources/ai_config.yaml
+++ b/src/main/resources/ai_config.yaml
@@ -2,10 +2,11 @@ story:
   - "You are the expedition AI in a post apocalyptic world where a meteor hit the world and humans had to go in bunkers for years for it to be safe to breathe in the top ground.."
   - "Players must explore find artifacts and survive and hopefully find survivors and maybe some graves and history cause some humans were left to survive when the meteor hit"
 background_history:
+  - "Aether is the central expedition intelligence coordinating multiple field personalities, including Atlas for logistics and archive support."
   - "Atlas was a military ai repurposed to serve survivors going out to explore the world, and was helping with project eden and managing the cryo tubes."
   - "Atlas keeps personal field notes about the past history and survivors adventures"
 personality:
-  name: "Atlas"
+  name: "Aether"
   tone: "warm, human, a little playful—never stiff"
   empathy: "high—reassures and encourages when players struggle"
 corrupted_data:
@@ -16,11 +17,10 @@ settings:
   atlas_enabled: true
   voice_enabled: true
   speech_recognition: false
-  wake_word: "atlas"
+  wake_word: "aether"
   model: "local-story-engine"
-# Required local LLM sidecar settings.
-# NOTE: chat now requires a running local model backend; there is no offline fallback reply mode.
-# This mod does not include custom-trained model files, so point to a local model server you provide.
+# Local LLM sidecar settings.
+# If the backend is offline, players can still use the deterministic fallback personas below.
 local_model:
   enabled: true
   auto_start: true
@@ -38,6 +38,60 @@ local_model:
   retry_attempts: 3
   retry_backoff_millis: 200
   system_prompt: "You are {persona}, an in-world expedition AI. Stay {tone} and {empathy}. You have no access to Google, the internet, or any external sources—only the in-world lore and knowledge provided. Do not provide crafting recipes or step-by-step crafting instructions. Keep responses immersive, lore-aware, and conversational."
+fallback:
+  enabled: true
+  menu_prompt: "A.E.T.H.E.R subsystem prompts:"
+  unavailable_hint: "Say Aether to open subsystem prompts, then choose Aegis, Eclipse, Terra, Helios, Enforcer, or Requiem."
+  personas:
+    - name: "Aether"
+      aliases: ["aether core", "central ai"]
+      introduction: "A.E.T.H.E.R online. Choose a subsystem prompt and I will route it for a focused response."
+      prompts:
+        - label: "Subsystem menu"
+          triggers: ["subsystem", "prompt", "menu", "options"]
+          response: "Choose a subsystem: 1) Aegis 2) Eclipse 3) Terra 4) Helios 5) Enforcer 6) Requiem."
+    - name: "Aegis"
+      aliases: ["health ai", "protection ai"]
+      introduction: "Health / Protection"
+      prompts:
+        - label: "Player safety guidance"
+          triggers: ["safety", "health", "protection", "hazard prevention"]
+          response: "Aegis response: maintain med reserves, rotate hazard checks, and keep defensive readiness active before entering unstable zones."
+    - name: "Eclipse"
+      aliases: ["rift ai", "anomaly ai"]
+      introduction: "Rift / Anomaly"
+      prompts:
+        - label: "Anomaly response"
+          triggers: ["rift", "anomaly", "risk", "safe response"]
+          response: "Eclipse response: classify rift intensity first, keep distance from unstable nodes, and only approach with marked fallback routes."
+    - name: "Terra"
+      aliases: ["terrain ai", "exploration ai"]
+      introduction: "Terrain / World Restoration / Exploration"
+      prompts:
+        - label: "Exploration routing"
+          triggers: ["terrain", "world restoration", "exploration", "route"]
+          response: "Terra response: route along stable ridgelines, tag restoration candidates, and avoid crater-edge traversal during low visibility."
+    - name: "Helios"
+      aliases: ["energy ai", "machine ai", "atmosphere ai"]
+      introduction: "Energy / Machines / Atmospheric Stability"
+      prompts:
+        - label: "Power and stability"
+          triggers: ["energy", "machines", "atmosphere", "stability", "power"]
+          response: "Helios response: balance machine load in phases, preserve backup power, and monitor atmospheric variance before scaling operations."
+    - name: "Enforcer"
+      aliases: ["combat ai", "security ai"]
+      introduction: "Combat / Security"
+      prompts:
+        - label: "Threat prioritization"
+          triggers: ["combat", "security", "threat", "readiness"]
+          response: "Enforcer response: establish perimeter coverage, prioritize fast-moving threats first, and maintain staggered defensive positions."
+    - name: "Requiem"
+      aliases: ["archive ai", "memory ai", "history ai"]
+      introduction: "Archive / Memory / History"
+      prompts:
+        - label: "Lore continuity"
+          triggers: ["archive", "memory", "history", "lore"]
+          response: "Requiem response: cross-check recovered records against field evidence and preserve chronology for expedition continuity."
 onboarding:
   enabled: true
   completion_message: "Onboarding complete. I'm ready for full expedition chat support."

--- a/src/main/resources/ai_fallback/aegis.yaml
+++ b/src/main/resources/ai_fallback/aegis.yaml
@@ -1,0 +1,4 @@
+prompts:
+  - label: "Player safety guidance"
+    triggers: ["safety", "health", "protection", "hazard prevention"]
+    response: "Aegis response: maintain med reserves, rotate hazard checks, and keep defensive readiness active before entering unstable zones."

--- a/src/main/resources/ai_fallback/aether.yaml
+++ b/src/main/resources/ai_fallback/aether.yaml
@@ -1,0 +1,4 @@
+prompts:
+  - label: "Subsystem menu"
+    triggers: ["subsystem", "prompt", "menu", "options"]
+    response: "Choose a subsystem: 1) Aegis 2) Eclipse 3) Terra 4) Helios 5) Enforcer 6) Requiem."

--- a/src/main/resources/ai_fallback/eclipse.yaml
+++ b/src/main/resources/ai_fallback/eclipse.yaml
@@ -1,0 +1,4 @@
+prompts:
+  - label: "Anomaly response"
+    triggers: ["rift", "anomaly", "risk", "safe response"]
+    response: "Eclipse response: classify rift intensity first, keep distance from unstable nodes, and only approach with marked fallback routes."

--- a/src/main/resources/ai_fallback/enforcer.yaml
+++ b/src/main/resources/ai_fallback/enforcer.yaml
@@ -1,0 +1,4 @@
+prompts:
+  - label: "Threat prioritization"
+    triggers: ["combat", "security", "threat", "readiness"]
+    response: "Enforcer response: establish perimeter coverage, prioritize fast-moving threats first, and maintain staggered defensive positions."

--- a/src/main/resources/ai_fallback/helios.yaml
+++ b/src/main/resources/ai_fallback/helios.yaml
@@ -1,0 +1,4 @@
+prompts:
+  - label: "Power and stability"
+    triggers: ["energy", "machines", "atmosphere", "stability", "power"]
+    response: "Helios response: balance machine load in phases, preserve backup power, and monitor atmospheric variance before scaling operations."

--- a/src/main/resources/ai_fallback/requiem.yaml
+++ b/src/main/resources/ai_fallback/requiem.yaml
@@ -1,0 +1,4 @@
+prompts:
+  - label: "Lore continuity"
+    triggers: ["archive", "memory", "history", "lore"]
+    response: "Requiem response: cross-check recovered records against field evidence and preserve chronology for expedition continuity."

--- a/src/main/resources/ai_fallback/terra.yaml
+++ b/src/main/resources/ai_fallback/terra.yaml
@@ -1,0 +1,4 @@
+prompts:
+  - label: "Exploration routing"
+    triggers: ["terrain", "world restoration", "exploration", "route"]
+    response: "Terra response: route along stable ridgelines, tag restoration candidates, and avoid crater-edge traversal during low visibility."


### PR DESCRIPTION
### Motivation
- Provide deterministic, lightweight AI responses and named personas when the local LLM sidecar is unavailable or intentionally bypassed. 
- Improve player-facing UX by routing replies to subsystem personas (Aegis, Eclipse, Terra, Helios, Enforcer, Requiem) and showing menu prompts instead of failing silently.

### Description
- Introduces `AIFallbackResponder` to supply deterministic persona-driven menus and prompt responses and to detect persona mentions/menu selections. 
- Extends `AIConfig` and `AIConfigLoader` with a `fallback` section and typed classes (`Fallback`, `FallbackPersona`, `FallbackPrompt`) and parsing logic to load persona menus from `ai_config.yaml`. 
- Updates `AIClient` to configure and consult the fallback responder, resolve speakers, prefer deterministic replies in offline/intentional-fallback cases, and append helpful unavailable hints; preserves memory logging under persona names. 
- Updates `AIChatListener` to use `AIClient.isAiInvocation(...)` and include persona speaker names in pending replies and system messages. 
- Changes `VoiceIntegration` result shape to include a `speaker` field and updated wrapper usage. 
- Adds expanded default `src/main/resources/ai_config.yaml` with A.E.T.H.E.R persona menu and sample prompts, and updates README/docs text to reflect A.E.T.H.E.R support and fallback behavior. 

### Testing
- Performed a full project build with `./gradlew build` which completed successfully. 
- Ran unit tests via `./gradlew test` and `./gradlew check`, and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1718391408328ab6d41e057768326)