### PR TITLE
Add dedicated Spark webhook and optional blocking logout telemetry

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/telemetry/PlayerTelemetryConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/telemetry/PlayerTelemetryConfig.java
@@ -15,6 +15,9 @@ public final class PlayerTelemetryConfig {
     public static final ModConfigSpec.IntValue REQUEST_TIMEOUT_SECONDS;
     public static final ModConfigSpec.BooleanValue EXPORT_ON_LOGOUT;
     public static final ModConfigSpec.BooleanValue INCLUDE_SPARK_REPORT;
+    public static final ModConfigSpec.ConfigValue<String> SPARK_WEBHOOK_URL;
+    public static final ModConfigSpec.BooleanValue BLOCK_LOGOUT_UNTIL_SPARK_SENT;
+    public static final ModConfigSpec.IntValue LOGOUT_BLOCK_TIMEOUT_SECONDS;
     public static final ModConfigSpec.DoubleValue SAMPLE_RATE_PERCENT;
     public static final ModConfigSpec.IntValue SAMPLE_EVERY_NTH;
     public static final ModConfigSpec.BooleanValue HASH_PLAYER_IDENTIFIERS;
@@ -60,6 +63,20 @@ public final class PlayerTelemetryConfig {
                         "When Spark is installed, attach a Spark report URL to logout exports.",
                         "Requires exportOnLogout to be enabled.")
                 .define("includeSparkReport", false);
+
+        SPARK_WEBHOOK_URL = BUILDER.comment(
+                        "Optional dedicated webhook for Spark report payloads on logout.",
+                        "When set, Spark report metadata is sent separately from the main telemetry webhook.")
+                .define("sparkWebhookUrl", "");
+
+        BLOCK_LOGOUT_UNTIL_SPARK_SENT = BUILDER.comment(
+                        "When true, run logout telemetry synchronously so Spark webhook delivery can complete before logout finishes.",
+                        "Use with caution: this can delay logout while network calls complete.")
+                .define("blockLogoutUntilSparkSent", false);
+
+        LOGOUT_BLOCK_TIMEOUT_SECONDS = BUILDER.comment(
+                        "Maximum time to wait during blocking logout telemetry execution.")
+                .defineInRange("logoutBlockTimeoutSeconds", 15, 1, 120);
 
         SAMPLE_RATE_PERCENT = BUILDER.comment(
                         "Sampling rate percentage for player telemetry (0-100).",
@@ -116,6 +133,9 @@ public final class PlayerTelemetryConfig {
                 REQUEST_TIMEOUT_SECONDS.get(),
                 EXPORT_ON_LOGOUT.get(),
                 INCLUDE_SPARK_REPORT.get(),
+                SPARK_WEBHOOK_URL.get(),
+                BLOCK_LOGOUT_UNTIL_SPARK_SENT.get(),
+                LOGOUT_BLOCK_TIMEOUT_SECONDS.get(),
                 SAMPLE_RATE_PERCENT.get(),
                 SAMPLE_EVERY_NTH.get(),
                 HASH_PLAYER_IDENTIFIERS.get(),
@@ -136,6 +156,9 @@ public final class PlayerTelemetryConfig {
             int requestTimeoutSeconds,
             boolean exportOnLogout,
             boolean includeSparkReport,
+            String sparkWebhookUrl,
+            boolean blockLogoutUntilSparkSent,
+            int logoutBlockTimeoutSeconds,
             double sampleRatePercent,
             int sampleEveryNth,
             boolean hashPlayerIdentifiers,

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/telemetry/PlayerTelemetryReporter.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/telemetry/PlayerTelemetryReporter.java
@@ -121,25 +121,48 @@ public final class PlayerTelemetryReporter {
         }
 
         long playTimeSeconds = getTotalPlayTimeSeconds(player);
+        Runnable logoutExportTask = () -> runLogoutExport(player, config, playTimeSeconds);
+        if (config.blockLogoutUntilSparkSent()) {
+            logoutExportTask.run();
+            return;
+        }
+
         AsyncTaskManager.submitIoTask("player-telemetry-spark-report", () -> {
-            try {
-                String sparkReportUrl = config.includeSparkReport()
-                        ? fetchSparkReportUrl(player).orElse(null)
-                        : null;
-                if (!TelemetrySampling.shouldSample("player_logout", config.sampleEveryNth(), config.sampleRatePercent())) {
-                    return Optional.empty();
-                }
-                JsonObject payload = buildPayload(player, GeoInfo.empty(), AccountAgeInfo.empty(), playTimeSeconds,
-                        sparkReportUrl, "logout", config);
-                boolean sent = sendPayload(player, payload, config.sheetWebhookUrl(), config);
-                if (!sent) {
-                    enqueueFailedPayload(player.server, "player", payload, config);
-                }
-            } catch (Exception ex) {
-                LOGGER.error("[Telemetry] Failed to export telemetry for {}", player.getGameProfile().getName(), ex);
-            }
+            logoutExportTask.run();
             return Optional.empty();
         });
+    }
+
+    private static void runLogoutExport(ServerPlayer player, PlayerTelemetryConfig.TelemetryConfigValues config,
+                                        long playTimeSeconds) {
+        try {
+            String sparkReportUrl = config.includeSparkReport()
+                    ? fetchSparkReportUrl(player, config.logoutBlockTimeoutSeconds()).orElse(null)
+                    : null;
+            if (!TelemetrySampling.shouldSample("player_logout", config.sampleEveryNth(), config.sampleRatePercent())) {
+                return;
+            }
+
+            String sparkWebhookUrl = config.sparkWebhookUrl();
+            boolean hasDedicatedSparkWebhook = sparkWebhookUrl != null && !sparkWebhookUrl.isBlank();
+            if (hasDedicatedSparkWebhook && sparkReportUrl != null && !sparkReportUrl.isBlank()) {
+                JsonObject sparkPayload = buildSparkPayload(player, sparkReportUrl, playTimeSeconds);
+                boolean sparkSent = sendPayload(player, sparkPayload, sparkWebhookUrl, config);
+                if (!sparkSent) {
+                    enqueueFailedPayload(player.server, "spark", sparkPayload, config);
+                }
+            }
+
+            String sparkUrlForMainPayload = hasDedicatedSparkWebhook ? null : sparkReportUrl;
+            JsonObject payload = buildPayload(player, GeoInfo.empty(), AccountAgeInfo.empty(), playTimeSeconds,
+                    sparkUrlForMainPayload, "logout", config);
+            boolean sent = sendPayload(player, payload, config.sheetWebhookUrl(), config);
+            if (!sent) {
+                enqueueFailedPayload(player.server, "player", payload, config);
+            }
+        } catch (Exception ex) {
+            LOGGER.error("[Telemetry] Failed to export telemetry for {}", player.getGameProfile().getName(), ex);
+        }
     }
 
     private static String resolveIpAddress(ServerPlayer player) {
@@ -340,7 +363,7 @@ public final class PlayerTelemetryReporter {
         return ticks / 20L;
     }
 
-    private static Optional<String> fetchSparkReportUrl(ServerPlayer player) {
+    private static Optional<String> fetchSparkReportUrl(ServerPlayer player, int timeoutSeconds) {
         if (!ModList.get().isLoaded("spark")) {
             return Optional.empty();
         }
@@ -375,13 +398,28 @@ public final class PlayerTelemetryReporter {
             Method executeCommand = platform.getClass().getMethod("executeCommand", senderInterface, String[].class);
             Object result = executeCommand.invoke(platform, senderProxy, (Object) new String[]{"report"});
             if (result instanceof CompletableFuture<?> future) {
-                future.get(10, TimeUnit.SECONDS);
+                future.get(Math.max(1, timeoutSeconds), TimeUnit.SECONDS);
             }
             return capture.getReportUrl();
         } catch (Exception ex) {
             LOGGER.warn("[Telemetry] Spark report generation failed: {}", ex.getMessage());
             return Optional.empty();
         }
+    }
+
+    private static JsonObject buildSparkPayload(ServerPlayer player, String sparkReportUrl, long playTimeSeconds) {
+        Instant now = Instant.now();
+        JsonObject payload = new JsonObject();
+        payload.addProperty("event_type", "spark_report");
+        payload.addProperty("player_name", player.getGameProfile().getName());
+        payload.addProperty("player_uuid", player.getUUID().toString());
+        payload.addProperty("spark_report_url", sparkReportUrl);
+        payload.addProperty("timestamp", now.toString());
+        payload.addProperty("report_date_utc", now.toString().substring(0, 10));
+        payload.addProperty("report_time_utc", now.toString().substring(11, 19));
+        payload.addProperty("play_time_seconds", playTimeSeconds);
+        payload.addProperty("play_time_minutes", Math.round((playTimeSeconds / 60.0) * 100.0) / 100.0);
+        return payload;
     }
 
     private static final class SparkCommandCapture implements InvocationHandler {


### PR DESCRIPTION
### Motivation
- Allow Spark report metadata to be delivered to a dedicated webhook separate from the main telemetry sheet webhook. 
- Provide an option to block logout until Spark report generation/delivery completes to ensure the report URL is available for export. 
- Add a configurable timeout for Spark report generation and delivery to avoid unbounded waits during logout.

### Description
- Added new config fields in `PlayerTelemetryConfig`: `SPARK_WEBHOOK_URL`, `BLOCK_LOGOUT_UNTIL_SPARK_SENT`, and `LOGOUT_BLOCK_TIMEOUT_SECONDS`, and wired them into `values()` and the `TelemetryConfigValues` record. 
- Refactored logout export logic in `PlayerTelemetryReporter` by extracting `runLogoutExport(...)` and adding synchronous execution when `blockLogoutUntilSparkSent` is enabled; the async task now delegates to this shared routine. 
- Extended Spark handling: changed `fetchSparkReportUrl(...)` to accept a timeout parameter, added `buildSparkPayload(...)`, and implemented sending Spark-specific payloads to the dedicated webhook (and falling back to include the Spark URL in the main payload if no dedicated webhook is configured), with failed payloads enqueued using existing retry handling. 

### Testing
- Ran a project build with `./gradlew build` to validate compilation and configuration updates, and the build completed successfully. 
- Ran unit tests with `./gradlew test` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69f93bde08328a9c8cc069a6fab32)