### PR TITLE
Add sparse volumetric water simulation with config and operator commands

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/command/VolumetricFluidCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/VolumetricFluidCommand.java
@@ -1,0 +1,60 @@
+package com.thunder.wildernessodysseyapi.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+
+/**
+ * Operator command surface for the volumetric fluid simulation.
+ */
+public final class VolumetricFluidCommand {
+
+    private VolumetricFluidCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("volfluid")
+                .requires(source -> source.hasPermission(2))
+                .then(Commands.literal("stats")
+                        .executes(VolumetricFluidCommand::reportStats))
+                .then(Commands.literal("clear")
+                        .executes(VolumetricFluidCommand::clear))
+                .then(Commands.literal("seed")
+                        .then(Commands.argument("radius", IntegerArgumentType.integer(1, 64))
+                                .executes(VolumetricFluidCommand::seed))));
+    }
+
+    private static int reportStats(CommandContext<CommandSourceStack> context) {
+        ServerLevel level = context.getSource().getLevel();
+        VolumetricFluidManager.SimulationSnapshot snapshot = VolumetricFluidManager.getSnapshot(level);
+        context.getSource().sendSuccess(() -> Component.literal(String.format(
+                "VolFluid: cells=%d, controlled=%d, totalVolume=%.2f, avgSpeed=%.4f",
+                snapshot.activeCells(), snapshot.controlledBlocks(), snapshot.totalVolume(), snapshot.averageSpeed()
+        )), false);
+        return snapshot.activeCells();
+    }
+
+    private static int clear(CommandContext<CommandSourceStack> context) {
+        ServerLevel level = context.getSource().getLevel();
+        VolumetricFluidManager.clear(level);
+        context.getSource().sendSuccess(() -> Component.literal("Volumetric fluid grid cleared in this dimension."), true);
+        return 1;
+    }
+
+    private static int seed(CommandContext<CommandSourceStack> context) {
+        int radius = IntegerArgumentType.getInteger(context, "radius");
+        BlockPos center = BlockPos.containing(context.getSource().getPosition());
+        ServerLevel level = context.getSource().getLevel();
+        int injected = VolumetricFluidManager.seedFromExistingWater(level, center, radius);
+        context.getSource().sendSuccess(() -> Component.literal(
+                "Seeded volumetric grid from " + injected + " water blocks in radius " + radius + "."
+        ), true);
+        return injected;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/VolumetricFluidCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/VolumetricFluidCommand.java
@@ -34,8 +34,9 @@ public final class VolumetricFluidCommand {
         ServerLevel level = context.getSource().getLevel();
         VolumetricFluidManager.SimulationSnapshot snapshot = VolumetricFluidManager.getSnapshot(level);
         context.getSource().sendSuccess(() -> Component.literal(String.format(
-                "VolFluid: cells=%d, controlled=%d, totalVolume=%.2f, avgSpeed=%.4f",
-                snapshot.activeCells(), snapshot.controlledBlocks(), snapshot.totalVolume(), snapshot.averageSpeed()
+                "VolFluid: cells=%d, controlled=%d, totalVolume=%.2f, avgSpeed=%.4f, replaceVanilla=%s",
+                snapshot.activeCells(), snapshot.controlledBlocks(), snapshot.totalVolume(), snapshot.averageSpeed(),
+                VolumetricFluidManager.shouldReplaceVanillaWaterEngine()
         )), false);
         return snapshot.activeCells();
     }

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/VolumetricFluidCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/VolumetricFluidCommand.java
@@ -34,8 +34,9 @@ public final class VolumetricFluidCommand {
         ServerLevel level = context.getSource().getLevel();
         VolumetricFluidManager.SimulationSnapshot snapshot = VolumetricFluidManager.getSnapshot(level);
         context.getSource().sendSuccess(() -> Component.literal(String.format(
-                "VolFluid: cells=%d, controlled=%d, totalVolume=%.2f, avgSpeed=%.4f, replaceVanilla=%s",
+                "VolFluid: cells=%d, controlled=%d, totalVolume=%.2f, avgSpeed=%.4f, preset=%s, replaceVanilla=%s",
                 snapshot.activeCells(), snapshot.controlledBlocks(), snapshot.totalVolume(), snapshot.averageSpeed(),
+                VolumetricFluidManager.activePreset(),
                 VolumetricFluidManager.shouldReplaceVanillaWaterEngine()
         )), false);
         return snapshot.activeCells();

--- a/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
@@ -27,6 +27,7 @@ import com.thunder.wildernessodysseyapi.donations.command.DonateCommand;
 import com.thunder.wildernessodysseyapi.command.WorldGenScanCommand;
 import com.thunder.wildernessodysseyapi.command.StructurePlacementDebugCommand;
 import com.thunder.wildernessodysseyapi.command.TideInfoCommand;
+import com.thunder.wildernessodysseyapi.command.VolumetricFluidCommand;
 import com.thunder.wildernessodysseyapi.command.ModpackStructureCommand;
 import com.thunder.wildernessodysseyapi.command.MeteorCommand;
 import com.thunder.wildernessodysseyapi.command.UnstuckCommand;
@@ -51,6 +52,8 @@ import com.thunder.wildernessodysseyapi.globalchat.GlobalChatManager;
 import com.thunder.wildernessodysseyapi.ModPackPatches.rules.GameRulesListManager;
 import com.thunder.wildernessodysseyapi.watersystem.ocean.tide.TideConfig;
 import com.thunder.wildernessodysseyapi.watersystem.ocean.tide.TideManager;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidConfig;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager;
 import com.thunder.wildernessodysseyapi.ModPackPatches.telemetry.PlayerTelemetryConfig;
 import com.thunder.wildernessodysseyapi.ModPackPatches.telemetry.PlayerTelemetryReporter;
 import com.thunder.wildernessodysseyapi.ModPackPatches.telemetry.EventTelemetryConfig;
@@ -158,6 +161,8 @@ public class WildernessOdysseyAPIMainModClass {
                 CONFIG_FOLDER + "wildernessodysseyapi-structureblocks-server.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, TideConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-tides-server.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, VolumetricFluidConfig.CONFIG_SPEC,
+                CONFIG_FOLDER + "wildernessodysseyapi-volumetric-fluid-server.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, CloakChipConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-cloak-chip-server.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, PlayerTelemetryConfig.CONFIG_SPEC,
@@ -223,6 +228,7 @@ public class WildernessOdysseyAPIMainModClass {
         GlobalChatOptToggleCommand.register(dispatcher);
         LoreBookCommand.register(dispatcher);
         TideInfoCommand.register(dispatcher);
+        VolumetricFluidCommand.register(dispatcher);
         ModpackStructureCommand.register(dispatcher);
         TelemetryConsentCommand.register(dispatcher);
         TelemetryQueueStatsCommand.register(dispatcher);
@@ -281,6 +287,9 @@ public class WildernessOdysseyAPIMainModClass {
         if (event.getConfig().getSpec() == TideConfig.CONFIG_SPEC) {
             TideManager.reloadConfig();
         }
+        if (event.getConfig().getSpec() == VolumetricFluidConfig.CONFIG_SPEC) {
+            VolumetricFluidManager.reloadConfig();
+        }
     }
 
     public void onConfigReloaded(ModConfigEvent.Reloading event) {
@@ -292,6 +301,9 @@ public class WildernessOdysseyAPIMainModClass {
         }
         if (event.getConfig().getSpec() == TideConfig.CONFIG_SPEC) {
             TideManager.reloadConfig();
+        }
+        if (event.getConfig().getSpec() == VolumetricFluidConfig.CONFIG_SPEC) {
+            VolumetricFluidManager.reloadConfig();
         }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/LiquidBlockVolumetricMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/LiquidBlockVolumetricMixin.java
@@ -1,0 +1,36 @@
+package com.thunder.wildernessodysseyapi.mixin;
+
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Fluids;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Optional hard-replacement hook for vanilla water updates.
+ */
+@Mixin(net.minecraft.world.level.block.LiquidBlock.class)
+public class LiquidBlockVolumetricMixin {
+
+    @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
+    private void wildernessodysseyapi$replaceVanillaWaterTick(BlockState state,
+                                                              ServerLevel level,
+                                                              BlockPos pos,
+                                                              RandomSource random,
+                                                              CallbackInfo ci) {
+        if (!VolumetricFluidManager.shouldReplaceVanillaWaterEngine()) {
+            return;
+        }
+        if (state.getFluidState().getType() != Fluids.WATER) {
+            return;
+        }
+
+        VolumetricFluidManager.ingestVanillaWaterTick(level, pos, state.getFluidState().getAmount() / 8.0D);
+        ci.cancel();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
@@ -13,6 +13,7 @@ public final class VolumetricFluidConfig {
     public static final ModConfigSpec.IntValue PLAYER_SAMPLE_RADIUS;
     public static final ModConfigSpec.IntValue PLAYER_SAMPLE_STEP;
     public static final ModConfigSpec.IntValue ACTIVE_RADIUS;
+    public static final ModConfigSpec.BooleanValue REPLACE_VANILLA_ENGINE;
     public static final ModConfigSpec.DoubleValue DOWNWARD_TRANSFER;
     public static final ModConfigSpec.DoubleValue LATERAL_TRANSFER;
     public static final ModConfigSpec.DoubleValue ADVECTION_TRANSFER;
@@ -43,6 +44,9 @@ public final class VolumetricFluidConfig {
 
         ACTIVE_RADIUS = BUILDER.comment("Cells farther than this many blocks from all players are skipped for expensive updates.")
                 .defineInRange("activeRadius", 80, 8, 256);
+
+        REPLACE_VANILLA_ENGINE = BUILDER.comment("If true, cancels vanilla water fluid ticks and routes behavior through the volumetric solver.")
+                .define("replaceVanillaWaterEngine", false);
 
         DOWNWARD_TRANSFER = BUILDER.comment("Max water volume moved downward per step from one cell.")
                 .defineInRange("downwardTransfer", 0.35D, 0.01D, 1.0D);
@@ -88,6 +92,7 @@ public final class VolumetricFluidConfig {
                 PLAYER_SAMPLE_RADIUS.get(),
                 PLAYER_SAMPLE_STEP.get(),
                 ACTIVE_RADIUS.get(),
+                REPLACE_VANILLA_ENGINE.get(),
                 DOWNWARD_TRANSFER.get(),
                 LATERAL_TRANSFER.get(),
                 ADVECTION_TRANSFER.get(),
@@ -108,6 +113,7 @@ public final class VolumetricFluidConfig {
                 PLAYER_SAMPLE_RADIUS.getDefault(),
                 PLAYER_SAMPLE_STEP.getDefault(),
                 ACTIVE_RADIUS.getDefault(),
+                REPLACE_VANILLA_ENGINE.getDefault(),
                 DOWNWARD_TRANSFER.getDefault(),
                 LATERAL_TRANSFER.getDefault(),
                 ADVECTION_TRANSFER.getDefault(),
@@ -127,6 +133,7 @@ public final class VolumetricFluidConfig {
             int playerSampleRadius,
             int playerSampleStep,
             int activeRadius,
+            boolean replaceVanillaWaterEngine,
             double downwardTransfer,
             double lateralTransfer,
             double advectionTransfer,

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
@@ -13,6 +13,7 @@ public final class VolumetricFluidConfig {
     public static final ModConfigSpec.IntValue PLAYER_SAMPLE_RADIUS;
     public static final ModConfigSpec.IntValue PLAYER_SAMPLE_STEP;
     public static final ModConfigSpec.IntValue ACTIVE_RADIUS;
+    public static final ModConfigSpec.ConfigValue<String> PRESET;
     public static final ModConfigSpec.BooleanValue REPLACE_VANILLA_ENGINE;
     public static final ModConfigSpec.DoubleValue DOWNWARD_TRANSFER;
     public static final ModConfigSpec.DoubleValue LATERAL_TRANSFER;
@@ -44,6 +45,9 @@ public final class VolumetricFluidConfig {
 
         ACTIVE_RADIUS = BUILDER.comment("Cells farther than this many blocks from all players are skipped for expensive updates.")
                 .defineInRange("activeRadius", 80, 8, 256);
+
+        PRESET = BUILDER.comment("Preset profile: safe, realism, or custom. Presets override many tunables below.")
+                .defineInList("preset", "safe", java.util.List.of("safe", "realism", "custom"));
 
         REPLACE_VANILLA_ENGINE = BUILDER.comment("If true, cancels vanilla water fluid ticks and routes behavior through the volumetric solver.")
                 .define("replaceVanillaWaterEngine", false);
@@ -86,12 +90,13 @@ public final class VolumetricFluidConfig {
     }
 
     public static Values values() {
-        return new Values(
+        Values raw = new Values(
                 ENABLED.get(),
                 TICK_INTERVAL.get(),
                 PLAYER_SAMPLE_RADIUS.get(),
                 PLAYER_SAMPLE_STEP.get(),
                 ACTIVE_RADIUS.get(),
+                PRESET.get(),
                 REPLACE_VANILLA_ENGINE.get(),
                 DOWNWARD_TRANSFER.get(),
                 LATERAL_TRANSFER.get(),
@@ -104,15 +109,17 @@ public final class VolumetricFluidConfig {
                 MIN_CELL_VOLUME.get(),
                 MAX_CELLS_PER_STEP.get()
         );
+        return applyPreset(raw);
     }
 
     public static Values defaultValues() {
-        return new Values(
+        Values raw = new Values(
                 ENABLED.getDefault(),
                 TICK_INTERVAL.getDefault(),
                 PLAYER_SAMPLE_RADIUS.getDefault(),
                 PLAYER_SAMPLE_STEP.getDefault(),
                 ACTIVE_RADIUS.getDefault(),
+                PRESET.getDefault(),
                 REPLACE_VANILLA_ENGINE.getDefault(),
                 DOWNWARD_TRANSFER.getDefault(),
                 LATERAL_TRANSFER.getDefault(),
@@ -125,6 +132,53 @@ public final class VolumetricFluidConfig {
                 MIN_CELL_VOLUME.getDefault(),
                 MAX_CELLS_PER_STEP.getDefault()
         );
+        return applyPreset(raw);
+    }
+
+
+    private static Values applyPreset(Values raw) {
+        String preset = raw.preset() == null ? "safe" : raw.preset().toLowerCase(java.util.Locale.ROOT);
+        return switch (preset) {
+            case "realism" -> new Values(
+                    raw.enabled(),
+                    1,
+                    24,
+                    1,
+                    128,
+                    "realism",
+                    true,
+                    0.45D,
+                    0.18D,
+                    0.14D,
+                    0.28D,
+                    5,
+                    0.90D,
+                    0.55D,
+                    0.05D,
+                    0.005D,
+                    50000
+            );
+            case "custom" -> raw;
+            default -> new Values(
+                    raw.enabled(),
+                    3,
+                    12,
+                    3,
+                    64,
+                    "safe",
+                    false,
+                    0.25D,
+                    0.06D,
+                    0.04D,
+                    0.12D,
+                    2,
+                    0.88D,
+                    0.72D,
+                    0.08D,
+                    0.015D,
+                    12000
+            );
+        };
     }
 
     public record Values(
@@ -133,6 +187,7 @@ public final class VolumetricFluidConfig {
             int playerSampleRadius,
             int playerSampleStep,
             int activeRadius,
+            String preset,
             boolean replaceVanillaWaterEngine,
             double downwardTransfer,
             double lateralTransfer,

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
@@ -1,0 +1,142 @@
+package com.thunder.wildernessodysseyapi.watersystem.volumetric;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+/**
+ * Server-side tuning values for the sparse volumetric water simulation.
+ */
+public final class VolumetricFluidConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+
+    public static final ModConfigSpec.BooleanValue ENABLED;
+    public static final ModConfigSpec.IntValue TICK_INTERVAL;
+    public static final ModConfigSpec.IntValue PLAYER_SAMPLE_RADIUS;
+    public static final ModConfigSpec.IntValue PLAYER_SAMPLE_STEP;
+    public static final ModConfigSpec.IntValue ACTIVE_RADIUS;
+    public static final ModConfigSpec.DoubleValue DOWNWARD_TRANSFER;
+    public static final ModConfigSpec.DoubleValue LATERAL_TRANSFER;
+    public static final ModConfigSpec.DoubleValue ADVECTION_TRANSFER;
+    public static final ModConfigSpec.DoubleValue PRESSURE_STRENGTH;
+    public static final ModConfigSpec.IntValue PRESSURE_ITERATIONS;
+    public static final ModConfigSpec.DoubleValue INERTIA_DAMPING;
+    public static final ModConfigSpec.DoubleValue PLACE_THRESHOLD;
+    public static final ModConfigSpec.DoubleValue REMOVE_THRESHOLD;
+    public static final ModConfigSpec.DoubleValue MIN_CELL_VOLUME;
+    public static final ModConfigSpec.IntValue MAX_CELLS_PER_STEP;
+
+    private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
+
+    static {
+        BUILDER.push("volumetricFluid");
+
+        ENABLED = BUILDER.comment("Master toggle for sparse volumetric water simulation.")
+                .define("enabled", true);
+
+        TICK_INTERVAL = BUILDER.comment("Simulation step cadence in game ticks.")
+                .defineInRange("tickInterval", 2, 1, 20);
+
+        PLAYER_SAMPLE_RADIUS = BUILDER.comment("Radius around each player used to ingest vanilla water into the simulation.")
+                .defineInRange("playerSampleRadius", 16, 1, 64);
+
+        PLAYER_SAMPLE_STEP = BUILDER.comment("Stride used when sampling world water around players. Higher = cheaper.")
+                .defineInRange("playerSampleStep", 2, 1, 8);
+
+        ACTIVE_RADIUS = BUILDER.comment("Cells farther than this many blocks from all players are skipped for expensive updates.")
+                .defineInRange("activeRadius", 80, 8, 256);
+
+        DOWNWARD_TRANSFER = BUILDER.comment("Max water volume moved downward per step from one cell.")
+                .defineInRange("downwardTransfer", 0.35D, 0.01D, 1.0D);
+
+        LATERAL_TRANSFER = BUILDER.comment("Max water volume moved horizontally per neighbor per step.")
+                .defineInRange("lateralTransfer", 0.10D, 0.0D, 0.5D);
+
+        ADVECTION_TRANSFER = BUILDER.comment("Volume moved along the velocity vector after pressure solving.")
+                .defineInRange("advectionTransfer", 0.08D, 0.0D, 0.5D);
+
+        PRESSURE_STRENGTH = BUILDER.comment("Pressure gradient response strength. Higher values equalize cells faster.")
+                .defineInRange("pressureStrength", 0.18D, 0.01D, 1.0D);
+
+        PRESSURE_ITERATIONS = BUILDER.comment("Jacobi-like pressure relaxation iterations per simulation step.")
+                .defineInRange("pressureIterations", 3, 1, 10);
+
+        INERTIA_DAMPING = BUILDER.comment("Velocity damping factor applied every step.")
+                .defineInRange("inertiaDamping", 0.82D, 0.1D, 0.99D);
+
+        PLACE_THRESHOLD = BUILDER.comment("Cell volume threshold to place/update a world water block.")
+                .defineInRange("placeThreshold", 0.65D, 0.05D, 1.0D);
+
+        REMOVE_THRESHOLD = BUILDER.comment("Cell volume threshold to remove a water block that this system previously placed.")
+                .defineInRange("removeThreshold", 0.10D, 0.0D, 0.95D);
+
+        MIN_CELL_VOLUME = BUILDER.comment("Cells below this volume are discarded.")
+                .defineInRange("minCellVolume", 0.01D, 0.0001D, 0.25D);
+
+        MAX_CELLS_PER_STEP = BUILDER.comment("Hard cap of actively processed cells per dimension step.")
+                .defineInRange("maxCellsPerStep", 24000, 100, 200000);
+
+        BUILDER.pop();
+        CONFIG_SPEC = BUILDER.build();
+    }
+
+    private VolumetricFluidConfig() {
+    }
+
+    public static Values values() {
+        return new Values(
+                ENABLED.get(),
+                TICK_INTERVAL.get(),
+                PLAYER_SAMPLE_RADIUS.get(),
+                PLAYER_SAMPLE_STEP.get(),
+                ACTIVE_RADIUS.get(),
+                DOWNWARD_TRANSFER.get(),
+                LATERAL_TRANSFER.get(),
+                ADVECTION_TRANSFER.get(),
+                PRESSURE_STRENGTH.get(),
+                PRESSURE_ITERATIONS.get(),
+                INERTIA_DAMPING.get(),
+                PLACE_THRESHOLD.get(),
+                REMOVE_THRESHOLD.get(),
+                MIN_CELL_VOLUME.get(),
+                MAX_CELLS_PER_STEP.get()
+        );
+    }
+
+    public static Values defaultValues() {
+        return new Values(
+                ENABLED.getDefault(),
+                TICK_INTERVAL.getDefault(),
+                PLAYER_SAMPLE_RADIUS.getDefault(),
+                PLAYER_SAMPLE_STEP.getDefault(),
+                ACTIVE_RADIUS.getDefault(),
+                DOWNWARD_TRANSFER.getDefault(),
+                LATERAL_TRANSFER.getDefault(),
+                ADVECTION_TRANSFER.getDefault(),
+                PRESSURE_STRENGTH.getDefault(),
+                PRESSURE_ITERATIONS.getDefault(),
+                INERTIA_DAMPING.getDefault(),
+                PLACE_THRESHOLD.getDefault(),
+                REMOVE_THRESHOLD.getDefault(),
+                MIN_CELL_VOLUME.getDefault(),
+                MAX_CELLS_PER_STEP.getDefault()
+        );
+    }
+
+    public record Values(
+            boolean enabled,
+            int tickInterval,
+            int playerSampleRadius,
+            int playerSampleStep,
+            int activeRadius,
+            double downwardTransfer,
+            double lateralTransfer,
+            double advectionTransfer,
+            double pressureStrength,
+            int pressureIterations,
+            double inertiaDamping,
+            double placeThreshold,
+            double removeThreshold,
+            double minCellVolume,
+            int maxCellsPerStep
+    ) {
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
@@ -1,0 +1,390 @@
+package com.thunder.wildernessodysseyapi.watersystem.volumetric;
+
+import com.thunder.wildernessodysseyapi.core.ModConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.server.ServerStartingEvent;
+import net.neoforged.neoforge.event.server.ServerStoppingEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Sparse 3D water simulation that augments vanilla water with pressure and velocity.
+ */
+@EventBusSubscriber(modid = ModConstants.MOD_ID)
+public final class VolumetricFluidManager {
+    private static final Direction[] LATERALS = {Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST};
+    private static final Map<ResourceKey<Level>, FluidGrid> GRIDS = new ConcurrentHashMap<>();
+    private static VolumetricFluidConfig.Values cachedConfig = VolumetricFluidConfig.defaultValues();
+
+    private VolumetricFluidManager() {
+    }
+
+    public static void reloadConfig() {
+        cachedConfig = loadConfigWithFallback();
+    }
+
+    @SubscribeEvent
+    public static void onServerStarting(ServerStartingEvent event) {
+        GRIDS.clear();
+        cachedConfig = loadConfigWithFallback();
+    }
+
+    @SubscribeEvent
+    public static void onServerStopping(ServerStoppingEvent event) {
+        GRIDS.clear();
+    }
+
+    @SubscribeEvent
+    public static void onServerTick(ServerTickEvent.Post event) {
+        if (!event.hasTime() || !cachedConfig.enabled()) {
+            return;
+        }
+
+        MinecraftServer server = event.getServer();
+        ServerLevel overworld = server.overworld();
+        if (overworld == null) {
+            return;
+        }
+
+        long gameTime = overworld.getGameTime();
+        if (gameTime % Math.max(1, cachedConfig.tickInterval()) != 0L) {
+            return;
+        }
+
+        for (ServerLevel level : server.getAllLevels()) {
+            if (level.players().isEmpty()) {
+                continue;
+            }
+            FluidGrid grid = GRIDS.computeIfAbsent(level.dimension(), ignored -> new FluidGrid());
+            ingestWaterNearPlayers(level, grid, cachedConfig);
+            stepSimulation(level, grid, cachedConfig);
+            applyToWorld(level, grid, cachedConfig);
+        }
+    }
+
+    public static SimulationSnapshot getSnapshot(ServerLevel level) {
+        FluidGrid grid = GRIDS.computeIfAbsent(level.dimension(), ignored -> new FluidGrid());
+        double totalVolume = 0.0D;
+        double totalSpeed = 0.0D;
+        for (FluidCell cell : grid.cells.values()) {
+            totalVolume += cell.volume;
+            totalSpeed += Math.sqrt(cell.vx * cell.vx + cell.vy * cell.vy + cell.vz * cell.vz);
+        }
+        double avgSpeed = grid.cells.isEmpty() ? 0.0D : totalSpeed / grid.cells.size();
+        return new SimulationSnapshot(grid.cells.size(), grid.controlledBlocks.size(), totalVolume, avgSpeed);
+    }
+
+    public static void clear(ServerLevel level) {
+        FluidGrid grid = GRIDS.get(level.dimension());
+        if (grid == null) {
+            return;
+        }
+        for (Long packedPos : new ArrayList<>(grid.controlledBlocks)) {
+            BlockPos pos = BlockPos.of(packedPos);
+            if (level.getBlockState(pos).is(Blocks.WATER)) {
+                level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
+            }
+        }
+        grid.cells.clear();
+        grid.controlledBlocks.clear();
+    }
+
+    public static int seedFromExistingWater(ServerLevel level, BlockPos center, int radius) {
+        FluidGrid grid = GRIDS.computeIfAbsent(level.dimension(), ignored -> new FluidGrid());
+        int injected = 0;
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        int minY = Math.max(level.getMinBuildHeight(), center.getY() - radius);
+        int maxY = Math.min(level.getMaxBuildHeight() - 1, center.getY() + radius);
+
+        for (int x = center.getX() - radius; x <= center.getX() + radius; x++) {
+            for (int y = minY; y <= maxY; y++) {
+                for (int z = center.getZ() - radius; z <= center.getZ() + radius; z++) {
+                    cursor.set(x, y, z);
+                    if (!level.isLoaded(cursor) || level.getFluidState(cursor).getType() != Fluids.WATER) {
+                        continue;
+                    }
+                    FluidCell cell = grid.cells.computeIfAbsent(cursor.asLong(), ignored -> new FluidCell());
+                    cell.volume = Math.max(cell.volume, level.getFluidState(cursor).getAmount() / 8.0D);
+                    injected++;
+                }
+            }
+        }
+        pruneCells(grid, cachedConfig.minCellVolume());
+        return injected;
+    }
+
+    private static void ingestWaterNearPlayers(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config) {
+        int radius = config.playerSampleRadius();
+        int step = Math.max(1, config.playerSampleStep());
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+
+        for (ServerPlayer player : level.players()) {
+            BlockPos origin = player.blockPosition();
+            int minY = Math.max(level.getMinBuildHeight(), origin.getY() - radius);
+            int maxY = Math.min(level.getMaxBuildHeight() - 1, origin.getY() + radius);
+            for (int x = origin.getX() - radius; x <= origin.getX() + radius; x += step) {
+                for (int y = minY; y <= maxY; y += step) {
+                    for (int z = origin.getZ() - radius; z <= origin.getZ() + radius; z += step) {
+                        cursor.set(x, y, z);
+                        if (!level.isLoaded(cursor) || level.getFluidState(cursor).getType() != Fluids.WATER) {
+                            continue;
+                        }
+                        FluidCell cell = grid.cells.computeIfAbsent(cursor.asLong(), ignored -> new FluidCell());
+                        cell.volume = Math.max(cell.volume, Math.max(0.125D, level.getFluidState(cursor).getAmount() / 8.0D));
+                    }
+                }
+            }
+        }
+    }
+
+    private static void stepSimulation(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config) {
+        if (grid.cells.isEmpty()) {
+            return;
+        }
+
+        List<Long> keys = new ArrayList<>(grid.cells.keySet());
+        int processed = 0;
+        int activeRadiusSq = config.activeRadius() * config.activeRadius();
+
+        for (int iteration = 0; iteration < config.pressureIterations(); iteration++) {
+            Map<Long, Double> volumeDelta = new HashMap<>();
+            for (Long packedPos : keys) {
+                if (processed++ >= config.maxCellsPerStep()) {
+                    break;
+                }
+
+                FluidCell cell = grid.cells.get(packedPos);
+                if (cell == null || cell.volume <= config.minCellVolume()) {
+                    continue;
+                }
+
+                BlockPos pos = BlockPos.of(packedPos);
+                if (!isNearAnyPlayer(level, pos, activeRadiusSq)) {
+                    continue;
+                }
+
+                double pressure = Math.max(0.0D, cell.volume - 0.5D);
+                double remaining = cell.volume;
+
+                // gravity/downward bias
+                BlockPos below = pos.below();
+                if (below.getY() >= level.getMinBuildHeight() && isFluidPassable(level, below)) {
+                    double down = Math.min(remaining, config.downwardTransfer() * (1.0D + pressure));
+                    if (down > 0.0D) {
+                        accumulate(volumeDelta, below.asLong(), down);
+                        accumulate(volumeDelta, packedPos, -down);
+                        cell.vy -= down;
+                        remaining -= down;
+                    }
+                }
+
+                // pressure equalization on lateral neighbors
+                for (Direction direction : LATERALS) {
+                    if (remaining <= config.minCellVolume()) {
+                        break;
+                    }
+                    BlockPos sidePos = pos.relative(direction);
+                    if (!isFluidPassable(level, sidePos)) {
+                        continue;
+                    }
+
+                    FluidCell neighbor = grid.cells.get(sidePos.asLong());
+                    double neighborVolume = neighbor == null ? 0.0D : neighbor.volume;
+                    double gradient = (cell.volume - neighborVolume);
+                    if (gradient <= config.minCellVolume()) {
+                        continue;
+                    }
+
+                    double flow = Math.min(remaining,
+                            Math.min(config.lateralTransfer(), gradient * config.pressureStrength()));
+                    if (flow <= 0.0D) {
+                        continue;
+                    }
+
+                    accumulate(volumeDelta, sidePos.asLong(), flow);
+                    accumulate(volumeDelta, packedPos, -flow);
+
+                    double directionalVelocity = flow * 0.6D;
+                    switch (direction) {
+                        case EAST -> cell.vx += directionalVelocity;
+                        case WEST -> cell.vx -= directionalVelocity;
+                        case SOUTH -> cell.vz += directionalVelocity;
+                        case NORTH -> cell.vz -= directionalVelocity;
+                        default -> {
+                        }
+                    }
+                    remaining -= flow;
+                }
+            }
+
+            applyVolumeDelta(grid, volumeDelta, config.minCellVolume());
+            if (processed >= config.maxCellsPerStep()) {
+                break;
+            }
+        }
+
+        advectByVelocity(level, grid, config);
+        applyVelocityDamping(grid, config.inertiaDamping());
+        pruneCells(grid, config.minCellVolume());
+    }
+
+    private static void advectByVelocity(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config) {
+        Map<Long, Double> advectedVolume = new HashMap<>();
+
+        for (Map.Entry<Long, FluidCell> entry : new ArrayList<>(grid.cells.entrySet())) {
+            long packedPos = entry.getKey();
+            FluidCell cell = entry.getValue();
+            if (cell.volume <= config.minCellVolume()) {
+                continue;
+            }
+
+            int moveX = (int) Math.signum(cell.vx);
+            int moveY = (int) Math.signum(cell.vy);
+            int moveZ = (int) Math.signum(cell.vz);
+            if (moveX == 0 && moveY == 0 && moveZ == 0) {
+                continue;
+            }
+
+            BlockPos pos = BlockPos.of(packedPos);
+            BlockPos target = pos.offset(moveX, moveY, moveZ);
+            if (target.getY() < level.getMinBuildHeight() || target.getY() >= level.getMaxBuildHeight()) {
+                continue;
+            }
+            if (!isFluidPassable(level, target)) {
+                continue;
+            }
+
+            double transfer = Math.min(cell.volume, config.advectionTransfer());
+            if (transfer <= 0.0D) {
+                continue;
+            }
+
+            accumulate(advectedVolume, packedPos, -transfer);
+            accumulate(advectedVolume, target.asLong(), transfer);
+        }
+
+        applyVolumeDelta(grid, advectedVolume, config.minCellVolume());
+    }
+
+    private static void applyToWorld(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config) {
+        Set<Long> controlledNow = new HashSet<>();
+
+        for (Map.Entry<Long, FluidCell> entry : grid.cells.entrySet()) {
+            long packedPos = entry.getKey();
+            FluidCell cell = entry.getValue();
+            BlockPos pos = BlockPos.of(packedPos);
+
+            if (!level.isLoaded(pos)) {
+                continue;
+            }
+
+            if (cell.volume >= config.placeThreshold()) {
+                BlockState state = level.getBlockState(pos);
+                if (state.isAir()) {
+                    level.setBlockAndUpdate(pos, Blocks.WATER.defaultBlockState());
+                }
+                controlledNow.add(packedPos);
+            }
+        }
+
+        for (Long packedPos : new ArrayList<>(grid.controlledBlocks)) {
+            FluidCell cell = grid.cells.get(packedPos);
+            double volume = cell == null ? 0.0D : cell.volume;
+            if (volume > config.removeThreshold()) {
+                continue;
+            }
+            BlockPos pos = BlockPos.of(packedPos);
+            if (level.isLoaded(pos) && level.getBlockState(pos).is(Blocks.WATER)) {
+                level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
+            }
+        }
+
+        grid.controlledBlocks.clear();
+        grid.controlledBlocks.addAll(controlledNow);
+    }
+
+    private static boolean isNearAnyPlayer(ServerLevel level, BlockPos pos, int radiusSq) {
+        for (ServerPlayer player : level.players()) {
+            if (player.blockPosition().distSqr(pos) <= radiusSq) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isFluidPassable(ServerLevel level, BlockPos pos) {
+        if (!level.isLoaded(pos)) {
+            return false;
+        }
+        BlockState state = level.getBlockState(pos);
+        return state.isAir() || state.is(Blocks.WATER) || state.canBeReplaced();
+    }
+
+    private static void accumulate(Map<Long, Double> delta, long packedPos, double value) {
+        delta.merge(packedPos, value, Double::sum);
+    }
+
+    private static void applyVolumeDelta(FluidGrid grid, Map<Long, Double> delta, double minCellVolume) {
+        for (Map.Entry<Long, Double> update : delta.entrySet()) {
+            FluidCell cell = grid.cells.computeIfAbsent(update.getKey(), ignored -> new FluidCell());
+            cell.volume = Math.max(0.0D, Math.min(1.0D, cell.volume + update.getValue()));
+            if (cell.volume <= minCellVolume) {
+                grid.cells.remove(update.getKey());
+            }
+        }
+    }
+
+    private static void applyVelocityDamping(FluidGrid grid, double damping) {
+        for (FluidCell cell : grid.cells.values()) {
+            cell.vx *= damping;
+            cell.vy *= damping;
+            cell.vz *= damping;
+        }
+    }
+
+    private static void pruneCells(FluidGrid grid, double minCellVolume) {
+        grid.cells.entrySet().removeIf(entry -> entry.getValue().volume <= minCellVolume);
+    }
+
+    private static VolumetricFluidConfig.Values loadConfigWithFallback() {
+        try {
+            return VolumetricFluidConfig.values();
+        } catch (IllegalStateException e) {
+            ModConstants.LOGGER.warn("Volumetric fluid config accessed before load; using defaults. ({})", e.getMessage());
+            return VolumetricFluidConfig.defaultValues();
+        }
+    }
+
+    private static final class FluidGrid {
+        private final Map<Long, FluidCell> cells = new HashMap<>();
+        private final Set<Long> controlledBlocks = new HashSet<>();
+    }
+
+    private static final class FluidCell {
+        private double volume;
+        private double vx;
+        private double vy;
+        private double vz;
+    }
+
+    public record SimulationSnapshot(int activeCells, int controlledBlocks, double totalVolume, double averageSpeed) {
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
@@ -298,10 +298,13 @@ public final class VolumetricFluidManager {
 
             if (cell.volume >= config.placeThreshold()) {
                 BlockState state = level.getBlockState(pos);
+                boolean wasControlled = grid.controlledBlocks.contains(packedPos);
                 if (state.isAir()) {
                     level.setBlockAndUpdate(pos, Blocks.WATER.defaultBlockState());
+                    controlledNow.add(packedPos);
+                } else if (wasControlled && state.is(Blocks.WATER)) {
+                    controlledNow.add(packedPos);
                 }
-                controlledNow.add(packedPos);
             }
         }
 

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
@@ -41,6 +41,19 @@ public final class VolumetricFluidManager {
         cachedConfig = loadConfigWithFallback();
     }
 
+    public static boolean shouldReplaceVanillaWaterEngine() {
+        return cachedConfig.enabled() && cachedConfig.replaceVanillaWaterEngine();
+    }
+
+    public static void ingestVanillaWaterTick(ServerLevel level, BlockPos pos, double normalizedVolume) {
+        if (!cachedConfig.enabled()) {
+            return;
+        }
+        FluidGrid grid = GRIDS.computeIfAbsent(level.dimension(), ignored -> new FluidGrid());
+        FluidCell cell = grid.cells.computeIfAbsent(pos.asLong(), ignored -> new FluidCell());
+        cell.volume = Math.max(cell.volume, Math.max(cachedConfig.minCellVolume(), normalizedVolume));
+    }
+
     @SubscribeEvent
     public static void onServerStarting(ServerStartingEvent event) {
         GRIDS.clear();

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
@@ -45,6 +45,10 @@ public final class VolumetricFluidManager {
         return cachedConfig.enabled() && cachedConfig.replaceVanillaWaterEngine();
     }
 
+    public static String activePreset() {
+        return cachedConfig.preset();
+    }
+
     public static void ingestVanillaWaterTick(ServerLevel level, BlockPos pos, double normalizedVolume) {
         if (!cachedConfig.enabled()) {
             return;

--- a/src/main/resources/mixins.wildernessodysseyapi.json
+++ b/src/main/resources/mixins.wildernessodysseyapi.json
@@ -16,7 +16,8 @@
     "StructureBlockEntityMixin",
     "StructureTemplateAccessor",
     "StructureTemplatePaletteAccessor",
-    "ServerGamePacketListenerImplMixin"
+    "ServerGamePacketListenerImplMixin",
+    "LiquidBlockVolumetricMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
### Motivation

- Introduce a sparse 3D volumetric water simulation to augment vanilla water with pressure and velocity for more realistic fluid behaviour.
- Provide server-side tuning for the simulation so operators can control performance and behavior via configuration.
- Expose operator commands to inspect, seed, and clear the volumetric grid from in-game commands.

### Description

- Add a new runtime manager `VolumetricFluidManager` that implements a sparse grid, tick-driven updates, player-based ingestion, pressure relaxation, advection, world application, seeding, clearing, and snapshot APIs. 
- Add `VolumetricFluidConfig` which declares server-side tuning options and a `Values` record for easy access to parsed config values. 
- Add `VolumetricFluidCommand` to register `volfluid` subcommands `stats`, `clear`, and `seed <radius>` that interact with the manager. 
- Integrate the feature into the mod bootstrap by registering the server config via `ConfigRegistrationValidator.register`, registering the command in `onRegisterCommands`, and invoking `VolumetricFluidManager.reloadConfig()` in `onConfigLoaded` and `onConfigReloaded`.

### Testing

- Executed a full project build with `./gradlew build`, and the build completed successfully. 
- Executed unit/integration test task with `./gradlew test`, and there were no failing tests (no tests or all tests passed). 
- Static/compile-time checks (IDE/compiler) were run as part of the build and reported no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca048db3948328b8cccd5502c033bf)