### PR TITLE
Protect vanilla/seeded water from volumetric simulation and adjust server tick check

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
@@ -56,6 +56,9 @@ public final class VolumetricFluidManager {
         FluidGrid grid = GRIDS.computeIfAbsent(level.dimension(), ignored -> new FluidGrid());
         FluidCell cell = grid.cells.computeIfAbsent(pos.asLong(), ignored -> new FluidCell());
         cell.volume = Math.max(cell.volume, Math.max(cachedConfig.minCellVolume(), normalizedVolume));
+        if (level.getBlockState(pos).is(Blocks.WATER)) {
+            grid.protectedWaterBlocks.add(pos.asLong());
+        }
     }
 
     @SubscribeEvent
@@ -71,7 +74,7 @@ public final class VolumetricFluidManager {
 
     @SubscribeEvent
     public static void onServerTick(ServerTickEvent.Post event) {
-        if (!event.hasTime() || !cachedConfig.enabled()) {
+        if (!cachedConfig.enabled()) {
             return;
         }
 
@@ -122,6 +125,7 @@ public final class VolumetricFluidManager {
         }
         grid.cells.clear();
         grid.controlledBlocks.clear();
+        grid.protectedWaterBlocks.clear();
     }
 
     public static int seedFromExistingWater(ServerLevel level, BlockPos center, int radius) {
@@ -140,6 +144,7 @@ public final class VolumetricFluidManager {
                     }
                     FluidCell cell = grid.cells.computeIfAbsent(cursor.asLong(), ignored -> new FluidCell());
                     cell.volume = Math.max(cell.volume, level.getFluidState(cursor).getAmount() / 8.0D);
+                    grid.protectedWaterBlocks.add(cursor.asLong());
                     injected++;
                 }
             }
@@ -166,6 +171,7 @@ public final class VolumetricFluidManager {
                         }
                         FluidCell cell = grid.cells.computeIfAbsent(cursor.asLong(), ignored -> new FluidCell());
                         cell.volume = Math.max(cell.volume, Math.max(0.125D, level.getFluidState(cursor).getAmount() / 8.0D));
+                        grid.protectedWaterBlocks.add(cursor.asLong());
                     }
                 }
             }
@@ -303,6 +309,10 @@ public final class VolumetricFluidManager {
 
     private static void applyToWorld(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config) {
         Set<Long> controlledNow = new HashSet<>();
+        grid.protectedWaterBlocks.removeIf(packedPos -> {
+            BlockPos pos = BlockPos.of(packedPos);
+            return level.isLoaded(pos) && !level.getBlockState(pos).is(Blocks.WATER);
+        });
 
         for (Map.Entry<Long, FluidCell> entry : grid.cells.entrySet()) {
             long packedPos = entry.getKey();
@@ -318,14 +328,18 @@ public final class VolumetricFluidManager {
                 boolean wasControlled = grid.controlledBlocks.contains(packedPos);
                 if (state.isAir()) {
                     level.setBlockAndUpdate(pos, Blocks.WATER.defaultBlockState());
+                    grid.protectedWaterBlocks.remove(packedPos);
                     controlledNow.add(packedPos);
-                } else if (wasControlled && state.is(Blocks.WATER)) {
+                } else if (wasControlled && state.is(Blocks.WATER) && !grid.protectedWaterBlocks.contains(packedPos)) {
                     controlledNow.add(packedPos);
                 }
             }
         }
 
         for (Long packedPos : new ArrayList<>(grid.controlledBlocks)) {
+            if (grid.protectedWaterBlocks.contains(packedPos)) {
+                continue;
+            }
             FluidCell cell = grid.cells.get(packedPos);
             double volume = cell == null ? 0.0D : cell.volume;
             if (volume > config.removeThreshold()) {
@@ -396,6 +410,7 @@ public final class VolumetricFluidManager {
     private static final class FluidGrid {
         private final Map<Long, FluidCell> cells = new HashMap<>();
         private final Set<Long> controlledBlocks = new HashSet<>();
+        private final Set<Long> protectedWaterBlocks = new HashSet<>();
     }
 
     private static final class FluidCell {


### PR DESCRIPTION
### Motivation
- Prevent the volumetric fluid system from overwriting or removing vanilla or seeded water that was not created/controlled by the simulation. 
- Ensure water discovered via vanilla ticks, seeding, or player-area sampling is treated as protected so the sim does not take control or clear it. 
- Remove the redundant `event.hasTime()` guard in server tick handling to rely solely on the config-enabled check.

### Description
- Add a `protectedWaterBlocks` set to `FluidGrid` to track positions that should not be claimed or removed by the simulation. 
- Mark blocks as protected in `ingestVanillaWaterTick`, `seedFromExistingWater`, and `ingestWaterNearPlayers`. 
- In `applyToWorld` prune stale protections for non-water blocks, avoid claiming or removing any position present in `protectedWaterBlocks`, and remove protections when the simulation explicitly places water. 
- Clear `protectedWaterBlocks` in `clear()` and remove the `event.hasTime()` check from `onServerTick` so tick handling only depends on `cachedConfig.enabled()`.

### Testing
- Built the project using `./gradlew build` and the build completed successfully. 
- Ran the existing automated unit test suite with `./gradlew test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cabe885f248328aadccb85bbd6d595)