### PR TITLE
Add debug config to disable starter bunker placement

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/configurable/StructureConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/configurable/StructureConfig.java
@@ -29,6 +29,8 @@ public class StructureConfig {
     public static final ModConfigSpec.IntValue MAX_LEVELING_DEPTH;
     /** Prevent hostile mob spawns inside the starter bunker immediately after placement */
     public static final ModConfigSpec.BooleanValue PREVENT_STARTER_STRUCTURE_HOSTILES;
+    /** Debug toggle to skip starter bunker placement and keep vanilla spawn selection. */
+    public static final ModConfigSpec.BooleanValue DEBUG_DISABLE_STARTER_BUNKER;
     /** Horizontal radius where hostile mobs may not spawn around the placed starter bunker */
     public static final ModConfigSpec.IntValue STARTER_STRUCTURE_SPAWN_DENY_RADIUS;
     /** Vertical half-height where hostile mobs may not spawn around the placed starter bunker */
@@ -81,6 +83,10 @@ public class StructureConfig {
                         "When true, hostile mob spawns inside the starter bunker will be blocked after placement."
                 )
                 .define("starterStructurePreventHostiles", true);
+        DEBUG_DISABLE_STARTER_BUNKER = BUILDER.comment(
+                        "If true, the starter bunker will not be placed and vanilla spawn selection will run instead."
+                )
+                .define("debugDisableStarterBunker", false);
         STARTER_STRUCTURE_SPAWN_DENY_RADIUS = BUILDER.comment(
                         "Horizontal radius (in blocks) around the starter bunker where hostile mob spawns are denied."
                 )

--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/spawn/SpawnBunkerPlacer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/spawn/SpawnBunkerPlacer.java
@@ -1,6 +1,7 @@
 package com.thunder.wildernessodysseyapi.worldgen.spawn;
 
 import com.thunder.wildernessodysseyapi.core.ModConstants;
+import com.thunder.wildernessodysseyapi.worldgen.configurable.StructureConfig;
 import com.thunder.wildernessodysseyapi.worldgen.processor.BunkerPlacementProcessor;
 import com.thunder.wildernessodysseyapi.worldgen.structure.NBTStructurePlacer;
 import com.thunder.wildernessodysseyapi.worldgen.structure.StarterStructureSpawnGuard;
@@ -63,6 +64,10 @@ public final class SpawnBunkerPlacer {
             return;
         }
         if (!level.dimension().equals(Level.OVERWORLD)) {
+            return;
+        }
+        if (StructureConfig.DEBUG_DISABLE_STARTER_BUNKER.get()) {
+            ModConstants.LOGGER.info("Skipping starter bunker placement because placement.debugDisableStarterBunker is enabled.");
             return;
         }
 


### PR DESCRIPTION
### Motivation
- Provide a runtime toggle to disable automatic starter bunker placement so debugging spawn selection and related systems is easier without the bunker being created.

### Description
- Added a new common config flag `placement.debugDisableStarterBunker` (`DEBUG_DISABLE_STARTER_BUNKER`) in `StructureConfig` and wired `SpawnBunkerPlacer.onCreateSpawn` to skip bunker placement and emit an info log when the flag is enabled (files changed: `StructureConfig.java`, `SpawnBunkerPlacer.java`).

### Testing
- Executed `./gradlew compileJava`, but the build could not complete in this environment due to an external NeoForge/Mojang artifact download failure caused by an SSL certificate trust error (`PKIX path building failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cabc11ab108328b7e3a45985de27eb)