### PR TITLE
Add config audit tool and `/configaudit` command to map config files to mods

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ModListTracker/ConfigLinkAudit.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ModListTracker/ConfigLinkAudit.java
@@ -1,0 +1,210 @@
+package com.thunder.wildernessodysseyapi.ModPackPatches.ModListTracker;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.moddiscovery.ModInfo;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.thunder.wildernessodysseyapi.core.ModConstants.LOGGER;
+import static com.thunder.wildernessodysseyapi.core.ModConstants.MOD_ID;
+
+/**
+ * Audits files under the config directory and attempts to link each file to an installed mod id.
+ */
+public final class ConfigLinkAudit {
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final Set<String> SUPPORTED_EXTENSIONS = Set.of(
+            ".toml", ".json", ".json5", ".yaml", ".yml", ".cfg", ".conf", ".properties", ".ini", ".txt"
+    );
+
+    private ConfigLinkAudit() {
+    }
+
+    public static AuditResult run(Path configDir, Path reportPath, Path unresolvedLogPath) {
+        List<String> installedMods = ModList.get().getMods().stream()
+                .filter(mod -> mod instanceof ModInfo)
+                .map(mod -> ((ModInfo) mod).getModId().toLowerCase(Locale.ROOT))
+                .distinct()
+                .sorted()
+                .toList();
+
+        List<String> configFiles = collectConfigFiles(configDir);
+        Map<String, String> linked = new LinkedHashMap<>();
+        Map<String, List<String>> ambiguous = new LinkedHashMap<>();
+        List<String> unresolved = new ArrayList<>();
+
+        for (String relPath : configFiles) {
+            List<String> matches = guessModMatches(relPath, installedMods);
+            if (matches.size() == 1) {
+                linked.put(relPath, matches.get(0));
+            } else if (matches.isEmpty()) {
+                unresolved.add(relPath);
+            } else {
+                ambiguous.put(relPath, matches);
+            }
+        }
+
+        AuditResult result = new AuditResult(
+                Instant.now().toString(),
+                configDir.toString(),
+                installedMods.size(),
+                configFiles.size(),
+                linked,
+                ambiguous,
+                unresolved
+        );
+
+        writeReport(reportPath, result);
+        writeUnresolvedLog(unresolvedLogPath, unresolved, ambiguous);
+        unresolved.forEach(file -> LOGGER.error("[ConfigLinkAudit] Unresolved config file: {}", file));
+        ambiguous.forEach((file, mods) -> LOGGER.error("[ConfigLinkAudit] Ambiguous config file {} -> {}", file, mods));
+        LOGGER.info("[ConfigLinkAudit] Audit complete. Total={}, linked={}, ambiguous={}, unresolved={}",
+                configFiles.size(), linked.size(), ambiguous.size(), unresolved.size());
+
+        return result;
+    }
+
+    private static List<String> collectConfigFiles(Path configDir) {
+        if (!Files.exists(configDir)) {
+            return Collections.emptyList();
+        }
+
+        try (var stream = Files.walk(configDir)) {
+            return stream
+                    .filter(Files::isRegularFile)
+                    .filter(path -> hasSupportedExtension(path.getFileName().toString()))
+                    .map(path -> configDir.relativize(path).toString().replace('\\', '/'))
+                    .sorted(Comparator.naturalOrder())
+                    .toList();
+        } catch (IOException e) {
+            LOGGER.error("[ConfigLinkAudit] Failed to scan config directory {}", configDir, e);
+            return Collections.emptyList();
+        }
+    }
+
+    private static boolean hasSupportedExtension(String filename) {
+        String lower = filename.toLowerCase(Locale.ROOT);
+        for (String ext : SUPPORTED_EXTENSIONS) {
+            if (lower.endsWith(ext)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<String> guessModMatches(String relativePath, List<String> modIds) {
+        String lowerPath = relativePath.toLowerCase(Locale.ROOT);
+        String filename = lowerPath.substring(lowerPath.lastIndexOf('/') + 1);
+        String base = filename.contains(".") ? filename.substring(0, filename.lastIndexOf('.')) : filename;
+
+        Set<String> matches = new LinkedHashSet<>();
+
+        for (String modId : modIds) {
+            if (lowerPath.startsWith(modId + "/")
+                    || filename.equals(modId)
+                    || filename.startsWith(modId + "-")
+                    || filename.startsWith(modId + "_")
+                    || filename.startsWith(modId + ".")
+                    || base.equals(modId)
+                    || base.contains(modId)) {
+                matches.add(modId);
+            }
+        }
+
+        if (matches.isEmpty()) {
+            Set<String> tokens = tokenize(base);
+            for (String modId : modIds) {
+                if (tokens.contains(modId)) {
+                    matches.add(modId);
+                }
+            }
+        }
+
+        if (matches.contains(MOD_ID) && matches.size() > 1) {
+            matches.remove(MOD_ID);
+        }
+
+        return matches.stream().sorted().collect(Collectors.toList());
+    }
+
+    private static Set<String> tokenize(String input) {
+        Set<String> tokens = new HashSet<>();
+        for (String token : input.split("[^a-z0-9]+")) {
+            if (!token.isBlank()) {
+                tokens.add(token);
+            }
+        }
+        return tokens;
+    }
+
+    private static void writeReport(Path reportPath, AuditResult result) {
+        try {
+            Files.createDirectories(reportPath.getParent());
+            try (Writer writer = Files.newBufferedWriter(reportPath, StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+                GSON.toJson(result, writer);
+            }
+        } catch (IOException e) {
+            LOGGER.error("[ConfigLinkAudit] Failed writing report to {}", reportPath, e);
+        }
+    }
+
+    private static void writeUnresolvedLog(Path logPath, List<String> unresolved, Map<String, List<String>> ambiguous) {
+        List<String> lines = new ArrayList<>();
+        lines.add("[ConfigLinkAudit] Unresolved and ambiguous config files");
+        lines.add("Timestamp: " + Instant.now());
+        lines.add("");
+
+        if (unresolved.isEmpty()) {
+            lines.add("No unresolved files.");
+        } else {
+            lines.add("Unresolved files:");
+            unresolved.forEach(file -> lines.add("- " + file));
+        }
+
+        lines.add("");
+        if (ambiguous.isEmpty()) {
+            lines.add("No ambiguous files.");
+        } else {
+            lines.add("Ambiguous files:");
+            ambiguous.forEach((file, mods) -> lines.add("- " + file + " -> " + String.join(", ", mods)));
+        }
+
+        try {
+            Files.createDirectories(logPath.getParent());
+            Files.write(logPath, lines, StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+        } catch (IOException e) {
+            LOGGER.error("[ConfigLinkAudit] Failed writing unresolved log {}", logPath, e);
+        }
+    }
+
+    public record AuditResult(String generatedAt,
+                              String configDirectory,
+                              int installedModCount,
+                              int totalConfigFiles,
+                              Map<String, String> linkedConfigs,
+                              Map<String, List<String>> ambiguousConfigs,
+                              List<String> unresolvedConfigs) {
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ModListTracker/commands/ConfigAuditCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ModListTracker/commands/ConfigAuditCommand.java
@@ -28,7 +28,7 @@ public final class ConfigAuditCommand {
         MinecraftServer server = source.getServer();
         Path configDir = server.getFile("config");
         Path reportPath = configDir.resolve("wildernessodysseyapi/config-audit-report.json");
-        Path unresolvedLogPath = server.getFile("logs").toPath().resolve("config-audit-unresolved.log");
+        Path unresolvedLogPath = server.getFile("logs").resolve("config-audit-unresolved.log");
 
         ConfigLinkAudit.AuditResult result = ConfigLinkAudit.run(configDir, reportPath, unresolvedLogPath);
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ModListTracker/commands/ConfigAuditCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/ModListTracker/commands/ConfigAuditCommand.java
@@ -1,0 +1,45 @@
+package com.thunder.wildernessodysseyapi.ModPackPatches.ModListTracker.commands;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.thunder.wildernessodysseyapi.ModPackPatches.ModListTracker.ConfigLinkAudit;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.MinecraftServer;
+
+import java.nio.file.Path;
+
+/**
+ * Command to audit files under /config and map each file to an installed mod when possible.
+ */
+public final class ConfigAuditCommand {
+
+    private ConfigAuditCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("configaudit")
+                .requires(source -> source.hasPermission(2))
+                .executes(context -> runAudit(context.getSource())));
+    }
+
+    private static int runAudit(CommandSourceStack source) {
+        MinecraftServer server = source.getServer();
+        Path configDir = server.getFile("config");
+        Path reportPath = configDir.resolve("wildernessodysseyapi/config-audit-report.json");
+        Path unresolvedLogPath = server.getFile("logs").toPath().resolve("config-audit-unresolved.log");
+
+        ConfigLinkAudit.AuditResult result = ConfigLinkAudit.run(configDir, reportPath, unresolvedLogPath);
+
+        source.sendSuccess(() -> Component.literal("[ConfigAudit] Complete: "
+                + result.totalConfigFiles() + " files, "
+                + result.linkedConfigs().size() + " linked, "
+                + result.ambiguousConfigs().size() + " ambiguous, "
+                + result.unresolvedConfigs().size() + " unresolved."), true);
+
+        source.sendSuccess(() -> Component.literal("[ConfigAudit] Report: " + reportPath), false);
+        source.sendSuccess(() -> Component.literal("[ConfigAudit] Unresolved log: " + unresolvedLogPath), false);
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
@@ -6,6 +6,7 @@ import com.thunder.wildernessodysseyapi.ModPackPatches.faq.FaqCommand;
 import com.thunder.wildernessodysseyapi.ModPackPatches.faq.FaqReloadListener;
 import com.thunder.wildernessodysseyapi.ModPackPatches.ModListTracker.commands.ModListDiffCommand;
 import com.thunder.wildernessodysseyapi.ModPackPatches.ModListTracker.commands.ModListVersionCommand;
+import com.thunder.wildernessodysseyapi.ModPackPatches.ModListTracker.commands.ConfigAuditCommand;
 import com.thunder.wildernessodysseyapi.command.GlobalChatCommand;
 import com.thunder.wildernessodysseyapi.command.GlobalChatOptToggleCommand;
 import com.thunder.wildernessodysseyapi.command.ChangelogCommand;
@@ -212,6 +213,7 @@ public class WildernessOdysseyAPIMainModClass {
         CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
         ModListDiffCommand.register(dispatcher);
         ModListVersionCommand.register(dispatcher);
+        ConfigAuditCommand.register(dispatcher);
         StructureInfoCommand.register(event.getDispatcher());
         FaqCommand.register(event.getDispatcher());
         DonateCommand.register(event.getDispatcher());


### PR DESCRIPTION
### Motivation
- Provide a way to audit the server `config` directory and attempt to link each config file to an installed mod to help modpack maintainers identify orphaned, ambiguous, or misnamed config files.

### Description
- Add `ConfigLinkAudit` which scans a config directory, filters supported file extensions, and heuristically matches files to installed mod ids using path/filename heuristics and tokenization, producing an `AuditResult` JSON report and a plaintext unresolved/ambiguous log.
- Add `ConfigAuditCommand` which exposes the audit via the `/configaudit` command, writes the report to `config/wildernessodysseyapi/config-audit-report.json`, and writes unresolved details to the server logs path `logs/config-audit-unresolved.log`.
- Register the new command in `WildernessOdysseyAPIMainModClass` so the command is available during command registration.
- Implementation uses `ModList`/`ModInfo`, `Gson` for report serialization, a set of supported extensions, and logging for unresolved/ambiguous findings.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6edfe33f08328b08a4745f70fc16a)