### PR TITLE
Fix StructureBlockEditScreen addRenderableWidget invoker signature

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java
@@ -1,7 +1,7 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
 import com.thunder.wildernessodysseyapi.util.StructureBlockHostileSpawnContext;
-import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.inventory.StructureBlockEditScreen;
 import net.minecraft.network.chat.Component;
@@ -20,7 +20,7 @@ public abstract class StructureBlockEditScreenMixin {
 
     @Shadow private StructureBlockEntity structure;
     @Invoker("addRenderableWidget")
-    protected abstract <T extends AbstractWidget> T wildernessodysseyapi$invokeAddRenderableWidget(T widget);
+    protected abstract <T extends GuiEventListener> T wildernessodysseyapi$invokeAddRenderableWidget(T widget);
 
     @Unique
     private boolean wildernessodysseyapi$disableHostileSpawns;


### PR DESCRIPTION
### Motivation
- The mixin `StructureBlockEditScreenMixin` used an `@Invoker` bound to `AbstractWidget` which did not match the runtime-erased signature and caused `InvalidAccessorException` during mixin application, so the invoker needs to match Minecraft 1.21.1's method types to avoid crashes.

### Description
- Updated `src/main/java/com/thunder/wildernessodysseyapi/mixin/StructureBlockEditScreenMixin.java` to replace the `AbstractWidget` import with `net.minecraft.client.gui.components.events.GuiEventListener` and changed the `@Invoker` generic bound to `GuiEventListener`, leaving the mixin logic and injections unchanged.

### Testing
- Ran `./gradlew compileJava --no-daemon` to verify compilation, but the build aborted due to an environment SSL trust error while downloading Mojang metadata (`PKIX path building failed`), so a full successful compile could not be confirmed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c46982e0688328aae382e29ed2baf3)