### PR TITLE
Register music discs with jukebox-playable properties

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/item/ModItems.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/item/ModItems.java
@@ -4,7 +4,12 @@ import com.thunder.wildernessodysseyapi.item.cloak.CloakChipItem;
 import com.thunder.wildernessodysseyapi.item.cloak.CloakItem;
 import com.thunder.wildernessodysseyapi.item.neural.NeuralFrameItem;
 
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.JukeboxSong;
+import net.minecraft.world.item.Rarity;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.neoforge.registries.DeferredRegister;
@@ -35,13 +40,22 @@ public class ModItems {
 
     public static final DeferredItem<Item> MUSIC_DISC_DUSTWINDS = ITEMS.register(
             "music_disc_dustwinds",
-            () -> new Item(new Item.Properties().stacksTo(1))
+            () -> new Item(createMusicDiscProperties("dont_be_so_serious"))
     );
 
     public static final DeferredItem<Item> MUSIC_DISC_STARFALL = ITEMS.register(
             "music_disc_starfall",
-            () -> new Item(new Item.Properties().stacksTo(1))
+            () -> new Item(createMusicDiscProperties("outside_the_box"))
     );
+
+    private static Item.Properties createMusicDiscProperties(String songPath) {
+        ResourceLocation songId = ResourceLocation.fromNamespaceAndPath(MOD_ID, songPath);
+        ResourceKey<JukeboxSong> songKey = ResourceKey.create(Registries.JUKEBOX_SONG, songId);
+        return new Item.Properties()
+                .stacksTo(1)
+                .rarity(Rarity.RARE)
+                .jukeboxPlayable(songKey);
+    }
 
     /**
      * Register.


### PR DESCRIPTION
### Motivation
- Custom music discs were registered as plain `Item` instances and were not being recognized by jukebox interaction code, preventing insertion and playback.

### Description
- Replaced plain `Item` registration for `music_disc_dustwinds` and `music_disc_starfall` with a shared `createMusicDiscProperties` helper that returns `Item.Properties` using `.jukeboxPlayable(...)`.
- Bind each disc to the correct song by creating a `ResourceKey<JukeboxSong>` from `Registries.JUKEBOX_SONG` and the mod `ResourceLocation` (`dont_be_so_serious` / `outside_the_box`).
- The helper also sets `stacksTo(1)` and `Rarity.RARE` so the in-code properties match the data definitions.

### Testing
- Attempted to compile with `./gradlew compileJava -x test`, but the build failed due to an external SSL certificate trust error while NeoForge tried to download Mojang metadata (`SSLHandshakeException: PKIX path building failed`).
- No further automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c70ab3243083288d92454f03763420)