### PR TITLE
Fix invalid grass_color_modifier in anomaly_rainforest biome JSON

### DIFF
--- a/src/main/resources/data/wildernessodysseyapi/worldgen/biome/anomaly_rainforest.json
+++ b/src/main/resources/data/wildernessodysseyapi/worldgen/biome/anomaly_rainforest.json
@@ -8,7 +8,9 @@
     "water_color": 4159204,
     "water_fog_color": 329011,
     "sky_color": 7842047,
-    "grass_color_modifier": "jungle"
+    "grass_color_modifier": "none",
+    "grass_color": 5011004,
+    "foliage_color": 5470985
   },
   "spawners": {
     "monster": [],


### PR DESCRIPTION
### Motivation
- The biome JSON used an unsupported `grass_color_modifier` value `"jungle"`, which caused registry parsing to fail with an "Unknown element name:jungle" error when loading biomes.

### Description
- Updated `src/main/resources/data/wildernessodysseyapi/worldgen/biome/anomaly_rainforest.json` to set `"grass_color_modifier"` to `"none"` and added explicit `"grass_color"` and `"foliage_color"` fields to preserve the intended rainforest coloring.

### Testing
- Ran `./gradlew compileJava`; the build did not complete due to an environment SSL certificate trust error while downloading Mojang metadata (`PKIX path building failed`), and the failure is unrelated to this JSON fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca95d34f5c832894549853cb02147e)