### PR TITLE
Fix /meteor summon null-entity crash in impact targeting

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/command/MeteorCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/MeteorCommand.java
@@ -12,14 +12,11 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.item.FallingBlockEntity;
-import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BaseFireBlock;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.Heightmap;
-import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
 /**
@@ -67,13 +64,8 @@ public final class MeteorCommand {
         int targetZ = Mth.floor(origin.z + Math.sin(angle) * distance);
         BlockPos impactPos = level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, new BlockPos(targetX, 0, targetZ));
 
-        // If an overhang exists, ray trace down so impact feels grounded to visible terrain.
-        Vec3 start = new Vec3(targetX + 0.5, impactPos.getY() + 40, targetZ + 0.5);
-        Vec3 end = new Vec3(targetX + 0.5, impactPos.getY() - 20, targetZ + 0.5);
-        BlockHitResult hitResult = level.clip(new ClipContext(start, end, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, null));
-        if (hitResult.getType() == HitResult.Type.BLOCK) {
-            impactPos = hitResult.getBlockPos().above();
-        }
+        // Refine the impact to the first visible surface in this column.
+        impactPos = findSurfaceFromAbove(level, impactPos, targetX, targetZ);
 
         createImpact(level, impactPos, size, random);
 
@@ -86,6 +78,19 @@ public final class MeteorCommand {
                 size
         )), true);
         return Command.SINGLE_SUCCESS;
+    }
+
+    private static BlockPos findSurfaceFromAbove(ServerLevel level, BlockPos fallback, int targetX, int targetZ) {
+        int maxY = Math.min(level.getMaxBuildHeight() - 1, fallback.getY() + 40);
+        int minY = Math.max(level.getMinBuildHeight(), fallback.getY() - 20);
+
+        for (int y = maxY; y >= minY; y--) {
+            BlockPos cursor = new BlockPos(targetX, y, targetZ);
+            if (!level.getBlockState(cursor).isAir()) {
+                return cursor.above();
+            }
+        }
+        return fallback;
     }
 
     private static void createImpact(ServerLevel level, BlockPos impactPos, int size, RandomSource random) {


### PR DESCRIPTION
### Motivation
- Prevent a `NullPointerException` thrown when `/meteor summon` is executed from a source without a backing entity (for example console or command block).
- The previous ray-trace used `ClipContext` with a `null` entity which triggered `EntityCollisionContext` to dereference a null entity.

### Description
- Removed the `ClipContext`-based ray trace and its imports to avoid constructing an `EntityCollisionContext` with a `null` entity. 
- Added `findSurfaceFromAbove(ServerLevel, BlockPos, int, int)` which scans the target column from `y+40` down to `y-20` and returns the first non-air surface above that block. 
- Replaced the ray-trace refinement with a call to `findSurfaceFromAbove(...)` so impact positioning remains grounded without relying on entity collision context.

### Testing
- Ran `./gradlew compileJava` to validate the change, but the build failed in this environment due to a TLS certificate validation error while downloading Mojang metadata (`PKIX path building failed`), not due to Java compilation errors in the modified source.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c356c093848328bf57e8a96693238f)