### PR TITLE
Restrict purple storm to anomaly biomes

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/client/weather/PurpleStormClientEffects.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/client/weather/PurpleStormClientEffects.java
@@ -1,11 +1,14 @@
 package com.thunder.wildernessodysseyapi.client.weather;
 
 import com.thunder.wildernessodysseyapi.core.ModConstants;
+import com.thunder.wildernessodysseyapi.worldgen.biome.ModBiomes;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.core.particles.DustParticleOptions;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -52,6 +55,22 @@ public final class PurpleStormClientEffects {
     }
 
     private static boolean isPurpleStormVisualActive(Level level) {
-        return level.isRaining() && level.isThundering();
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.player == null) {
+            return false;
+        }
+
+        return level.isRaining()
+                && level.isThundering()
+                && isInAnomalyBiome(level, minecraft.player.blockPosition());
+    }
+
+    private static boolean isInAnomalyBiome(Level level, BlockPos pos) {
+        Holder<Biome> biome = level.getBiome(pos);
+        return biome.is(ModBiomes.ANOMALY_PLAINS_KEY)
+                || biome.is(ModBiomes.ANOMALY_TUNDRA_KEY)
+                || biome.is(ModBiomes.ANOMALY_RAINFOREST_KEY)
+                || biome.is(ModBiomes.ANOMALY_ZONE_KEY)
+                || biome.is(ModBiomes.ANOMALY_DESERT_KEY);
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/weather/PurpleStormWeatherHandler.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/weather/PurpleStormWeatherHandler.java
@@ -4,12 +4,15 @@ import com.thunder.ticktoklib.api.TickTokAPI;
 import com.thunder.wildernessodysseyapi.core.ModConstants;
 import com.thunder.wildernessodysseyapi.entity.ModEntities;
 import com.thunder.wildernessodysseyapi.entity.PurpleStormMonsterEntity;
+import com.thunder.wildernessodysseyapi.worldgen.biome.ModBiomes;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.level.GameRules;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -50,7 +53,7 @@ public final class PurpleStormWeatherHandler {
 
         if (gameTime >= data.nextRollGameTime()) {
             data.setNextRollGameTime(gameTime + HOUR_TICKS);
-            if (serverLevel.random.nextFloat() <= 0.5F) {
+            if (hasPlayersInAnomalyBiomes(serverLevel) && serverLevel.random.nextFloat() <= 0.5F) {
                 startStorm(serverLevel, data, gameTime);
             }
         }
@@ -90,6 +93,10 @@ public final class PurpleStormWeatherHandler {
     private static void trySpawnPurpleStormMonster(ServerLevel level) {
         RandomSource random = level.getRandom();
         for (ServerPlayer player : level.players()) {
+            if (!isInAnomalyBiome(level, player.blockPosition())) {
+                continue;
+            }
+
             if (random.nextFloat() > 0.35F) {
                 continue;
             }
@@ -98,6 +105,9 @@ public final class PurpleStormWeatherHandler {
             int z = player.blockPosition().getZ() + random.nextInt(49) - 24;
             int y = level.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, x, z);
             BlockPos spawnPos = new BlockPos(x, y, z);
+            if (!isInAnomalyBiome(level, spawnPos)) {
+                continue;
+            }
 
             if (!level.getBlockState(spawnPos).isAir() || !level.getBlockState(spawnPos.above()).isAir()) {
                 continue;
@@ -113,5 +123,23 @@ public final class PurpleStormWeatherHandler {
                 level.addFreshEntity(monster);
             }
         }
+    }
+
+    private static boolean hasPlayersInAnomalyBiomes(ServerLevel level) {
+        for (ServerPlayer player : level.players()) {
+            if (isInAnomalyBiome(level, player.blockPosition())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isInAnomalyBiome(ServerLevel level, BlockPos pos) {
+        Holder<Biome> biome = level.getBiome(pos);
+        return biome.is(ModBiomes.ANOMALY_PLAINS_KEY)
+                || biome.is(ModBiomes.ANOMALY_TUNDRA_KEY)
+                || biome.is(ModBiomes.ANOMALY_RAINFOREST_KEY)
+                || biome.is(ModBiomes.ANOMALY_ZONE_KEY)
+                || biome.is(ModBiomes.ANOMALY_DESERT_KEY);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent purple storms and their effects from occurring outside anomaly zones so the event is localized to anomaly biomes and does not start globally.
- Ensure purple-storm monsters and client visuals only appear where players are actually inside an anomaly, avoiding off-location spawns and visuals.

### Description
- Gate purple storm start rolls so a storm only begins when at least one overworld player is currently inside an anomaly biome by adding `hasPlayersInAnomalyBiomes` and using it in `PurpleStormWeatherHandler`.
- Restrict monster spawn attempts to players located in anomaly biomes and require candidate spawn positions to be in anomaly biomes in `PurpleStormWeatherHandler`.
- Limit client-side fog/particle visuals to when the local player is in an anomaly biome by updating `PurpleStormClientEffects` to check `isInAnomalyBiome` before rendering effects.
- Add compatibility checks for legacy anomaly biome keys (`ANOMALY_ZONE_KEY`, `ANOMALY_DESERT_KEY`) and update imports in `PurpleStormWeatherHandler` and `PurpleStormClientEffects`.

### Testing
- Ran `./gradlew compileJava`, which failed in this environment due to an SSL certificate trust error while downloading the Mojang manifest and not due to compilation errors in the modified sources.
- Verified the changed files build paths and performed local code inspection (`nl`/`rg`/`sed`) to confirm the new biome-checking logic was inserted and imported correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c718369b988328ac3f75d81b1e4c5c)