### PR TITLE
Improve ocean anchor search with fast sampling, budget cap and fallback

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/spawn/SpawnBunkerPlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/spawn/SpawnBunkerPlacer.java
@@ -34,6 +34,9 @@ public final class SpawnBunkerPlacer {
     private static final ResourceLocation BUNKER_ID = ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "bunker");
     private static final int OCEAN_SEARCH_RADIUS = 4096;
     private static final int OCEAN_SEARCH_STEP = 32;
+    private static final int MAX_ANCHOR_CANDIDATES = 2048;
+    private static final int FAST_OCEAN_SAMPLE_OFFSET = 48;
+    private static final int OCEAN_FALLBACK_SEARCH_STEP = 64;
     private static final int OCEAN_REGION_RADIUS = 112;
     private static final int OCEAN_REGION_STEP = 16;
     private static final int FOOTPRINT_SAMPLE_STEP = 4;
@@ -97,6 +100,7 @@ public final class SpawnBunkerPlacer {
 
         int baseX = baseSpawn.getX();
         int baseZ = baseSpawn.getZ();
+        int evaluated = 1;
         for (int radius = OCEAN_SEARCH_STEP; radius <= OCEAN_SEARCH_RADIUS; radius += OCEAN_SEARCH_STEP) {
             for (int dx = -radius; dx <= radius; dx += OCEAN_SEARCH_STEP) {
                 for (int dz = -radius; dz <= radius; dz += OCEAN_SEARCH_STEP) {
@@ -108,13 +112,22 @@ public final class SpawnBunkerPlacer {
                     if (isViableOceanAnchor(level, candidate, bunkerSize)) {
                         return candidate;
                     }
+                    evaluated++;
+                    if (evaluated >= MAX_ANCHOR_CANDIDATES) {
+                        BlockPos forcedOceanAnchor = findAnyOceanAnchor(level, baseSpawn);
+                        ModConstants.LOGGER.warn(
+                                "Hit spawn bunker ocean-search budget ({} candidates) near {}; using fallback {}.",
+                                MAX_ANCHOR_CANDIDATES, baseSpawn, forcedOceanAnchor);
+                        return forcedOceanAnchor;
+                    }
                 }
             }
         }
 
+        BlockPos forcedOceanAnchor = findAnyOceanAnchor(level, baseSpawn);
         ModConstants.LOGGER.warn("Unable to locate a fully open ocean spawn region within {} blocks of {}; using best-effort ocean fallback.",
                 OCEAN_SEARCH_RADIUS, baseSpawn);
-        return anchor;
+        return forcedOceanAnchor;
     }
 
     private static BlockPos toOceanAnchor(ServerLevel level, BlockPos pos) {
@@ -149,6 +162,9 @@ public final class SpawnBunkerPlacer {
     }
 
     private static boolean isViableOceanAnchor(ServerLevel level, BlockPos anchor, Vec3i bunkerSize) {
+        if (!fastIsProbablyOceanAnchor(level, anchor)) {
+            return false;
+        }
         if (!isOceanBiome(level, anchor)) {
             return false;
         }
@@ -159,6 +175,49 @@ public final class SpawnBunkerPlacer {
             return false;
         }
         return hasStableSeafloor(level, anchor, bunkerSize);
+    }
+
+    private static boolean fastIsProbablyOceanAnchor(ServerLevel level, BlockPos anchor) {
+        if (!isOceanWaterSample(level, anchor)) {
+            return false;
+        }
+        return isOceanWaterSample(level, anchor.offset(FAST_OCEAN_SAMPLE_OFFSET, 0, 0))
+                && isOceanWaterSample(level, anchor.offset(-FAST_OCEAN_SAMPLE_OFFSET, 0, 0))
+                && isOceanWaterSample(level, anchor.offset(0, 0, FAST_OCEAN_SAMPLE_OFFSET))
+                && isOceanWaterSample(level, anchor.offset(0, 0, -FAST_OCEAN_SAMPLE_OFFSET));
+    }
+
+    private static boolean isOceanWaterSample(ServerLevel level, BlockPos pos) {
+        if (!isOceanBiome(level, pos)) {
+            return false;
+        }
+        BlockPos surface = level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, pos);
+        return !level.getFluidState(surface).isEmpty();
+    }
+
+    private static BlockPos findAnyOceanAnchor(ServerLevel level, BlockPos baseSpawn) {
+        BlockPos baseAnchor = toOceanAnchor(level, baseSpawn);
+        if (isOceanWaterSample(level, baseAnchor)) {
+            return baseAnchor;
+        }
+
+        int baseX = baseSpawn.getX();
+        int baseZ = baseSpawn.getZ();
+        for (int radius = OCEAN_FALLBACK_SEARCH_STEP; radius <= OCEAN_SEARCH_RADIUS; radius += OCEAN_FALLBACK_SEARCH_STEP) {
+            for (int dx = -radius; dx <= radius; dx += OCEAN_FALLBACK_SEARCH_STEP) {
+                for (int dz = -radius; dz <= radius; dz += OCEAN_FALLBACK_SEARCH_STEP) {
+                    if (Math.abs(dx) != radius && Math.abs(dz) != radius) {
+                        continue;
+                    }
+
+                    BlockPos candidate = toOceanAnchor(level, new BlockPos(baseX + dx, level.getMinBuildHeight(), baseZ + dz));
+                    if (isOceanWaterSample(level, candidate)) {
+                        return candidate;
+                    }
+                }
+            }
+        }
+        return baseAnchor;
     }
 
     private static boolean isOceanBiome(ServerLevel level, BlockPos pos) {


### PR DESCRIPTION
### Motivation

- Reduce expensive spawn bunker ocean searches and avoid pathological long-running scans by short-circuiting non-ocean areas and bounding candidate evaluation. 
- Improve robustness by providing a best-effort fallback anchor when the full search budget is exhausted or a fully open ocean area cannot be found. 

### Description

- Added new constants: `MAX_ANCHOR_CANDIDATES`, `FAST_OCEAN_SAMPLE_OFFSET`, and `OCEAN_FALLBACK_SEARCH_STEP` to control sampling, search budget, and fallback search granularity. 
- Introduced a fast pre-check `fastIsProbablyOceanAnchor` (and helper `isOceanWaterSample`) which samples a cross of positions around the candidate to quickly reject obvious non-ocean anchors before performing costly checks. 
- Enforced a candidate evaluation budget in `findOceanAnchor` that aborts the expensive search after `MAX_ANCHOR_CANDIDATES` and falls back to `findAnyOceanAnchor`, with a warning log when the budget is hit. 
- Implemented `findAnyOceanAnchor` which performs a coarser fallback scan for any ocean water sample to use as a best-effort anchor when the main search fails. 
- Updated `isViableOceanAnchor` to run the fast sampling filter early to short-circuit full validation for poor candidates. 

### Testing

- Ran a full project build with `./gradlew build` which completed successfully. 
- Executed the project's unit test suite with `./gradlew test` which passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c60120ae648328ab0ee0481bd9903b)