### PR TITLE
Fix StructureBlockEditScreen mixin invoker signature for NeoForge 1.21.1

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java
@@ -1,10 +1,8 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
 import com.thunder.wildernessodysseyapi.util.StructureBlockHostileSpawnContext;
+import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.components.Renderable;
-import net.minecraft.client.gui.components.events.GuiEventListener;
-import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.screens.inventory.StructureBlockEditScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.block.entity.StructureBlockEntity;
@@ -22,7 +20,7 @@ public abstract class StructureBlockEditScreenMixin {
 
     @Shadow private StructureBlockEntity structure;
     @Invoker("addRenderableWidget")
-    protected abstract <T extends GuiEventListener & Renderable & NarratableEntry> T wildernessodysseyapi$invokeAddRenderableWidget(T widget);
+    protected abstract <T extends AbstractWidget> T wildernessodysseyapi$invokeAddRenderableWidget(T widget);
 
     @Unique
     private boolean wildernessodysseyapi$disableHostileSpawns;


### PR DESCRIPTION
### Motivation
- Prevent a mixin apply failure caused by a mismatched `addRenderableWidget` invoker descriptor that produced an `InvalidAccessorException` during client startup.

### Description
- Change the `StructureBlockEditScreenMixin` invoker generic bound from `GuiEventListener & Renderable & NarratableEntry` to `AbstractWidget` to match the runtime method shape.
- Add `import net.minecraft.client.gui.components.AbstractWidget;` and remove the now-unused GUI interface imports in `StructureBlockEditScreenMixin`.
- This aligns the mixin invoker signature with the current `StructureBlockEditScreen` API so the accessor can be located at mixin-apply time.

### Testing
- Ran `./gradlew compileJava`, which failed in this environment due to an external SSL `PKIX` certificate trust error while downloading Mojang/launcher metadata, so the build could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c466a343e08328b4c836d61b4124f4)