### PR TITLE
Add structure-block toggle to disable hostile entity spawns

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/bridge/StructureBlockHostileSpawnToggleBridge.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/bridge/StructureBlockHostileSpawnToggleBridge.java
@@ -1,0 +1,7 @@
+package com.thunder.wildernessodysseyapi.bridge;
+
+public interface StructureBlockHostileSpawnToggleBridge {
+    boolean wildernessodysseyapi$isHostileSpawnsDisabled();
+
+    void wildernessodysseyapi$setHostileSpawnsDisabled(boolean disabled);
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/ServerGamePacketListenerImplMixin.java
@@ -1,0 +1,26 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.thunder.wildernessodysseyapi.bridge.StructureBlockHostileSpawnToggleBridge;
+import com.thunder.wildernessodysseyapi.util.StructureBlockHostileSpawnContext;
+import net.minecraft.network.protocol.game.ServerboundSetStructureBlockPacket;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerGamePacketListenerImpl.class)
+public abstract class ServerGamePacketListenerImplMixin {
+
+    @Inject(method = "handleSetStructureBlock", at = @At("HEAD"))
+    private void wildernessodysseyapi$trackHostileSpawnToggle(ServerboundSetStructureBlockPacket packet, CallbackInfo ci) {
+        boolean disabled = packet instanceof StructureBlockHostileSpawnToggleBridge bridge
+                && bridge.wildernessodysseyapi$isHostileSpawnsDisabled();
+        StructureBlockHostileSpawnContext.setDisableHostileSpawns(disabled);
+    }
+
+    @Inject(method = "handleSetStructureBlock", at = @At("RETURN"))
+    private void wildernessodysseyapi$clearHostileSpawnToggle(ServerboundSetStructureBlockPacket packet, CallbackInfo ci) {
+        StructureBlockHostileSpawnContext.clear();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/ServerboundSetStructureBlockPacketMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/ServerboundSetStructureBlockPacketMixin.java
@@ -1,5 +1,7 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
+import com.thunder.wildernessodysseyapi.bridge.StructureBlockHostileSpawnToggleBridge;
+import com.thunder.wildernessodysseyapi.util.StructureBlockHostileSpawnContext;
 import com.thunder.wildernessodysseyapi.util.StructureBlockSettings;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
@@ -10,6 +12,7 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -18,7 +21,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * Extends the structure block packet so it can transmit the expanded capture limits.
  */
 @Mixin(ServerboundSetStructureBlockPacket.class)
-public abstract class ServerboundSetStructureBlockPacketMixin {
+public abstract class ServerboundSetStructureBlockPacketMixin implements StructureBlockHostileSpawnToggleBridge {
+
+    @Unique
+    private boolean wildernessodysseyapi$disableHostileSpawns;
 
     @Shadow @Final @Mutable private BlockPos offset;
     @Shadow @Final @Mutable private Vec3i size;
@@ -34,6 +40,9 @@ public abstract class ServerboundSetStructureBlockPacketMixin {
         buffer.writeVarInt(Mth.clamp(this.size.getX(), 0, maxSize));
         buffer.writeVarInt(Mth.clamp(this.size.getY(), 0, maxSize));
         buffer.writeVarInt(Mth.clamp(this.size.getZ(), 0, maxSize));
+        this.wildernessodysseyapi$disableHostileSpawns = this.wildernessodysseyapi$disableHostileSpawns
+                || StructureBlockHostileSpawnContext.isDisableHostileSpawns();
+        buffer.writeBoolean(this.wildernessodysseyapi$disableHostileSpawns);
     }
 
     @Inject(method = "<init>(Lnet/minecraft/network/FriendlyByteBuf;)V", at = @At("TAIL"))
@@ -55,8 +64,23 @@ public abstract class ServerboundSetStructureBlockPacketMixin {
 
             this.offset = new BlockPos(offsetX, offsetY, offsetZ);
             this.size = new Vec3i(sizeX, sizeY, sizeZ);
+            if (buffer.isReadable()) {
+                this.wildernessodysseyapi$disableHostileSpawns = buffer.readBoolean();
+            }
         } catch (IndexOutOfBoundsException ignored) {
             // Fall back to the vanilla bounds if the extra payload was not present.
         }
     }
+
+
+    @Override
+    public boolean wildernessodysseyapi$isHostileSpawnsDisabled() {
+        return this.wildernessodysseyapi$disableHostileSpawns;
+    }
+
+    @Override
+    public void wildernessodysseyapi$setHostileSpawnsDisabled(boolean disabled) {
+        this.wildernessodysseyapi$disableHostileSpawns = disabled;
+    }
+
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java
@@ -1,0 +1,78 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.thunder.wildernessodysseyapi.util.StructureBlockHostileSpawnContext;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.inventory.StructureBlockEditScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.block.entity.StructureBlockEntity;
+import net.minecraft.world.level.block.state.properties.StructureMode;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(StructureBlockEditScreen.class)
+public abstract class StructureBlockEditScreenMixin {
+
+    @Shadow private StructureBlockEntity structure;
+
+    @Unique
+    private boolean wildernessodysseyapi$disableHostileSpawns;
+    @Unique
+    private Button wildernessodysseyapi$disableHostileSpawnsButton;
+
+    @Inject(method = "init", at = @At("TAIL"))
+    private void wildernessodysseyapi$addDisableHostileSpawnButton(CallbackInfo ci) {
+        StructureBlockEditScreen screen = (StructureBlockEditScreen) (Object) this;
+        int x = screen.width / 2 - 152;
+        int y = screen.height / 4 + 144;
+        this.wildernessodysseyapi$disableHostileSpawnsButton = screen.addRenderableWidget(Button
+                .builder(wildernessodysseyapi$toggleLabel(), button -> wildernessodysseyapi$toggleDisableHostileSpawns())
+                .bounds(x, y, 304, 20)
+                .build());
+        wildernessodysseyapi$refreshButtonState();
+    }
+
+    @Inject(method = "updateMode", at = @At("TAIL"))
+    private void wildernessodysseyapi$refreshOnModeChange(CallbackInfo ci) {
+        wildernessodysseyapi$refreshButtonState();
+    }
+
+    @Inject(method = "sendToServer", at = @At("HEAD"))
+    private void wildernessodysseyapi$pushToggleToPacketContext(StructureBlockEntity.UpdateType updateType, CallbackInfo ci) {
+        StructureBlockHostileSpawnContext.setDisableHostileSpawns(this.wildernessodysseyapi$disableHostileSpawns);
+    }
+
+    @Inject(method = "sendToServer", at = @At("RETURN"))
+    private void wildernessodysseyapi$clearPacketContext(StructureBlockEntity.UpdateType updateType, CallbackInfo ci) {
+        StructureBlockHostileSpawnContext.clear();
+    }
+
+    @Unique
+    private void wildernessodysseyapi$toggleDisableHostileSpawns() {
+        this.wildernessodysseyapi$disableHostileSpawns = !this.wildernessodysseyapi$disableHostileSpawns;
+        if (this.wildernessodysseyapi$disableHostileSpawnsButton != null) {
+            this.wildernessodysseyapi$disableHostileSpawnsButton.setMessage(wildernessodysseyapi$toggleLabel());
+        }
+    }
+
+    @Unique
+    private void wildernessodysseyapi$refreshButtonState() {
+        if (this.wildernessodysseyapi$disableHostileSpawnsButton == null) {
+            return;
+        }
+        boolean inSaveMode = this.structure.getMode() == StructureMode.SAVE;
+        this.wildernessodysseyapi$disableHostileSpawnsButton.visible = inSaveMode;
+        this.wildernessodysseyapi$disableHostileSpawnsButton.active = inSaveMode;
+        this.wildernessodysseyapi$disableHostileSpawnsButton.setMessage(wildernessodysseyapi$toggleLabel());
+    }
+
+    @Unique
+    private Component wildernessodysseyapi$toggleLabel() {
+        return this.wildernessodysseyapi$disableHostileSpawns
+                ? Component.literal("Disable Hostile Mob Spawns: ON")
+                : Component.literal("Disable Hostile Mob Spawns: OFF");
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -3,6 +3,7 @@ package com.thunder.wildernessodysseyapi.mixin;
 import com.thunder.wildernessodysseyapi.bridge.StructureBlockCornerCacheBridge;
 import com.thunder.wildernessodysseyapi.util.StructureBlockCornerCache;
 import com.thunder.wildernessodysseyapi.util.NbtCompressionUtils;
+import com.thunder.wildernessodysseyapi.util.StructureBlockHostileSpawnContext;
 import com.thunder.wildernessodysseyapi.util.StructureBlockSettings;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -24,6 +25,12 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.util.Mth;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.storage.LevelResource;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobCategory;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -775,8 +782,9 @@ public abstract class StructureBlockEntityMixin extends BlockEntity implements S
         if (structureName == null || structureName.isBlank()) {
             return;
         }
+        boolean disableHostileSpawns = StructureBlockHostileSpawnContext.isDisableHostileSpawns();
         int compressionLevel = StructureBlockSettings.getStructureCompressionLevel();
-        if (compressionLevel <= 0) {
+        if (!disableHostileSpawns && compressionLevel <= 0) {
             return;
         }
 
@@ -791,7 +799,47 @@ public abstract class StructureBlockEntityMixin extends BlockEntity implements S
             return;
         }
 
-        NbtCompressionUtils.rewriteCompressedAsync(structurePath, compressionLevel, com.thunder.wildernessodysseyapi.io.CompressionCodec.VANILLA_GZIP);
+        if (disableHostileSpawns) {
+            wildernessodysseyapi$stripHostileEntities(structurePath);
+        }
+        if (compressionLevel > 0) {
+            NbtCompressionUtils.rewriteCompressedAsync(structurePath, compressionLevel, com.thunder.wildernessodysseyapi.io.CompressionCodec.VANILLA_GZIP);
+        }
+    }
+
+    @Unique
+    private static void wildernessodysseyapi$stripHostileEntities(java.nio.file.Path structurePath) {
+        try {
+            CompoundTag root = NbtIo.readCompressed(structurePath);
+            if (root == null || !root.contains("entities", Tag.TAG_LIST)) {
+                return;
+            }
+            ListTag sourceEntities = root.getList("entities", Tag.TAG_COMPOUND);
+            if (sourceEntities.isEmpty()) {
+                return;
+            }
+
+            ListTag filteredEntities = new ListTag();
+            for (int i = 0; i < sourceEntities.size(); i++) {
+                CompoundTag entityEntry = sourceEntities.getCompound(i);
+                CompoundTag entityNbt = entityEntry.getCompound("nbt");
+                String id = entityNbt.getString("id");
+                if (id.isBlank()) {
+                    filteredEntities.add(entityEntry.copy());
+                    continue;
+                }
+                EntityType<?> entityType = BuiltInRegistries.ENTITY_TYPE.getOptional(ResourceLocation.tryParse(id)).orElse(null);
+                if (entityType != null && entityType.getCategory() == MobCategory.MONSTER) {
+                    continue;
+                }
+                filteredEntities.add(entityEntry.copy());
+            }
+
+            root.put("entities", filteredEntities);
+            NbtIo.writeCompressed(root, structurePath);
+        } catch (Exception exception) {
+            com.thunder.wildernessodysseyapi.ModConstants.LOGGER.warn("Failed stripping hostile entities from saved structure {}", structurePath, exception);
+        }
     }
 
     @Unique

--- a/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockHostileSpawnContext.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockHostileSpawnContext.java
@@ -1,0 +1,20 @@
+package com.thunder.wildernessodysseyapi.util;
+
+public final class StructureBlockHostileSpawnContext {
+    private static final ThreadLocal<Boolean> DISABLE_HOSTILE_SPAWNS = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    private StructureBlockHostileSpawnContext() {
+    }
+
+    public static void setDisableHostileSpawns(boolean disabled) {
+        DISABLE_HOSTILE_SPAWNS.set(disabled);
+    }
+
+    public static boolean isDisableHostileSpawns() {
+        return DISABLE_HOSTILE_SPAWNS.get();
+    }
+
+    public static void clear() {
+        DISABLE_HOSTILE_SPAWNS.remove();
+    }
+}

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -15,7 +15,8 @@
     "ServerboundSetStructureBlockPacketMixin",
     "StructureBlockEntityMixin",
     "StructureTemplateAccessor",
-    "StructureTemplatePaletteAccessor"
+    "StructureTemplatePaletteAccessor",
+    "ServerGamePacketListenerImplMixin"
   ],
   "injectors": {
     "defaultRequire": 1
@@ -28,6 +29,7 @@
     "StructureBlockRendererMixin",
     "ClientLevelWeatherColorMixin",
     "ClientLevelTrueDarknessMixin",
-    "LightTextureTrueDarknessMixin"
+    "LightTextureTrueDarknessMixin",
+    "StructureBlockEditScreenMixin"
   ]
 }


### PR DESCRIPTION
### Motivation

- Provide a UI toggle on the Structure Block edit screen to allow users to keep `Include Entities` but opt out of saving hostile mobs. 
- Carry the toggle through the client→server packet flow so server-side save logic can act on the user's choice. 
- Avoid changing default behavior when the toggle is not used and preserve existing compression/rewrite logic for saved structures.

### Description

- Added a client-side edit-screen mixin that inserts a `Disable Hostile Mob Spawns: ON/OFF` button visible in SAVE mode and pushes the choice into a thread-local context; implemented in `src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java` and `src/main/java/com/thunder/wildernessodysseyapi/util/StructureBlockHostileSpawnContext.java`.
- Extended the structure-block update packet mixin to serialize/deserialize a `disableHostileSpawns` boolean and expose it via a small bridge interface; implemented in `ServerboundSetStructureBlockPacketMixin.java` and `StructureBlockHostileSpawnToggleBridge.java`.
- Added a server packet-listener mixin that reads the packet flag and sets the thread-local context during `handleSetStructureBlock`, then clears it after processing; implemented in `ServerGamePacketListenerImplMixin.java`.
- Updated post-save logic to optionally remove hostile entities (`MobCategory.MONSTER`) from the saved `.nbt` file when the toggle is enabled, while preserving non-hostile entities and existing compression behavior; implemented in `StructureBlockEntityMixin.java` and registered new mixins in `src/main/resources/mixins.wildernessodysseyapi.json`.

### Testing

- Attempted to compile with `./gradlew compileJava -x test` to validate the changes, but the build failed in this environment while downloading Mojang metadata due to an SSL certificate/trust error (`SSLHandshakeException`).
- No automated tests (unit or game tests) completed in this environment because the compile step could not finish.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3566709148328a332263b72fe4ce7)