### PR TITLE
Add anomaly music rotation and impact-site proximity music with fade

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/client/biome/ImpactSiteMusicController.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/client/biome/ImpactSiteMusicController.java
@@ -1,0 +1,125 @@
+package com.thunder.wildernessodysseyapi.client.biome;
+
+import com.thunder.wildernessodysseyapi.core.ModConstants;
+import com.thunder.wildernessodysseyapi.worldgen.biome.ModBiomes;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Blocks;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+
+@EventBusSubscriber(modid = ModConstants.MOD_ID, value = Dist.CLIENT)
+public final class ImpactSiteMusicController {
+    private static final int EFFECT_RADIUS = 100;
+    private static final int SCAN_STEP = 4;
+    private static final int SCAN_VERTICAL = 12;
+    private static final int SCAN_INTERVAL_TICKS = 20;
+
+    private static ImpactSiteMusicSoundInstance activeMusic;
+    private static BlockPos cachedImpactCenter;
+    private static int scanCooldown;
+
+    private ImpactSiteMusicController() {
+    }
+
+    @SubscribeEvent
+    public static void onClientTick(ClientTickEvent.Post event) {
+        Minecraft minecraft = Minecraft.getInstance();
+        Level level = minecraft.level;
+        if (level == null || minecraft.player == null || minecraft.isPaused()) {
+            fadeOutAndCleanup(minecraft);
+            return;
+        }
+
+        BlockPos playerPos = minecraft.player.blockPosition();
+        if (!isInAnomalyBiome(level, playerPos)) {
+            fadeOutAndCleanup(minecraft);
+            return;
+        }
+
+        scanCooldown--;
+        if (cachedImpactCenter == null || scanCooldown <= 0 || cachedImpactCenter.distSqr(playerPos) > (EFFECT_RADIUS * EFFECT_RADIUS * 4.0D)) {
+            cachedImpactCenter = findNearestImpactCenter(level, playerPos, EFFECT_RADIUS);
+            scanCooldown = SCAN_INTERVAL_TICKS;
+        }
+
+        float targetVolume = 0.0F;
+        if (cachedImpactCenter != null) {
+            double distance = Math.sqrt(cachedImpactCenter.distSqr(playerPos));
+            if (distance <= EFFECT_RADIUS) {
+                targetVolume = (float) (1.0D - (distance / EFFECT_RADIUS));
+            }
+        }
+
+        if (targetVolume > 0.001F) {
+            ensureMusicStarted(minecraft);
+        }
+
+        if (activeMusic != null) {
+            activeMusic.setTargetVolume(targetVolume);
+            if (activeMusic.isStopped()) {
+                activeMusic = null;
+            }
+        }
+    }
+
+    private static void ensureMusicStarted(Minecraft minecraft) {
+        if (activeMusic != null && minecraft.getSoundManager().isActive(activeMusic)) {
+            return;
+        }
+
+        activeMusic = new ImpactSiteMusicSoundInstance();
+        minecraft.getSoundManager().play(activeMusic);
+    }
+
+    private static void fadeOutAndCleanup(Minecraft minecraft) {
+        cachedImpactCenter = null;
+        scanCooldown = 0;
+
+        if (activeMusic == null) {
+            return;
+        }
+
+        activeMusic.setTargetVolume(0.0F);
+        if (!minecraft.getSoundManager().isActive(activeMusic) || activeMusic.isStopped()) {
+            activeMusic = null;
+        }
+    }
+
+    private static BlockPos findNearestImpactCenter(Level level, BlockPos playerPos, int radius) {
+        BlockPos bestPos = null;
+        double bestDistanceSq = Double.MAX_VALUE;
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+
+        for (int dx = -radius; dx <= radius; dx += SCAN_STEP) {
+            for (int dz = -radius; dz <= radius; dz += SCAN_STEP) {
+                for (int dy = -SCAN_VERTICAL; dy <= SCAN_VERTICAL; dy += SCAN_STEP) {
+                    cursor.set(playerPos.getX() + dx, playerPos.getY() + dy, playerPos.getZ() + dz);
+                    if (!level.isLoaded(cursor) || !level.getBlockState(cursor).is(Blocks.CRYING_OBSIDIAN)) {
+                        continue;
+                    }
+
+                    double distSq = cursor.distSqr(playerPos);
+                    if (distSq <= radius * radius && distSq < bestDistanceSq) {
+                        bestDistanceSq = distSq;
+                        bestPos = cursor.immutable();
+                    }
+                }
+            }
+        }
+
+        return bestPos;
+    }
+
+    private static boolean isInAnomalyBiome(Level level, BlockPos pos) {
+        Holder<Biome> biome = level.getBiome(pos);
+        return biome.is(ModBiomes.ANOMALY_PLAINS_KEY)
+                || biome.is(ModBiomes.ANOMALY_TUNDRA_KEY)
+                || biome.is(ModBiomes.ANOMALY_RAINFOREST_KEY);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/client/biome/ImpactSiteMusicSoundInstance.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/client/biome/ImpactSiteMusicSoundInstance.java
@@ -1,0 +1,38 @@
+package com.thunder.wildernessodysseyapi.client.biome;
+
+import com.thunder.wildernessodysseyapi.item.ModSoundEvents;
+import net.minecraft.client.resources.sounds.AbstractTickableSoundInstance;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
+
+final class ImpactSiteMusicSoundInstance extends AbstractTickableSoundInstance {
+    private float targetVolume;
+
+    ImpactSiteMusicSoundInstance() {
+        super(ModSoundEvents.IMPACT_SITE_MUSIC.get(), SoundSource.MUSIC, RandomSource.create());
+        this.looping = true;
+        this.delay = 0;
+        this.relative = true;
+        this.volume = 0.0F;
+        this.targetVolume = 0.0F;
+    }
+
+    void setTargetVolume(float targetVolume) {
+        this.targetVolume = Math.max(0.0F, Math.min(1.0F, targetVolume));
+    }
+
+    @Override
+    public void tick() {
+        if (this.targetVolume <= 0.001F && this.volume <= 0.001F) {
+            this.stop();
+            return;
+        }
+
+        float fadeStep = 0.02F;
+        if (this.volume < this.targetVolume) {
+            this.volume = Math.min(this.targetVolume, this.volume + fadeStep);
+        } else if (this.volume > this.targetVolume) {
+            this.volume = Math.max(this.targetVolume, this.volume - fadeStep);
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/ModSoundEvents.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/ModSoundEvents.java
@@ -26,6 +26,21 @@ public final class ModSoundEvents {
             () -> SoundEvent.createVariableRangeEvent(ResourceLocation.fromNamespaceAndPath(MOD_ID, "outside_the_box"))
     );
 
+    public static final DeferredHolder<SoundEvent, SoundEvent> ANOMALY_PRIORITY_TRACK = SOUND_EVENTS.register(
+            "anomaly_priority_track",
+            () -> SoundEvent.createVariableRangeEvent(ResourceLocation.fromNamespaceAndPath(MOD_ID, "anomaly_priority_track"))
+    );
+
+    public static final DeferredHolder<SoundEvent, SoundEvent> ANOMALY_BIOME_MUSIC = SOUND_EVENTS.register(
+            "anomaly_biome_music",
+            () -> SoundEvent.createVariableRangeEvent(ResourceLocation.fromNamespaceAndPath(MOD_ID, "anomaly_biome_music"))
+    );
+
+    public static final DeferredHolder<SoundEvent, SoundEvent> IMPACT_SITE_MUSIC = SOUND_EVENTS.register(
+            "impact_site_music",
+            () -> SoundEvent.createVariableRangeEvent(ResourceLocation.fromNamespaceAndPath(MOD_ID, "impact_site_music"))
+    );
+
     private ModSoundEvents() {
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/biome/AnomalyBiomes.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/biome/AnomalyBiomes.java
@@ -122,7 +122,7 @@ public final class AnomalyBiomes {
     }
 
     private static Music defaultMusic() {
-        return new Music(ModSoundEvents.ANOMALY_BIOME_MUSIC.getHolder().orElseThrow(), 6000, 12000, false);
+        return new Music(ModSoundEvents.ANOMALY_BIOME_MUSIC, 6000, 12000, false);
     }
 
     private static BiomeGenerationSettings.Builder generationBuilder() {

--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/biome/AnomalyBiomes.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/biome/AnomalyBiomes.java
@@ -7,7 +7,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.sounds.Music;
-import net.minecraft.sounds.Musics;
+import com.thunder.wildernessodysseyapi.item.ModSoundEvents;
 import net.minecraft.world.level.biome.AmbientMoodSettings;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeGenerationSettings;
@@ -122,7 +122,7 @@ public final class AnomalyBiomes {
     }
 
     private static Music defaultMusic() {
-        return Musics.GAME;
+        return new Music(ModSoundEvents.ANOMALY_BIOME_MUSIC.getHolder().orElseThrow(), 6000, 12000, false);
     }
 
     private static BiomeGenerationSettings.Builder generationBuilder() {

--- a/src/main/resources/assets/wildernessodysseyapi/sounds.json
+++ b/src/main/resources/assets/wildernessodysseyapi/sounds.json
@@ -16,5 +16,48 @@
         "stream": true
       }
     ]
+  },
+  "anomaly_priority_track": {
+    "category": "music",
+    "sounds": [
+      {
+        "name": "wildernessodysseyapi:music/anomaly_priority_track",
+        "stream": true
+      }
+    ]
+  },
+  "anomaly_biome_music": {
+    "category": "music",
+    "sounds": [
+      {
+        "type": "event",
+        "name": "wildernessodysseyapi:anomaly_priority_track",
+        "weight": 7
+      },
+      {
+        "type": "event",
+        "name": "minecraft:music.overworld.badlands",
+        "weight": 2
+      },
+      {
+        "type": "event",
+        "name": "minecraft:music.overworld.grove",
+        "weight": 2
+      },
+      {
+        "type": "event",
+        "name": "minecraft:music.overworld.dripstone_caves",
+        "weight": 1
+      }
+    ]
+  },
+  "impact_site_music": {
+    "category": "music",
+    "sounds": [
+      {
+        "name": "wildernessodysseyapi:music/impact_site_music",
+        "stream": true
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/wildernessodysseyapi/sounds/music/README.txt
+++ b/src/main/resources/assets/wildernessodysseyapi/sounds/music/README.txt
@@ -1,0 +1,6 @@
+Drop custom anomaly/impact music .ogg files in this folder:
+
+- anomaly_priority_track.ogg  (used in anomaly biome rotation with high weight)
+- impact_site_music.ogg       (used for fade-in/fade-out near impact sites)
+
+These names match entries in assets/wildernessodysseyapi/sounds.json.


### PR DESCRIPTION
### Motivation
- Provide a slot for a custom anomaly track that is favored in biome music rotation and add a proximity-triggered impact-site ambient track that fades in/out near meteor impacts.
- Let designers drop .ogg files into the mod assets so the anomaly biome soundtrack can rotate between vanilla tracks and the custom priority track.

### Description
- Registered new sound events in `ModSoundEvents`: `ANOMALY_PRIORITY_TRACK`, `ANOMALY_BIOME_MUSIC`, and `IMPACT_SITE_MUSIC`.
- Switched anomaly biome background music in `AnomalyBiomes.defaultMusic()` to use the `anomaly_biome_music` event so the biome rotates tracks with a higher weight for the custom priority track.
- Updated `src/main/resources/assets/wildernessodysseyapi/sounds.json` to add `anomaly_priority_track`, a weighted `anomaly_biome_music` rotation (includes vanilla overworld music entries), and `impact_site_music` entries.
- Added client-side impact-site audio: `ImpactSiteMusicController` (runs client ticks inside anomaly biomes, scans for nearby impact centers by locating crying obsidian clusters up to 100 blocks, computes distance-based target volume, starts/stops playback) and `ImpactSiteMusicSoundInstance` (tickable sound instance implementing smooth fade in/out).
- Added `sounds/music/README.txt` documenting the expected `.ogg` filenames to drop: `anomaly_priority_track.ogg` and `impact_site_music.ogg`.

### Testing
- Ran `./gradlew compileJava` to verify changes, but the build failed in this environment due to SSL certificate/artifact download errors when fetching NeoForge/Minecraft artifacts, not due to Java source compilation diagnostics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c477902b148328baaf51df875c8e47)