### PR TITLE
Replace invalid @Shadow with @Invoker in StructureBlockEditScreenMixin

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java
@@ -11,6 +11,7 @@ import net.minecraft.world.level.block.entity.StructureBlockEntity;
 import net.minecraft.world.level.block.state.properties.StructureMode;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -20,7 +21,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class StructureBlockEditScreenMixin {
 
     @Shadow private StructureBlockEntity structure;
-    @Shadow protected abstract <T extends GuiEventListener & Renderable & NarratableEntry> T addRenderableWidget(T widget);
+    @Invoker("addRenderableWidget")
+    protected abstract <T extends GuiEventListener & Renderable & NarratableEntry> T wildernessodysseyapi$invokeAddRenderableWidget(T widget);
 
     @Unique
     private boolean wildernessodysseyapi$disableHostileSpawns;
@@ -32,7 +34,7 @@ public abstract class StructureBlockEditScreenMixin {
         StructureBlockEditScreen screen = (StructureBlockEditScreen) (Object) this;
         int x = screen.width / 2 - 152;
         int y = screen.height / 4 + 144;
-        this.wildernessodysseyapi$disableHostileSpawnsButton = this.addRenderableWidget(Button
+        this.wildernessodysseyapi$disableHostileSpawnsButton = this.wildernessodysseyapi$invokeAddRenderableWidget(Button
                 .builder(wildernessodysseyapi$toggleLabel(), button -> wildernessodysseyapi$toggleDisableHostileSpawns())
                 .bounds(x, y, 304, 20)
                 .build());


### PR DESCRIPTION
### Motivation
- The mixin application failed at runtime with `InvalidMixinException` because the `@Shadow` for `addRenderableWidget` could not be resolved on `net.minecraft.client.gui.screens.inventory.StructureBlockEditScreen`, causing the client to crash during mixin apply.

### Description
- Replaced the `@Shadow` declaration for `addRenderableWidget` with an `@Invoker("addRenderableWidget")` bridge method and updated usages to call the invoker in `src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java`.
- This preserves the button creation and behavior while avoiding brittle shadow resolution for an inherited GUI method.

### Testing
- Ran `./gradlew compileJava -q` to validate compilation, but the build failed in this environment due to an external TLS certificate handshake error when downloading Mojang metadata (`SSLHandshakeException: PKIX path building failed`), not due to compilation errors in the modified source.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43f60107883288f4086f32a8737d8)