### PR TITLE
Fix compile regressions in meteor and structure block mixins

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/command/MeteorCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/MeteorCommand.java
@@ -135,18 +135,7 @@ public final class MeteorCommand {
 
         // Refine the impact to the first visible surface in this column.
         impactPos = findSurfaceFromAbove(level, impactPos, targetX, targetZ);
-
-        createImpact(level, impactPos, size, random);
-
-        BlockPos finalImpactPos = impactPos;
-        source.sendSuccess(() -> Component.literal(String.format(
-                "Meteor impact created at %d, %d, %d (size %d)",
-                finalImpactPos.getX(),
-                finalImpactPos.getY(),
-                finalImpactPos.getZ(),
-                size
-        )), true);
-        return Command.SINGLE_SUCCESS;
+        return impactPos;
     }
 
     private static BlockPos findSurfaceFromAbove(ServerLevel level, BlockPos fallback, int targetX, int targetZ) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java
@@ -2,6 +2,9 @@ package com.thunder.wildernessodysseyapi.mixin;
 
 import com.thunder.wildernessodysseyapi.util.StructureBlockHostileSpawnContext;
 import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.screens.inventory.StructureBlockEditScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.block.entity.StructureBlockEntity;
@@ -17,6 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class StructureBlockEditScreenMixin {
 
     @Shadow private StructureBlockEntity structure;
+    @Shadow protected abstract <T extends GuiEventListener & Renderable & NarratableEntry> T addRenderableWidget(T widget);
 
     @Unique
     private boolean wildernessodysseyapi$disableHostileSpawns;
@@ -28,7 +32,7 @@ public abstract class StructureBlockEditScreenMixin {
         StructureBlockEditScreen screen = (StructureBlockEditScreen) (Object) this;
         int x = screen.width / 2 - 152;
         int y = screen.height / 4 + 144;
-        this.wildernessodysseyapi$disableHostileSpawnsButton = screen.addRenderableWidget(Button
+        this.wildernessodysseyapi$disableHostileSpawnsButton = this.addRenderableWidget(Button
                 .builder(wildernessodysseyapi$toggleLabel(), button -> wildernessodysseyapi$toggleDisableHostileSpawns())
                 .bounds(x, y, 304, 20)
                 .build());

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEntityMixin.java
@@ -1,6 +1,7 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
 import com.thunder.wildernessodysseyapi.bridge.StructureBlockCornerCacheBridge;
+import com.thunder.wildernessodysseyapi.core.ModConstants;
 import com.thunder.wildernessodysseyapi.util.StructureBlockCornerCache;
 import com.thunder.wildernessodysseyapi.util.NbtCompressionUtils;
 import com.thunder.wildernessodysseyapi.util.StructureBlockHostileSpawnContext;
@@ -27,6 +28,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.storage.LevelResource;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.entity.EntityType;
@@ -810,7 +812,7 @@ public abstract class StructureBlockEntityMixin extends BlockEntity implements S
     @Unique
     private static void wildernessodysseyapi$stripHostileEntities(java.nio.file.Path structurePath) {
         try {
-            CompoundTag root = NbtIo.readCompressed(structurePath);
+            CompoundTag root = NbtIo.readCompressed(structurePath, NbtAccounter.unlimitedHeap());
             if (root == null || !root.contains("entities", Tag.TAG_LIST)) {
                 return;
             }
@@ -838,7 +840,7 @@ public abstract class StructureBlockEntityMixin extends BlockEntity implements S
             root.put("entities", filteredEntities);
             NbtIo.writeCompressed(root, structurePath);
         } catch (Exception exception) {
-            com.thunder.wildernessodysseyapi.ModConstants.LOGGER.warn("Failed stripping hostile entities from saved structure {}", structurePath, exception);
+            ModConstants.LOGGER.warn("Failed stripping hostile entities from saved structure {}", structurePath, exception);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Restore correct behavior after accidental code duplication and API drift caused compile-time errors observed in the build logs. 
- Ensure mixins call protected widget helpers correctly and NBT I/O uses the current `NbtIo` signature.

### Description
- Removed stray command-side impact logic from `selectImpactPos(...)` so it now only computes and returns a `BlockPos`, fixing references to undefined `size`/`source` and incorrect return type in `MeteorCommand`. 
- Updated `StructureBlockEditScreenMixin` to shadow and call `addRenderableWidget(...)` directly and added the required `Renderable`, `GuiEventListener`, and `NarratableEntry` imports to avoid protected-access errors. 
- Updated `StructureBlockEntityMixin` to use `NbtIo.readCompressed(Path, NbtAccounter)` with `NbtAccounter.unlimitedHeap()` and added `NbtAccounter` import, and fixed the `ModConstants` logger reference by importing `com.thunder.wildernessodysseyapi.core.ModConstants`. 
- Committed fixes across the three modified files: `MeteorCommand.java`, `StructureBlockEditScreenMixin.java`, and `StructureBlockEntityMixin.java`.

### Testing
- Ran `./gradlew compileJava --no-daemon`, which failed during `:createMinecraftArtifacts` due to an SSL/certificate error when downloading Mojang metadata, not due to the code changes. 
- Ran `./gradlew compileJava -x createMinecraftArtifacts --no-daemon`, which still failed in this environment because skipping artifact generation leaves Minecraft/NeoForge classes unavailable on the classpath; the failures are environmental, not related to the applied fixes. 
- Local compilation issues reported in the original build log (undefined symbols, protected-method access, outdated `NbtIo` signature) have been addressed by the changes above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43a5ef0a883288ad015b07d0d2b89)