### PR TITLE
Make volumetric preset validation case-insensitive and centralized

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
@@ -6,6 +6,8 @@ import net.neoforged.neoforge.common.ModConfigSpec;
  * Server-side tuning values for the sparse volumetric water simulation.
  */
 public final class VolumetricFluidConfig {
+    private static final java.util.Set<String> VALID_PRESETS = java.util.Set.of("safe", "realism", "custom");
+
     public static final ModConfigSpec CONFIG_SPEC;
 
     public static final ModConfigSpec.BooleanValue ENABLED;
@@ -47,7 +49,8 @@ public final class VolumetricFluidConfig {
                 .defineInRange("activeRadius", 80, 8, 256);
 
         PRESET = BUILDER.comment("Preset profile: safe, realism, or custom. Presets override many tunables below.")
-                .defineInList("preset", "safe", java.util.List.of("safe", "realism", "custom"));
+                .define("preset", "safe", value -> value instanceof String preset
+                        && VALID_PRESETS.contains(preset.toLowerCase(java.util.Locale.ROOT)));
 
         REPLACE_VANILLA_ENGINE = BUILDER.comment("If true, cancels vanilla water fluid ticks and routes behavior through the volumetric solver.")
                 .define("replaceVanillaWaterEngine", false);


### PR DESCRIPTION
### Motivation
- Ensure the `preset` config accepts the known profiles (`safe`, `realism`, `custom`) robustly and case-insensitively by centralizing valid values and using a predicate validator.

### Description
- Add `VALID_PRESETS` as a `Set` of allowed preset names and replace the previous `defineInList` call with `define("preset", "safe", value -> value instanceof String preset && VALID_PRESETS.contains(preset.toLowerCase(java.util.Locale.ROOT)))` to perform case-insensitive validation.

### Testing
- Project compilation and existing automated tests were run (`./gradlew build` / `./gradlew test`) and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caa7e4dd348328aa25e82ce24f5489)