### PR TITLE
Replace TickTokHelper with TickTokAPI and standardize time conversions

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ClientSaveHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ClientSaveHandler.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.ModPackPatches;
 
+import com.thunder.ticktoklib.api.TickTokAPI;
 import net.minecraft.client.Minecraft;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -12,7 +13,7 @@ import static com.thunder.wildernessodysseyapi.core.ModConstants.MOD_ID;
 @EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT)
 public class ClientSaveHandler {
 
-    private static final int FLUSH_INTERVAL = 10000;
+    private static final int FLUSH_INTERVAL = TickTokAPI.duration(0, 8, 20, 0);
     private static int tickCounter = 0;
 
     /**

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/LoadingStallDetector.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/client/LoadingStallDetector.java
@@ -1,6 +1,6 @@
 package com.thunder.wildernessodysseyapi.ModPackPatches.client;
 
-import com.thunder.ticktoklib.TickTokHelper;
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.core.ModConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.LoadingOverlay;
@@ -31,8 +31,8 @@ import java.util.OptionalInt;
 public final class LoadingStallDetector {
     private static final int DEFAULT_THRESHOLD_MINUTES = 5;
     private static final int STALL_THRESHOLD_MINUTES = resolveThresholdMinutes();
-    private static final Duration STALL_THRESHOLD = toDuration(TickTokHelper.toTicksMinutes(STALL_THRESHOLD_MINUTES));
-    private static final Duration REMINDER_INTERVAL = toDuration(TickTokHelper.toTicksMinutes(1));
+    private static final Duration STALL_THRESHOLD = toDuration(TickTokAPI.toTicksFromMinutes(STALL_THRESHOLD_MINUTES));
+    private static final Duration REMINDER_INTERVAL = toDuration(TickTokAPI.toTicksFromMinutes(1));
     private static final DateTimeFormatter TIMESTAMP = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     private static long overlayStartedAt = 0L;
@@ -214,7 +214,7 @@ public final class LoadingStallDetector {
         long safeMillis = Math.max(millis, 0);
         int ticks = safeMillisToTicks(safeMillis);
 
-        String base = ticks >= TickTokHelper.TICKS_PER_HOUR
+        String base = ticks >= TickTokAPI.toTicksFromHours(1)
                 ? formatTicksToHMS(ticks)
                 : formatTicksToMinSec(ticks);
 
@@ -223,7 +223,7 @@ public final class LoadingStallDetector {
     }
 
     private static int safeMillisToTicks(long millis) {
-        double ticks = Math.round(Math.max(0L, millis) * TickTokHelper.TICKS_PER_SECOND / 1000.0d);
+        long ticks = TickTokAPI.toTicksFromMilliseconds(Math.max(0L, millis));
         return (int) Math.min(ticks, Integer.MAX_VALUE);
     }
 
@@ -240,7 +240,7 @@ public final class LoadingStallDetector {
         try {
             if (override.endsWith("t")) { // ticks suffix
                 int ticks = Integer.parseInt(override.substring(0, override.length() - 1));
-                int minutes = (int) Math.ceil(TickTokHelper.toMinutes(ticks));
+                int minutes = (int) Math.ceil(TickTokAPI.toMinutes(ticks));
                 return minutes > 0 ? OptionalInt.of(minutes) : OptionalInt.empty();
             }
 
@@ -263,12 +263,12 @@ public final class LoadingStallDetector {
     }
 
     private static Duration toDuration(int ticks) {
-        long millis = Math.round(TickTokHelper.toSeconds(ticks) * 1000.0d);
+        long millis = TickTokAPI.toMillisecondsLong(ticks);
         return Duration.ofMillis(millis);
     }
 
     private static String formatTicksToHMS(int ticks) {
-        long seconds = Math.max(0L, Math.round(TickTokHelper.toSeconds(ticks)));
+        long seconds = Math.max(0L, Math.round(TickTokAPI.toSeconds(ticks)));
         long hours = seconds / 3600;
         long minutes = (seconds % 3600) / 60;
         long remainderSeconds = seconds % 60;
@@ -276,7 +276,7 @@ public final class LoadingStallDetector {
     }
 
     private static String formatTicksToMinSec(int ticks) {
-        long seconds = Math.max(0L, Math.round(TickTokHelper.toSeconds(ticks)));
+        long seconds = Math.max(0L, Math.round(TickTokAPI.toSeconds(ticks)));
         long minutes = seconds / 60;
         long remainderSeconds = seconds % 60;
         return String.format("%02d:%02d", minutes, remainderSeconds);

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/server/PartnerAdHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/server/PartnerAdHandler.java
@@ -1,6 +1,7 @@
 package com.thunder.wildernessodysseyapi.ModPackPatches.server;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.core.ModConstants;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -29,7 +30,6 @@ import java.util.UUID;
  * Sends occasional partner advertisements to players.
  */
 public class PartnerAdHandler {
-    private static final long TICKS_PER_HOUR = 20L * 60L * 60L;
     private static long tickCounter = 0;
 
     private static final Set<UUID> OPTED_OUT = new HashSet<>();
@@ -41,7 +41,7 @@ public class PartnerAdHandler {
     private static final String DISCOUNT = "15%";
     private static final String HOSTING_LINK = "https://billing.kinetichosting.net/aff.php?aff=606";
 
-    private static final long DELAY_TICKS = 20L * 90L; // 1.5 minutes
+    private static final long DELAY_TICKS = TickTokAPI.durationLong(0, 1, 30, 0); // 1.5 minutes
     private static final Map<UUID, Long> PENDING_ADS = new HashMap<>();
 
     /**

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/telemetry/PlayerTelemetryReporter.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/telemetry/PlayerTelemetryReporter.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.async.AsyncTaskManager;
 import com.thunder.wildernessodysseyapi.ModPackPatches.telemetry.TelemetryConsentStore.ConsentDecision;
 import net.minecraft.stats.Stats;
@@ -337,7 +338,7 @@ public final class PlayerTelemetryReporter {
             return 0L;
         }
         int ticks = player.getStats().getValue(Stats.CUSTOM, Stats.PLAY_TIME);
-        return ticks / 20L;
+        return Math.round(TickTokAPI.toSeconds(ticks));
     }
 
     private static Optional<String> fetchSparkReportUrl(ServerPlayer player) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/client/biome/ImpactSiteMusicController.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/client/biome/ImpactSiteMusicController.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.client.biome;
 
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.core.ModConstants;
 import com.thunder.wildernessodysseyapi.worldgen.biome.ModBiomes;
 import net.minecraft.client.Minecraft;
@@ -18,7 +19,7 @@ public final class ImpactSiteMusicController {
     private static final int EFFECT_RADIUS = 100;
     private static final int SCAN_STEP = 4;
     private static final int SCAN_VERTICAL = 12;
-    private static final int SCAN_INTERVAL_TICKS = 20;
+    private static final int SCAN_INTERVAL_TICKS = TickTokAPI.toTicks(1);
 
     private static ImpactSiteMusicSoundInstance activeMusic;
     private static BlockPos cachedImpactCenter;

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/TideInfoCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/TideInfoCommand.java
@@ -2,6 +2,7 @@ package com.thunder.wildernessodysseyapi.command;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.watersystem.ocean.tide.TideAstronomy;
 import com.thunder.wildernessodysseyapi.watersystem.ocean.tide.TideManager;
 import net.minecraft.commands.CommandSourceStack;
@@ -43,7 +44,7 @@ public final class TideInfoCommand {
                 tideHeight,
                 snapshot.trendDescription(),
                 trendPerTick,
-                snapshot.cycleTicks() / 20.0D / 60.0D,
+                TickTokAPI.ticksToDuration(snapshot.cycleTicks()).toSeconds() / 60.0D,
                 moonPhase,
                 moonFactor
         );

--- a/src/main/java/com/thunder/wildernessodysseyapi/config/CloakChipConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/config/CloakChipConfig.java
@@ -1,11 +1,12 @@
 package com.thunder.wildernessodysseyapi.config;
 
+import com.thunder.ticktoklib.api.TickTokAPI;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
 public final class CloakChipConfig {
     public static final ModConfigSpec CONFIG_SPEC;
     public static final ModConfigSpec.BooleanValue ENABLE_NAUSEA;
-    public static final int NAUSEA_DURATION_TICKS = 200;
+    public static final int NAUSEA_DURATION_TICKS = TickTokAPI.toTicksFromSeconds(10);
 
     static {
         ModConfigSpec.Builder builder = new ModConfigSpec.Builder();

--- a/src/main/java/com/thunder/wildernessodysseyapi/donations/DonationReminder.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/donations/DonationReminder.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.donations;
 
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.donations.config.DonationReminderConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.ClickEvent;
@@ -20,7 +21,7 @@ import static com.thunder.wildernessodysseyapi.core.ModConstants.MOD_ID;
 public class DonationReminder {
     private static boolean pendingReminder = false;
     private static int tickCountdown = 0;
-    private static final int DELAY_TICKS = 20 * 180; // 3 minutes
+    private static final int DELAY_TICKS = TickTokAPI.toTicksFromMinutes(3); // 3 minutes
 
     /**
      * Starts the donation reminder countdown when the player joins.

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/chip/ChipSetItem.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/chip/ChipSetItem.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.item.chip;
 
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.item.ModItemTags;
 import com.thunder.wildernessodysseyapi.curios.CuriosIntegration;
 import net.minecraft.world.InteractionHand;
@@ -16,7 +17,7 @@ import top.theillusivec4.curios.api.type.capability.ICurioItem;
 
 public class ChipSetItem extends Item implements ICurioItem {
     public static final String CHIP_SET_SLOT = "chip";
-    private static final int NAUSEA_DURATION_TICKS = 20 * 20;
+    private static final int NAUSEA_DURATION_TICKS = TickTokAPI.toTicksFromSeconds(20);
     private static final float CHIP_DAMAGE = 2.0F;
 
     public ChipSetItem(Properties properties) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/item/cloak/CloakItem.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/cloak/CloakItem.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.item.cloak;
 
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.curios.CuriosIntegration;
 import com.thunder.wildernessodysseyapi.item.ModItems;
 import net.minecraft.network.chat.Component;
@@ -12,6 +13,8 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 
 public class CloakItem extends Item {
+    private static final int CLOAK_TOGGLE_COOLDOWN_TICKS = TickTokAPI.toTicks(1);
+
     public CloakItem(Properties properties) {
         super(properties);
     }
@@ -44,7 +47,7 @@ public class CloakItem extends Item {
             player.displayClientMessage(Component.translatable("message.wildernessodysseyapi.cloak_disabled"), true);
         }
 
-        player.getCooldowns().addCooldown(this, 20);
+        player.getCooldowns().addCooldown(this, CLOAK_TOGGLE_COOLDOWN_TICKS);
         return InteractionResultHolder.success(stack);
     }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/lorebook/LoreBookManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/lorebook/LoreBookManager.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.lorebook;
 
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.core.ModConstants;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
@@ -24,7 +25,7 @@ public final class LoreBookManager {
     private static final String ROOT_TAG = ModConstants.MOD_ID + "_lore_books";
     private static final String COLLECTED_TAG = "collected";
     private static final String LAST_SCAN_TAG = "last_scan";
-    private static final long SCAN_INTERVAL_TICKS = 40L;
+    private static final long SCAN_INTERVAL_TICKS = TickTokAPI.toTicksFromSeconds(2L);
 
     private static volatile LoreBookConfig cachedConfig;
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/DayNightCycleMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/DayNightCycleMixin.java
@@ -1,6 +1,6 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
-import com.thunder.ticktoklib.TickTokHelper;
+import com.thunder.ticktoklib.api.TickTokAPI;
 import net.minecraft.server.level.ServerLevel;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -17,18 +17,18 @@ public abstract class DayNightCycleMixin {
 
     // Total custom cycle duration
     @Unique
-    private static final long TOTAL_CYCLE      = TickTokHelper.duration(1, 0, 0,0); // 1 real hour
+    private static final long TOTAL_CYCLE      = TickTokAPI.durationLong(1, 0, 0, 0); // 1 real hour
     @Unique
-    private static final long DAY_DURATION     = TickTokHelper.duration(0, 30, 0,0); // 30 min
+    private static final long DAY_DURATION     = TickTokAPI.durationLong(0, 30, 0, 0); // 30 min
     @Unique
-    private static final long SUNSET_DURATION  = TickTokHelper.duration(0, 5, 0,0);  // 5 min
+    private static final long SUNSET_DURATION  = TickTokAPI.durationLong(0, 5, 0, 0);  // 5 min
     @Unique
-    private static final long NIGHT_DURATION   = TickTokHelper.duration(0, 20, 0,0); // 20 min
+    private static final long NIGHT_DURATION   = TickTokAPI.durationLong(0, 20, 0, 0); // 20 min
     @Unique
-    private static final long SUNRISE_DURATION = TickTokHelper.duration(0, 5, 0,0);  // 5 min
+    private static final long SUNRISE_DURATION = TickTokAPI.durationLong(0, 5, 0, 0);  // 5 min
 
     @Unique
-    private static final long VANILLA_DAY_TICKS = 24000L;
+    private static final long VANILLA_DAY_TICKS = TickTokAPI.toTicksFromMinutes(20L);
 
     @Inject(method = "getDayTimePerTick", at = @At("HEAD"), cancellable = true)
     private void overridePerTickSpeed(CallbackInfoReturnable<Float> cir) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/ocean/tide/TideConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/ocean/tide/TideConfig.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.watersystem.ocean.tide;
 
+import com.thunder.ticktoklib.api.TickTokAPI;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
 import java.util.List;
@@ -163,11 +164,11 @@ public final class TideConfig {
             double playerProximityBlocks
     ) {
         public long cycleTicks() {
-            return (long) Math.max(1L, Math.round(cycleMinutes * 60.0D * 20.0D));
+            return Math.max(1L, TickTokAPI.toTicksFromMinutes(cycleMinutes));
         }
 
         public long phaseOffsetTicks() {
-            return (long) Math.max(0L, Math.round(phaseOffsetMinutes * 60.0D * 20.0D));
+            return Math.max(0L, TickTokAPI.toTicksFromMinutes(phaseOffsetMinutes));
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/weather/PurpleStormWeatherHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/weather/PurpleStormWeatherHandler.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.weather;
 
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.core.ModConstants;
 import com.thunder.wildernessodysseyapi.entity.ModEntities;
 import com.thunder.wildernessodysseyapi.entity.PurpleStormMonsterEntity;
@@ -19,9 +20,9 @@ public final class PurpleStormWeatherHandler {
     private PurpleStormWeatherHandler() {
     }
 
-    public static final long HOUR_TICKS = 72_000L;
-    public static final long EVENT_DURATION_TICKS = 36_000L;
-    private static final int SPAWN_ATTEMPT_INTERVAL_TICKS = 200;
+    public static final long HOUR_TICKS = TickTokAPI.toTicksFromHours(1L);
+    public static final long EVENT_DURATION_TICKS = TickTokAPI.toTicksFromMinutes(30L);
+    private static final int SPAWN_ATTEMPT_INTERVAL_TICKS = TickTokAPI.toTicksFromSeconds(10);
 
     @SubscribeEvent
     public static void onLevelTick(LevelTickEvent.Post event) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/blocks/CryoTubeBlock.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/blocks/CryoTubeBlock.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.worldgen.blocks;
 
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.api.CryoSleepEvent;
 import com.thunder.wildernessodysseyapi.item.ModItems;
 import net.minecraft.core.BlockPos;
@@ -103,7 +104,7 @@ public class CryoTubeBlock {
         /**
          * After this many ticks (10 Minecraft days) tubes no longer function.
          */
-        private static final long MAX_SLEEP_TICKS = 24000L * 10L;
+        private static final long MAX_SLEEP_TICKS = TickTokAPI.toTicksFromMinutes(200L);
 
 
         public BlockImpl(Properties properties) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/spawn/PlayerSpawnHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/spawn/PlayerSpawnHandler.java
@@ -1,5 +1,6 @@
 package com.thunder.wildernessodysseyapi.worldgen.spawn;
 
+import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.worldgen.blocks.CryoTubeBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -29,6 +30,10 @@ public class PlayerSpawnHandler {
 
     private static final String CRYO_ASSIGNED_TAG = "wo_cryo_assigned";
     private static final String CRYO_POS_TAG = "wo_cryo_pos";
+    private static final int INTRO_SLOWDOWN_TICKS = TickTokAPI.toTicksFromSeconds(3);
+    private static final int TITLE_FADE_IN_TICKS = TickTokAPI.toTicks(1);
+    private static final int TITLE_STAY_TICKS = TickTokAPI.toTicksFromSeconds(3);
+    private static final int TITLE_FADE_OUT_TICKS = TickTokAPI.toTicks(1);
 
     private static List<BlockPos> spawnBlocks = Collections.emptyList();
 
@@ -69,7 +74,7 @@ public class PlayerSpawnHandler {
         playIntroCinematic(player);
         tag.putBoolean(CRYO_ASSIGNED_TAG, true);
         tag.putLong(CRYO_POS_TAG, spawnPos.asLong());
-        player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, 60, 255, false, false));
+        player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, INTRO_SLOWDOWN_TICKS, 255, false, false));
     }
 
     private static BlockPos selectSpawn(ServerPlayer player, CompoundTag tag) {
@@ -103,7 +108,7 @@ public class PlayerSpawnHandler {
      */
     private static void playIntroCinematic(ServerPlayer player) {
         ServerGamePacketListenerImpl connection = player.connection;
-        connection.send(new ClientboundSetTitlesAnimationPacket(20, 60, 20));
+        connection.send(new ClientboundSetTitlesAnimationPacket(TITLE_FADE_IN_TICKS, TITLE_STAY_TICKS, TITLE_FADE_OUT_TICKS));
         connection.send(new ClientboundSetTitleTextPacket(Component.translatable("message.wildernessodysseyapi.wake_up")));
     }
 }


### PR DESCRIPTION
### Motivation
- Consolidate time/tick conversion calls onto the `TickTokAPI` to centralize duration handling and replace the older `TickTokHelper` usages.
- Make duration and tick constants consistent and configurable via the TickTok library helpers across client, server, and gameplay systems.
- Reduce ad-hoc numeric tick literals and improve readability by using named conversion utilities.

### Description
- Replaced imports and usages of `TickTokHelper` (and direct numeric tick literals) with `com.thunder.ticktoklib.api.TickTokAPI` across multiple classes including `LoadingStallDetector`, `DayNightCycleMixin`, `PurpleStormWeatherHandler`, `TideConfig`, `PlayerTelemetryReporter`, `CloakChipConfig`, `DonationReminder`, `ChipSetItem`, `CloakItem`, `LoreBookManager`, `CryoTubeBlock`, `PlayerSpawnHandler`, `PartnerAdHandler`, `ImpactSiteMusicController`, `ClientSaveHandler`, `TideInfoCommand`, and others.
- Converted duration/tick calculations to API calls such as `duration(...)`, `durationLong(...)`, `toTicks(...)`, `toTicksFromSeconds(...)`, `toTicksFromMinutes(...)`, `toTicksFromHours(...)`, `toMillisecondsLong(...)`, and `toSeconds(...)` as appropriate to replace hard-coded math and helper functions.
- Added necessary `TickTokAPI` imports and adjusted several constants to use the new conversion helpers without changing the higher-level behavior.

### Testing
- Built the project with the standard build task (`./gradlew build`) to verify compilation after the API replacements, and the build completed successfully.
- Ran the project's unit tests via the Gradle `test` task, and the test suite completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c34d9f04832892e5b454350c5c25)