### PR TITLE
Make LiquidBlock mixin injection optional (require=0) to prevent startup crash

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/LiquidBlockVolumetricMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/LiquidBlockVolumetricMixin.java
@@ -17,7 +17,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(net.minecraft.world.level.block.LiquidBlock.class)
 public class LiquidBlockVolumetricMixin {
 
-    @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "tick", at = @At("HEAD"), cancellable = true, require = 0)
     private void wildernessodysseyapi$replaceVanillaWaterTick(BlockState state,
                                                               ServerLevel level,
                                                               BlockPos pos,


### PR DESCRIPTION
### Motivation
- Prevent a hard `InvalidInjectionException` at bootstrap when `LiquidBlock#tick` is absent in the active Minecraft/mappings/runtime, which caused a crash during mixin application.

### Description
- Made the `@Inject` in `src/main/java/com/thunder/wildernessodysseyapi/mixin/LiquidBlockVolumetricMixin.java` optional by adding `require = 0` to the injection on `LiquidBlock#tick`.

### Testing
- Ran `./gradlew compileJava -q` to validate; the build did not finish in this environment due to an unrelated TLS/PKIX certificate trust failure while downloading Mojang metadata (`version_manifest_v2.json`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9297850c8328bc95a001d656f938)