### PR TITLE
Volumetric fluid surface pipeline + lava support (mesher, sync, client preview)

### DIFF
--- a/docs/volumetric-fluid-mesh-renderer-plan.md
+++ b/docs/volumetric-fluid-mesh-renderer-plan.md
@@ -1,0 +1,52 @@
+# Volumetric Fluid Mesh Renderer Plan (Water/Lava)
+
+Goal: move from block-placement visuals to smooth, mesh-based fluid surfaces like modern realtime fluid demos.
+
+## Current state
+
+- Server hybrid simulation already tracks per-cell volume and velocity.
+- Server now exposes `sampleSurface(...)` data (one top sample per X/Z column) to support a client renderer pipeline.
+- `VolumetricSurfaceMesher` now converts those samples into mesh topology stats (quads/triangles/area) and optional triangle lists for renderer upload.
+- Added `VolumetricSurfaceSyncPayload` and `VolumetricSurfaceSyncManager` to periodically sync sampled water/lava surfaces to clients.
+- Added `VolumetricSurfaceClientCache` to store synchronized surface columns per-dimension for upcoming mesh rendering.
+- Added first-pass `VolumetricSurfaceRenderer` client pass that draws translucent triangle meshes from the synced cache (preview quality) with camera-distance culling.
+- Added `VolumetricFluidRenderConfig` (client) for renderer toggles, triangle budget, distance culling, stale-age cutoff, wave amplitude, and foam strength tuning.
+- Added shader scaffolding files for water/lava (`assets/.../shaders/core/volumetric_surface_{water,lava}.{vsh,fsh,json}`) to transition preview rendering to custom shader-backed materials.
+- Added runtime shader hookup classes (`VolumetricSurfaceShaders`, `VolumetricSurfaceRenderTypes`) so the preview renderer can use custom water/lava shader programs with fallback to vanilla position-color shader.
+- Added shoreline-aware wave behavior (sand/beach detection), moon-phase wave scaling, and tide offset propagation into sampled surface vertices so beach areas receive stronger wave motion and ocean/river tides move the preview mesh vertically.
+- Added `/volfluid tide` debug command output to inspect local water sample volume, shoreline factor, tide offset, moon-phase factor, and reconstructed surface height while tuning.
+
+## Next implementation phases
+
+1. **Networking**
+   - Send nearby `SurfaceSample` batches to each tracking player on a fixed cadence (e.g. every 4 ticks).
+   - Delta-compress by chunk section + quantized height/volume.
+
+2. **Client cache**
+   - Maintain short-lived per-dimension surface cache keyed by column.
+   - Expire samples that are stale/unseen.
+
+3. **Mesh generation**
+   - Build a regular grid mesh in local chunks from cached samples.
+   - Reconstruct smooth normals from height gradients.
+   - Add edge skirts at cache boundaries.
+
+4. **Material/shader pass**
+   - Water: refraction tint + fresnel + foam mask from velocity/curvature.
+   - Lava: emissive + heat distortion + crust mask based on low velocity / cooling rules.
+
+5. **Interaction bridge**
+   - Keep physics/hit checks on server cells while rendering is mesh-only on client.
+   - Optional: disable world block placement (`visualOnly`) once mesh path is stable.
+
+## Performance guardrails
+
+- Cap samples per player radius (target <= 2k samples frame-visible).
+- Rebuild mesh only for dirty regions.
+- Quantize heights to 1/32 block to reduce packet size.
+- LOD: coarser grid beyond 24-32 blocks from camera.
+
+## Why this matches the target visual
+
+The reference style is a *surface reconstruction* problem (heightfield/mesh + fluid shading), not block placement.
+Using server volumetric cells as source data and rendering a shaded client mesh is the practical NeoForge path.

--- a/src/main/java/com/thunder/wildernessodysseyapi/command/VolumetricFluidCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/command/VolumetricFluidCommand.java
@@ -4,6 +4,8 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager.SimulatedFluid;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricSurfaceMesher;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
@@ -23,40 +25,76 @@ public final class VolumetricFluidCommand {
                 .requires(source -> source.hasPermission(2))
                 .then(Commands.literal("stats")
                         .executes(VolumetricFluidCommand::reportStats))
+                .then(Commands.literal("tide")
+                        .executes(VolumetricFluidCommand::reportTideDebug))
                 .then(Commands.literal("clear")
-                        .executes(VolumetricFluidCommand::clear))
+                        .executes(context -> clear(context, SimulatedFluid.WATER))
+                        .then(Commands.literal("water")
+                                .executes(context -> clear(context, SimulatedFluid.WATER)))
+                        .then(Commands.literal("lava")
+                                .executes(context -> clear(context, SimulatedFluid.LAVA))))
                 .then(Commands.literal("seed")
                         .then(Commands.argument("radius", IntegerArgumentType.integer(1, 64))
-                                .executes(VolumetricFluidCommand::seed))));
+                                .executes(context -> seed(context, SimulatedFluid.WATER))
+                                .then(Commands.literal("water")
+                                        .executes(context -> seed(context, SimulatedFluid.WATER)))
+                                .then(Commands.literal("lava")
+                                        .executes(context -> seed(context, SimulatedFluid.LAVA))))));
     }
 
     private static int reportStats(CommandContext<CommandSourceStack> context) {
         ServerLevel level = context.getSource().getLevel();
-        VolumetricFluidManager.SimulationSnapshot snapshot = VolumetricFluidManager.getSnapshot(level);
+        BlockPos center = BlockPos.containing(context.getSource().getPosition());
+        VolumetricFluidManager.SimulationSnapshot waterSnapshot = VolumetricFluidManager.getSnapshot(level, SimulatedFluid.WATER);
+        VolumetricFluidManager.SimulationSnapshot lavaSnapshot = VolumetricFluidManager.getSnapshot(level, SimulatedFluid.LAVA);
+        var waterSamples = VolumetricFluidManager.sampleSurface(level, SimulatedFluid.WATER, center, 32, 1024);
+        var lavaSamples = VolumetricFluidManager.sampleSurface(level, SimulatedFluid.LAVA, center, 32, 1024);
+        VolumetricSurfaceMesher.MeshSnapshot waterMesh = VolumetricSurfaceMesher.buildMesh(waterSamples, 1.50D);
+        VolumetricSurfaceMesher.MeshSnapshot lavaMesh = VolumetricSurfaceMesher.buildMesh(lavaSamples, 1.50D);
         context.getSource().sendSuccess(() -> Component.literal(String.format(
-                "VolFluid: cells=%d, controlled=%d, totalVolume=%.2f, avgSpeed=%.4f, preset=%s, replaceVanilla=%s",
-                snapshot.activeCells(), snapshot.controlledBlocks(), snapshot.totalVolume(), snapshot.averageSpeed(),
+                "VolFluid Water: cells=%d, controlled=%d, totalVolume=%.2f, avgSpeed=%.4f, samples=%d, tris=%d, area=%.1f | Lava: cells=%d, controlled=%d, totalVolume=%.2f, avgSpeed=%.4f, samples=%d, tris=%d, area=%.1f | preset=%s, replaceWater=%s, replaceLava=%s",
+                waterSnapshot.activeCells(), waterSnapshot.controlledBlocks(), waterSnapshot.totalVolume(), waterSnapshot.averageSpeed(),
+                waterMesh.sampleCount(), waterMesh.triangles(), waterMesh.estimatedArea(),
+                lavaSnapshot.activeCells(), lavaSnapshot.controlledBlocks(), lavaSnapshot.totalVolume(), lavaSnapshot.averageSpeed(),
+                lavaMesh.sampleCount(), lavaMesh.triangles(), lavaMesh.estimatedArea(),
                 VolumetricFluidManager.activePreset(),
-                VolumetricFluidManager.shouldReplaceVanillaWaterEngine()
+                VolumetricFluidManager.shouldReplaceVanillaWaterEngine(),
+                VolumetricFluidManager.shouldReplaceVanillaLavaEngine()
         )), false);
-        return snapshot.activeCells();
+        return waterSnapshot.activeCells() + lavaSnapshot.activeCells();
     }
 
-    private static int clear(CommandContext<CommandSourceStack> context) {
+    private static int clear(CommandContext<CommandSourceStack> context, SimulatedFluid fluidType) {
         ServerLevel level = context.getSource().getLevel();
-        VolumetricFluidManager.clear(level);
-        context.getSource().sendSuccess(() -> Component.literal("Volumetric fluid grid cleared in this dimension."), true);
+        VolumetricFluidManager.clear(level, fluidType);
+        context.getSource().sendSuccess(() -> Component.literal("Volumetric " + fluidType.name().toLowerCase() + " grid cleared in this dimension."), true);
         return 1;
     }
 
-    private static int seed(CommandContext<CommandSourceStack> context) {
+    private static int seed(CommandContext<CommandSourceStack> context, SimulatedFluid fluidType) {
         int radius = IntegerArgumentType.getInteger(context, "radius");
         BlockPos center = BlockPos.containing(context.getSource().getPosition());
         ServerLevel level = context.getSource().getLevel();
-        int injected = VolumetricFluidManager.seedFromExistingWater(level, center, radius);
+        int injected = VolumetricFluidManager.seedFromExistingFluid(level, center, radius, fluidType);
         context.getSource().sendSuccess(() -> Component.literal(
-                "Seeded volumetric grid from " + injected + " water blocks in radius " + radius + "."
+                "Seeded volumetric " + fluidType.name().toLowerCase() + " grid from " + injected + " blocks in radius " + radius + "."
         ), true);
         return injected;
+    }
+
+    private static int reportTideDebug(CommandContext<CommandSourceStack> context) {
+        ServerLevel level = context.getSource().getLevel();
+        BlockPos pos = BlockPos.containing(context.getSource().getPosition());
+        VolumetricFluidManager.SurfaceSample sample = VolumetricFluidManager.sampleAtPosition(level, pos, SimulatedFluid.WATER);
+        context.getSource().sendSuccess(() -> Component.literal(String.format(
+                "VolFluid Tide Debug @ %d %d %d -> volume=%.3f, shoreline=%.3f, tideOffset=%.3f, moonFactor=%.3f, surfaceY=%.3f",
+                pos.getX(), pos.getY(), pos.getZ(),
+                sample.volume(),
+                sample.shorelineFactor(),
+                sample.tideOffset(),
+                sample.moonPhaseFactor(),
+                sample.surfaceY()
+        )), false);
+        return 1;
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
@@ -51,8 +51,10 @@ import com.thunder.wildernessodysseyapi.globalchat.GlobalChatManager;
 import com.thunder.wildernessodysseyapi.ModPackPatches.rules.GameRulesListManager;
 import com.thunder.wildernessodysseyapi.watersystem.ocean.tide.TideConfig;
 import com.thunder.wildernessodysseyapi.watersystem.ocean.tide.TideManager;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.client.VolumetricFluidRenderConfig;
 import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidConfig;
 import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.network.VolumetricSurfaceSyncPayload;
 import com.thunder.wildernessodysseyapi.ModPackPatches.telemetry.PlayerTelemetryConfig;
 import com.thunder.wildernessodysseyapi.ModPackPatches.telemetry.PlayerTelemetryReporter;
 import com.thunder.wildernessodysseyapi.ModPackPatches.telemetry.EventTelemetryConfig;
@@ -79,6 +81,8 @@ import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.network.handling.IPayloadHandler;
+import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModContainer;
@@ -120,6 +124,7 @@ public class WildernessOdysseyAPIMainModClass {
 
         // Register mod setup and creative tabs
         modEventBus.addListener(this::commonSetup);
+        modEventBus.addListener(this::registerPayloads);
         modEventBus.addListener(this::onConfigLoaded);
         modEventBus.addListener(this::onConfigReloaded);
         ModProcessors.PROCESSORS.register(modEventBus);
@@ -154,6 +159,8 @@ public class WildernessOdysseyAPIMainModClass {
                 CONFIG_FOLDER + "wildernessodysseyapi-debug-overlay-client.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.CLIENT, TrueDarknessConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-true-darkness-client.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.CLIENT, VolumetricFluidRenderConfig.CONFIG_SPEC,
+                CONFIG_FOLDER + "wildernessodysseyapi-volumetric-renderer-client.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, AsyncThreadingConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-async.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, StructureBlockConfig.CONFIG_SPEC,
@@ -185,6 +192,15 @@ public class WildernessOdysseyAPIMainModClass {
         });
         LOGGER.warn("Mod Pack Version: {}", VERSION); // Logs as a warning
         LOGGER.warn("This message is for development purposes only."); // Logs as info
+    }
+
+    private void registerPayloads(final RegisterPayloadHandlersEvent event) {
+        PayloadRegistrar registrar = event.registrar("1");
+        registrar.playToClient(
+                VolumetricSurfaceSyncPayload.TYPE,
+                VolumetricSurfaceSyncPayload.STREAM_CODEC,
+                VolumetricSurfaceSyncPayload::handle
+        );
     }
 
     private void addCreative(BuildCreativeModeTabContentsEvent event) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/LiquidBlockVolumetricMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/LiquidBlockVolumetricMixin.java
@@ -23,14 +23,17 @@ public class LiquidBlockVolumetricMixin {
                                                               BlockPos pos,
                                                               RandomSource random,
                                                               CallbackInfo ci) {
-        if (!VolumetricFluidManager.shouldReplaceVanillaWaterEngine()) {
+        if (state.getFluidState().getType() == Fluids.WATER) {
+            if (!VolumetricFluidManager.shouldReplaceVanillaWaterEngine()) {
+                return;
+            }
+            VolumetricFluidManager.ingestVanillaWaterTick(level, pos, state.getFluidState().getAmount() / 8.0D);
+            ci.cancel();
             return;
         }
-        if (state.getFluidState().getType() != Fluids.WATER) {
-            return;
+        if (state.getFluidState().getType() == Fluids.LAVA && VolumetricFluidManager.shouldReplaceVanillaLavaEngine()) {
+            VolumetricFluidManager.ingestVanillaLavaTick(level, pos, state.getFluidState().getAmount() / 8.0D);
+            ci.cancel();
         }
-
-        VolumetricFluidManager.ingestVanillaWaterTick(level, pos, state.getFluidState().getAmount() / 8.0D);
-        ci.cancel();
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
@@ -17,6 +17,8 @@ public final class VolumetricFluidConfig {
     public static final ModConfigSpec.IntValue ACTIVE_RADIUS;
     public static final ModConfigSpec.ConfigValue<String> PRESET;
     public static final ModConfigSpec.BooleanValue REPLACE_VANILLA_ENGINE;
+    public static final ModConfigSpec.BooleanValue ENABLE_LAVA;
+    public static final ModConfigSpec.BooleanValue REPLACE_VANILLA_LAVA_ENGINE;
     public static final ModConfigSpec.DoubleValue DOWNWARD_TRANSFER;
     public static final ModConfigSpec.DoubleValue LATERAL_TRANSFER;
     public static final ModConfigSpec.DoubleValue ADVECTION_TRANSFER;
@@ -54,6 +56,12 @@ public final class VolumetricFluidConfig {
 
         REPLACE_VANILLA_ENGINE = BUILDER.comment("If true, cancels vanilla water fluid ticks and routes behavior through the volumetric solver.")
                 .define("replaceVanillaWaterEngine", false);
+
+        ENABLE_LAVA = BUILDER.comment("If true, runs the hybrid volumetric solver for lava in addition to water.")
+                .define("enableLava", false);
+
+        REPLACE_VANILLA_LAVA_ENGINE = BUILDER.comment("If true, cancels vanilla lava fluid ticks and routes behavior through the volumetric solver.")
+                .define("replaceVanillaLavaEngine", false);
 
         DOWNWARD_TRANSFER = BUILDER.comment("Max water volume moved downward per step from one cell.")
                 .defineInRange("downwardTransfer", 0.35D, 0.01D, 1.0D);
@@ -101,6 +109,8 @@ public final class VolumetricFluidConfig {
                 ACTIVE_RADIUS.get(),
                 PRESET.get(),
                 REPLACE_VANILLA_ENGINE.get(),
+                ENABLE_LAVA.get(),
+                REPLACE_VANILLA_LAVA_ENGINE.get(),
                 DOWNWARD_TRANSFER.get(),
                 LATERAL_TRANSFER.get(),
                 ADVECTION_TRANSFER.get(),
@@ -124,6 +134,8 @@ public final class VolumetricFluidConfig {
                 ACTIVE_RADIUS.getDefault(),
                 PRESET.getDefault(),
                 REPLACE_VANILLA_ENGINE.getDefault(),
+                ENABLE_LAVA.getDefault(),
+                REPLACE_VANILLA_LAVA_ENGINE.getDefault(),
                 DOWNWARD_TRANSFER.getDefault(),
                 LATERAL_TRANSFER.getDefault(),
                 ADVECTION_TRANSFER.getDefault(),
@@ -150,6 +162,8 @@ public final class VolumetricFluidConfig {
                     128,
                     "realism",
                     true,
+                    true,
+                    true,
                     0.45D,
                     0.18D,
                     0.14D,
@@ -169,6 +183,8 @@ public final class VolumetricFluidConfig {
                     3,
                     64,
                     "safe",
+                    false,
+                    false,
                     false,
                     0.25D,
                     0.06D,
@@ -192,6 +208,8 @@ public final class VolumetricFluidConfig {
             int activeRadius,
             String preset,
             boolean replaceVanillaWaterEngine,
+            boolean enableLava,
+            boolean replaceVanillaLavaEngine,
             double downwardTransfer,
             double lateralTransfer,
             double advectionTransfer,

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
@@ -1,15 +1,21 @@
 package com.thunder.wildernessodysseyapi.watersystem.volumetric;
 
 import com.thunder.wildernessodysseyapi.core.ModConstants;
+import com.thunder.wildernessodysseyapi.watersystem.ocean.tide.TideAstronomy;
+import com.thunder.wildernessodysseyapi.watersystem.ocean.tide.TideManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.BiomeTags;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -31,7 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @EventBusSubscriber(modid = ModConstants.MOD_ID)
 public final class VolumetricFluidManager {
     private static final Direction[] LATERALS = {Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST};
-    private static final Map<ResourceKey<Level>, FluidGrid> GRIDS = new ConcurrentHashMap<>();
+    private static final Map<ResourceKey<Level>, Map<SimulatedFluid, FluidGrid>> GRIDS = new ConcurrentHashMap<>();
     private static VolumetricFluidConfig.Values cachedConfig = VolumetricFluidConfig.defaultValues();
 
     private VolumetricFluidManager() {
@@ -45,6 +51,14 @@ public final class VolumetricFluidManager {
         return cachedConfig.enabled() && cachedConfig.replaceVanillaWaterEngine();
     }
 
+    public static boolean shouldReplaceVanillaLavaEngine() {
+        return cachedConfig.enabled() && cachedConfig.enableLava() && cachedConfig.replaceVanillaLavaEngine();
+    }
+
+    public static boolean isLavaSimulationEnabled() {
+        return cachedConfig.enabled() && cachedConfig.enableLava();
+    }
+
     public static String activePreset() {
         return cachedConfig.preset();
     }
@@ -53,7 +67,16 @@ public final class VolumetricFluidManager {
         if (!cachedConfig.enabled()) {
             return;
         }
-        FluidGrid grid = GRIDS.computeIfAbsent(level.dimension(), ignored -> new FluidGrid());
+        FluidGrid grid = getGrid(level, SimulatedFluid.WATER);
+        FluidCell cell = grid.cells.computeIfAbsent(pos.asLong(), ignored -> new FluidCell());
+        cell.volume = Math.max(cell.volume, Math.max(cachedConfig.minCellVolume(), normalizedVolume));
+    }
+
+    public static void ingestVanillaLavaTick(ServerLevel level, BlockPos pos, double normalizedVolume) {
+        if (!cachedConfig.enabled() || !cachedConfig.enableLava()) {
+            return;
+        }
+        FluidGrid grid = getGrid(level, SimulatedFluid.LAVA);
         FluidCell cell = grid.cells.computeIfAbsent(pos.asLong(), ignored -> new FluidCell());
         cell.volume = Math.max(cell.volume, Math.max(cachedConfig.minCellVolume(), normalizedVolume));
     }
@@ -90,15 +113,15 @@ public final class VolumetricFluidManager {
             if (level.players().isEmpty()) {
                 continue;
             }
-            FluidGrid grid = GRIDS.computeIfAbsent(level.dimension(), ignored -> new FluidGrid());
-            ingestWaterNearPlayers(level, grid, cachedConfig);
-            stepSimulation(level, grid, cachedConfig);
-            applyToWorld(level, grid, cachedConfig);
+            stepFluid(level, SimulatedFluid.WATER, cachedConfig);
+            if (cachedConfig.enableLava()) {
+                stepFluid(level, SimulatedFluid.LAVA, cachedConfig);
+            }
         }
     }
 
-    public static SimulationSnapshot getSnapshot(ServerLevel level) {
-        FluidGrid grid = GRIDS.computeIfAbsent(level.dimension(), ignored -> new FluidGrid());
+    public static SimulationSnapshot getSnapshot(ServerLevel level, SimulatedFluid fluidType) {
+        FluidGrid grid = getGrid(level, fluidType);
         double totalVolume = 0.0D;
         double totalSpeed = 0.0D;
         for (FluidCell cell : grid.cells.values()) {
@@ -109,14 +132,80 @@ public final class VolumetricFluidManager {
         return new SimulationSnapshot(grid.cells.size(), grid.controlledBlocks.size(), totalVolume, avgSpeed);
     }
 
-    public static void clear(ServerLevel level) {
-        FluidGrid grid = GRIDS.get(level.dimension());
+    /**
+     * Builds a compact list of fluid-surface samples that a client mesh renderer can consume.
+     * One sample is emitted per X/Z column using the highest active cell.
+     */
+    public static List<SurfaceSample> sampleSurface(ServerLevel level,
+                                                    SimulatedFluid fluidType,
+                                                    BlockPos center,
+                                                    int radius,
+                                                    int maxSamples) {
+        FluidGrid grid = getGrid(level, fluidType);
+        if (grid.cells.isEmpty() || maxSamples <= 0 || radius <= 0) {
+            return List.of();
+        }
+
+        int minX = center.getX() - radius;
+        int maxX = center.getX() + radius;
+        int minZ = center.getZ() - radius;
+        int maxZ = center.getZ() + radius;
+        Map<Long, SurfaceSample> byColumn = new HashMap<>();
+        TideManager.TideSnapshot tideSnapshot = TideManager.snapshot(level);
+        double moonPhaseFactor = fluidType == SimulatedFluid.WATER ? TideAstronomy.getMoonPhaseAmplitudeFactor(level) : 1.0D;
+
+        for (Map.Entry<Long, FluidCell> entry : grid.cells.entrySet()) {
+            BlockPos pos = BlockPos.of(entry.getKey());
+            if (pos.getX() < minX || pos.getX() > maxX || pos.getZ() < minZ || pos.getZ() > maxZ) {
+                continue;
+            }
+            FluidCell cell = entry.getValue();
+            if (cell.volume <= cachedConfig.minCellVolume()) {
+                continue;
+            }
+
+            long columnKey = BlockPos.asLong(pos.getX(), 0, pos.getZ());
+            double surfaceY = pos.getY() + Math.max(0.0D, Math.min(1.0D, cell.volume));
+            double shorelineFactor = fluidType == SimulatedFluid.WATER ? computeShorelineFactor(level, pos) : 0.0D;
+            double tideOffset = 0.0D;
+            if (fluidType == SimulatedFluid.WATER) {
+                tideOffset = tideSnapshot.normalizedHeight() * TideManager.getLocalAmplitude(level, pos);
+            }
+            SurfaceSample current = byColumn.get(columnKey);
+            if (current == null || surfaceY > current.surfaceY()) {
+                byColumn.put(columnKey, new SurfaceSample(
+                        pos.getX(),
+                        pos.getZ(),
+                        surfaceY,
+                        cell.volume,
+                        shorelineFactor,
+                        tideOffset,
+                        moonPhaseFactor,
+                        fluidType
+                ));
+            }
+        }
+
+        if (byColumn.isEmpty()) {
+            return List.of();
+        }
+
+        List<SurfaceSample> samples = new ArrayList<>(byColumn.values());
+        samples.sort((a, b) -> Double.compare(b.volume(), a.volume()));
+        if (samples.size() > maxSamples) {
+            return List.copyOf(samples.subList(0, maxSamples));
+        }
+        return List.copyOf(samples);
+    }
+
+    public static void clear(ServerLevel level, SimulatedFluid fluidType) {
+        FluidGrid grid = getGridOrNull(level, fluidType);
         if (grid == null) {
             return;
         }
         for (Long packedPos : new ArrayList<>(grid.controlledBlocks)) {
             BlockPos pos = BlockPos.of(packedPos);
-            if (level.getBlockState(pos).is(Blocks.WATER)) {
+            if (level.getBlockState(pos).is(fluidType.block())) {
                 level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
             }
         }
@@ -124,8 +213,8 @@ public final class VolumetricFluidManager {
         grid.controlledBlocks.clear();
     }
 
-    public static int seedFromExistingWater(ServerLevel level, BlockPos center, int radius) {
-        FluidGrid grid = GRIDS.computeIfAbsent(level.dimension(), ignored -> new FluidGrid());
+    public static int seedFromExistingFluid(ServerLevel level, BlockPos center, int radius, SimulatedFluid fluidType) {
+        FluidGrid grid = getGrid(level, fluidType);
         int injected = 0;
         BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
         int minY = Math.max(level.getMinBuildHeight(), center.getY() - radius);
@@ -135,7 +224,7 @@ public final class VolumetricFluidManager {
             for (int y = minY; y <= maxY; y++) {
                 for (int z = center.getZ() - radius; z <= center.getZ() + radius; z++) {
                     cursor.set(x, y, z);
-                    if (!level.isLoaded(cursor) || level.getFluidState(cursor).getType() != Fluids.WATER) {
+                    if (!level.isLoaded(cursor) || level.getFluidState(cursor).getType() != fluidType.fluid()) {
                         continue;
                     }
                     FluidCell cell = grid.cells.computeIfAbsent(cursor.asLong(), ignored -> new FluidCell());
@@ -148,7 +237,30 @@ public final class VolumetricFluidManager {
         return injected;
     }
 
-    private static void ingestWaterNearPlayers(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config) {
+    public static SurfaceSample sampleAtPosition(ServerLevel level, BlockPos pos, SimulatedFluid fluidType) {
+        FluidGrid grid = getGrid(level, fluidType);
+        FluidCell cell = grid.cells.get(pos.asLong());
+        double volume = cell == null ? 0.0D : cell.volume;
+        double shorelineFactor = fluidType == SimulatedFluid.WATER ? computeShorelineFactor(level, pos) : 0.0D;
+        double tideOffset = 0.0D;
+        double moonPhaseFactor = 1.0D;
+        if (fluidType == SimulatedFluid.WATER) {
+            TideManager.TideSnapshot tideSnapshot = TideManager.snapshot(level);
+            tideOffset = tideSnapshot.normalizedHeight() * TideManager.getLocalAmplitude(level, pos);
+            moonPhaseFactor = TideAstronomy.getMoonPhaseAmplitudeFactor(level);
+        }
+        double surfaceY = pos.getY() + Math.max(0.0D, Math.min(1.0D, volume));
+        return new SurfaceSample(pos.getX(), pos.getZ(), surfaceY, volume, shorelineFactor, tideOffset, moonPhaseFactor, fluidType);
+    }
+
+    private static void stepFluid(ServerLevel level, SimulatedFluid fluidType, VolumetricFluidConfig.Values config) {
+        FluidGrid grid = getGrid(level, fluidType);
+        ingestFluidNearPlayers(level, grid, config, fluidType);
+        stepSimulation(level, grid, config, fluidType);
+        applyToWorld(level, grid, config, fluidType);
+    }
+
+    private static void ingestFluidNearPlayers(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config, SimulatedFluid fluidType) {
         int radius = config.playerSampleRadius();
         int step = Math.max(1, config.playerSampleStep());
         BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
@@ -161,7 +273,7 @@ public final class VolumetricFluidManager {
                 for (int y = minY; y <= maxY; y += step) {
                     for (int z = origin.getZ() - radius; z <= origin.getZ() + radius; z += step) {
                         cursor.set(x, y, z);
-                        if (!level.isLoaded(cursor) || level.getFluidState(cursor).getType() != Fluids.WATER) {
+                        if (!level.isLoaded(cursor) || level.getFluidState(cursor).getType() != fluidType.fluid()) {
                             continue;
                         }
                         FluidCell cell = grid.cells.computeIfAbsent(cursor.asLong(), ignored -> new FluidCell());
@@ -172,7 +284,7 @@ public final class VolumetricFluidManager {
         }
     }
 
-    private static void stepSimulation(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config) {
+    private static void stepSimulation(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config, SimulatedFluid fluidType) {
         if (grid.cells.isEmpty()) {
             return;
         }
@@ -203,7 +315,7 @@ public final class VolumetricFluidManager {
 
                 // gravity/downward bias
                 BlockPos below = pos.below();
-                if (below.getY() >= level.getMinBuildHeight() && isFluidPassable(level, below)) {
+                if (below.getY() >= level.getMinBuildHeight() && isFluidPassable(level, below, fluidType)) {
                     double down = Math.min(remaining, config.downwardTransfer() * (1.0D + pressure));
                     if (down > 0.0D) {
                         accumulate(volumeDelta, below.asLong(), down);
@@ -219,7 +331,7 @@ public final class VolumetricFluidManager {
                         break;
                     }
                     BlockPos sidePos = pos.relative(direction);
-                    if (!isFluidPassable(level, sidePos)) {
+                    if (!isFluidPassable(level, sidePos, fluidType)) {
                         continue;
                     }
 
@@ -258,12 +370,12 @@ public final class VolumetricFluidManager {
             }
         }
 
-        advectByVelocity(level, grid, config);
+        advectByVelocity(level, grid, config, fluidType);
         applyVelocityDamping(grid, config.inertiaDamping());
         pruneCells(grid, config.minCellVolume());
     }
 
-    private static void advectByVelocity(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config) {
+    private static void advectByVelocity(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config, SimulatedFluid fluidType) {
         Map<Long, Double> advectedVolume = new HashMap<>();
 
         for (Map.Entry<Long, FluidCell> entry : new ArrayList<>(grid.cells.entrySet())) {
@@ -285,7 +397,7 @@ public final class VolumetricFluidManager {
             if (target.getY() < level.getMinBuildHeight() || target.getY() >= level.getMaxBuildHeight()) {
                 continue;
             }
-            if (!isFluidPassable(level, target)) {
+            if (!isFluidPassable(level, target, fluidType)) {
                 continue;
             }
 
@@ -301,7 +413,7 @@ public final class VolumetricFluidManager {
         applyVolumeDelta(grid, advectedVolume, config.minCellVolume());
     }
 
-    private static void applyToWorld(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config) {
+    private static void applyToWorld(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config, SimulatedFluid fluidType) {
         Set<Long> controlledNow = new HashSet<>();
 
         for (Map.Entry<Long, FluidCell> entry : grid.cells.entrySet()) {
@@ -316,10 +428,14 @@ public final class VolumetricFluidManager {
             if (cell.volume >= config.placeThreshold()) {
                 BlockState state = level.getBlockState(pos);
                 boolean wasControlled = grid.controlledBlocks.contains(packedPos);
+                BlockState simulatedState = fluidStateForVolume(fluidType, cell.volume);
                 if (state.isAir()) {
-                    level.setBlockAndUpdate(pos, Blocks.WATER.defaultBlockState());
+                    level.setBlockAndUpdate(pos, simulatedState);
                     controlledNow.add(packedPos);
-                } else if (wasControlled && state.is(Blocks.WATER)) {
+                } else if (wasControlled && state.is(fluidType.block())) {
+                    if (!state.equals(simulatedState)) {
+                        level.setBlockAndUpdate(pos, simulatedState);
+                    }
                     controlledNow.add(packedPos);
                 }
             }
@@ -332,13 +448,24 @@ public final class VolumetricFluidManager {
                 continue;
             }
             BlockPos pos = BlockPos.of(packedPos);
-            if (level.isLoaded(pos) && level.getBlockState(pos).is(Blocks.WATER)) {
+            if (level.isLoaded(pos) && level.getBlockState(pos).is(fluidType.block())) {
                 level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
             }
         }
 
         grid.controlledBlocks.clear();
         grid.controlledBlocks.addAll(controlledNow);
+    }
+
+    private static BlockState fluidStateForVolume(SimulatedFluid fluidType, double volume) {
+        BlockState base = fluidType.block().defaultBlockState();
+        IntegerProperty flowingProperty = BlockStateProperties.LEVEL_FLOWING;
+        if (!base.hasProperty(flowingProperty)) {
+            return base;
+        }
+        // Minecraft liquid levels: 0 = full/source, 1..7 = descending heights.
+        int level = Math.max(0, Math.min(7, 7 - (int) Math.round(Math.max(0.0D, Math.min(1.0D, volume)) * 7.0D)));
+        return base.setValue(flowingProperty, level);
     }
 
     private static boolean isNearAnyPlayer(ServerLevel level, BlockPos pos, int radiusSq) {
@@ -350,12 +477,12 @@ public final class VolumetricFluidManager {
         return false;
     }
 
-    private static boolean isFluidPassable(ServerLevel level, BlockPos pos) {
+    private static boolean isFluidPassable(ServerLevel level, BlockPos pos, SimulatedFluid fluidType) {
         if (!level.isLoaded(pos)) {
             return false;
         }
         BlockState state = level.getBlockState(pos);
-        return state.isAir() || state.is(Blocks.WATER) || state.canBeReplaced();
+        return state.isAir() || state.is(fluidType.block()) || state.canBeReplaced();
     }
 
     private static void accumulate(Map<Long, Double> delta, long packedPos, double value) {
@@ -393,6 +520,19 @@ public final class VolumetricFluidManager {
         }
     }
 
+    private static FluidGrid getGrid(ServerLevel level, SimulatedFluid fluidType) {
+        Map<SimulatedFluid, FluidGrid> byFluid = GRIDS.computeIfAbsent(level.dimension(), ignored -> new ConcurrentHashMap<>());
+        return byFluid.computeIfAbsent(fluidType, ignored -> new FluidGrid());
+    }
+
+    private static FluidGrid getGridOrNull(ServerLevel level, SimulatedFluid fluidType) {
+        Map<SimulatedFluid, FluidGrid> byFluid = GRIDS.get(level.dimension());
+        if (byFluid == null) {
+            return null;
+        }
+        return byFluid.get(fluidType);
+    }
+
     private static final class FluidGrid {
         private final Map<Long, FluidCell> cells = new HashMap<>();
         private final Set<Long> controlledBlocks = new HashSet<>();
@@ -406,5 +546,59 @@ public final class VolumetricFluidManager {
     }
 
     public record SimulationSnapshot(int activeCells, int controlledBlocks, double totalVolume, double averageSpeed) {
+    }
+
+    public record SurfaceSample(int blockX,
+                                int blockZ,
+                                double surfaceY,
+                                double volume,
+                                double shorelineFactor,
+                                double tideOffset,
+                                double moonPhaseFactor,
+                                SimulatedFluid fluidType) {
+    }
+
+    private static double computeShorelineFactor(ServerLevel level, BlockPos pos) {
+        double biomeBoost = level.getBiome(pos).is(BiomeTags.IS_BEACH) ? 0.6D : 0.0D;
+        int sandHits = 0;
+        int edgeHits = 0;
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        for (Direction direction : LATERALS) {
+            cursor.setWithOffset(pos, direction);
+            if (!level.isLoaded(cursor)) {
+                continue;
+            }
+            BlockState state = level.getBlockState(cursor);
+            if (state.is(Blocks.SAND) || state.is(Blocks.RED_SAND) || state.is(Blocks.SANDSTONE)) {
+                sandHits++;
+            }
+            if (!state.isAir() && !state.liquid()) {
+                edgeHits++;
+            }
+        }
+        double sandFactor = sandHits / 4.0D;
+        double edgeFactor = edgeHits / 4.0D;
+        return Math.max(0.0D, Math.min(1.0D, biomeBoost + sandFactor * 0.6D + edgeFactor * 0.25D));
+    }
+
+    public enum SimulatedFluid {
+        WATER(Fluids.WATER, Blocks.WATER),
+        LAVA(Fluids.LAVA, Blocks.LAVA);
+
+        private final Fluid fluid;
+        private final net.minecraft.world.level.block.Block block;
+
+        SimulatedFluid(Fluid fluid, net.minecraft.world.level.block.Block block) {
+            this.fluid = fluid;
+            this.block = block;
+        }
+
+        public Fluid fluid() {
+            return fluid;
+        }
+
+        public net.minecraft.world.level.block.Block block() {
+            return block;
+        }
     }
 }

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricSurfaceMesher.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricSurfaceMesher.java
@@ -1,0 +1,146 @@
+package com.thunder.wildernessodysseyapi.watersystem.volumetric;
+
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager.SurfaceSample;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts sparse per-column fluid samples into a triangle mesh description.
+ * This is renderer-agnostic data that can be consumed by a future client shader pipeline.
+ */
+public final class VolumetricSurfaceMesher {
+
+    private VolumetricSurfaceMesher() {
+    }
+
+    public static MeshSnapshot buildMesh(List<SurfaceSample> samples, double maxEdgeDelta) {
+        if (samples == null || samples.isEmpty()) {
+            return MeshSnapshot.empty();
+        }
+
+        Map<Long, SurfaceSample> byColumn = new HashMap<>();
+        for (SurfaceSample sample : samples) {
+            byColumn.put(columnKey(sample.blockX(), sample.blockZ()), sample);
+        }
+
+        int quads = 0;
+        int triangles = 0;
+        int skipped = 0;
+        double area = 0.0D;
+
+        for (SurfaceSample sample : samples) {
+            SurfaceSample east = byColumn.get(columnKey(sample.blockX() + 1, sample.blockZ()));
+            SurfaceSample south = byColumn.get(columnKey(sample.blockX(), sample.blockZ() + 1));
+            SurfaceSample southEast = byColumn.get(columnKey(sample.blockX() + 1, sample.blockZ() + 1));
+
+            if (east == null || south == null || southEast == null) {
+                skipped++;
+                continue;
+            }
+
+            double max = Math.max(Math.max(sample.surfaceY(), east.surfaceY()), Math.max(south.surfaceY(), southEast.surfaceY()));
+            double min = Math.min(Math.min(sample.surfaceY(), east.surfaceY()), Math.min(south.surfaceY(), southEast.surfaceY()));
+            if ((max - min) > maxEdgeDelta) {
+                skipped++;
+                continue;
+            }
+
+            quads++;
+            triangles += 2;
+            area += estimateQuadArea(sample, east, south, southEast);
+        }
+
+        return new MeshSnapshot(samples.size(), quads, triangles, skipped, area);
+    }
+
+    public static List<Triangle> buildTriangles(List<SurfaceSample> samples, double maxEdgeDelta) {
+        if (samples == null || samples.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, SurfaceSample> byColumn = new HashMap<>();
+        for (SurfaceSample sample : samples) {
+            byColumn.put(columnKey(sample.blockX(), sample.blockZ()), sample);
+        }
+
+        List<Triangle> triangles = new ArrayList<>();
+        for (SurfaceSample sample : samples) {
+            SurfaceSample east = byColumn.get(columnKey(sample.blockX() + 1, sample.blockZ()));
+            SurfaceSample south = byColumn.get(columnKey(sample.blockX(), sample.blockZ() + 1));
+            SurfaceSample southEast = byColumn.get(columnKey(sample.blockX() + 1, sample.blockZ() + 1));
+            if (east == null || south == null || southEast == null) {
+                continue;
+            }
+
+            double max = Math.max(Math.max(sample.surfaceY(), east.surfaceY()), Math.max(south.surfaceY(), southEast.surfaceY()));
+            double min = Math.min(Math.min(sample.surfaceY(), east.surfaceY()), Math.min(south.surfaceY(), southEast.surfaceY()));
+            if ((max - min) > maxEdgeDelta) {
+                continue;
+            }
+
+            Vertex v0 = vertex(sample);
+            Vertex v1 = vertex(east);
+            Vertex v2 = vertex(south);
+            Vertex v3 = vertex(southEast);
+
+            triangles.add(new Triangle(v0, v1, v3));
+            triangles.add(new Triangle(v0, v3, v2));
+        }
+
+        return List.copyOf(triangles);
+    }
+
+    private static Vertex vertex(SurfaceSample sample) {
+        return new Vertex(
+                sample.blockX() + 0.5D,
+                sample.surfaceY() + sample.tideOffset(),
+                sample.blockZ() + 0.5D,
+                sample.volume(),
+                sample.shorelineFactor(),
+                sample.moonPhaseFactor()
+        );
+    }
+
+    private static double estimateQuadArea(SurfaceSample a, SurfaceSample b, SurfaceSample c, SurfaceSample d) {
+        Vertex v0 = vertex(a);
+        Vertex v1 = vertex(b);
+        Vertex v2 = vertex(c);
+        Vertex v3 = vertex(d);
+        return triangleArea(v0, v1, v3) + triangleArea(v0, v3, v2);
+    }
+
+    private static double triangleArea(Vertex a, Vertex b, Vertex c) {
+        double abX = b.x() - a.x();
+        double abY = b.y() - a.y();
+        double abZ = b.z() - a.z();
+
+        double acX = c.x() - a.x();
+        double acY = c.y() - a.y();
+        double acZ = c.z() - a.z();
+
+        double crossX = abY * acZ - abZ * acY;
+        double crossY = abZ * acX - abX * acZ;
+        double crossZ = abX * acY - abY * acX;
+
+        return 0.5D * Math.sqrt(crossX * crossX + crossY * crossY + crossZ * crossZ);
+    }
+
+    private static long columnKey(int x, int z) {
+        return (((long) x) << 32) ^ (z & 0xffffffffL);
+    }
+
+    public record MeshSnapshot(int sampleCount, int quads, int triangles, int skippedColumns, double estimatedArea) {
+        public static MeshSnapshot empty() {
+            return new MeshSnapshot(0, 0, 0, 0, 0.0D);
+        }
+    }
+
+    public record Vertex(double x, double y, double z, double volume, double shorelineFactor, double moonPhaseFactor) {
+    }
+
+    public record Triangle(Vertex a, Vertex b, Vertex c) {
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricFluidRenderConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricFluidRenderConfig.java
@@ -1,0 +1,63 @@
+package com.thunder.wildernessodysseyapi.watersystem.volumetric.client;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+/**
+ * Client-only controls for volumetric surface preview rendering.
+ */
+public final class VolumetricFluidRenderConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+
+    public static final ModConfigSpec.BooleanValue ENABLE_PREVIEW_RENDERER;
+    public static final ModConfigSpec.IntValue MAX_TRIANGLES_PER_FLUID;
+    public static final ModConfigSpec.IntValue MAX_RENDER_DISTANCE;
+    public static final ModConfigSpec.IntValue MAX_STALE_AGE_TICKS;
+    public static final ModConfigSpec.DoubleValue WAVE_STRENGTH;
+    public static final ModConfigSpec.DoubleValue FOAM_STRENGTH;
+    public static final ModConfigSpec.IntValue WATER_ALPHA;
+    public static final ModConfigSpec.IntValue LAVA_ALPHA;
+
+    private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
+
+    static {
+        BUILDER.push("volumetricFluidRenderer");
+
+        ENABLE_PREVIEW_RENDERER = BUILDER
+                .comment("Enable first-pass volumetric mesh preview rendering for synced water/lava surfaces.")
+                .define("enablePreviewRenderer", true);
+
+        MAX_TRIANGLES_PER_FLUID = BUILDER
+                .comment("Hard cap for rendered triangles per fluid type.")
+                .defineInRange("maxTrianglesPerFluid", 6000, 500, 40000);
+
+        MAX_RENDER_DISTANCE = BUILDER
+                .comment("Maximum camera distance (blocks) to render fluid triangles.")
+                .defineInRange("maxRenderDistance", 96, 16, 256);
+
+        MAX_STALE_AGE_TICKS = BUILDER
+                .comment("Skip rendering if no fresh sync packet was received in this many ticks.")
+                .defineInRange("maxStaleAgeTicks", 160, 20, 2000);
+
+        WAVE_STRENGTH = BUILDER
+                .comment("Simple sinusoidal wave amplitude applied to preview vertices.")
+                .defineInRange("waveStrength", 0.03D, 0.0D, 0.25D);
+
+        FOAM_STRENGTH = BUILDER
+                .comment("How strongly steep slopes brighten towards foam color.")
+                .defineInRange("foamStrength", 0.55D, 0.0D, 1.0D);
+
+        WATER_ALPHA = BUILDER
+                .comment("Alpha channel for water preview mesh.")
+                .defineInRange("waterAlpha", 120, 10, 255);
+
+        LAVA_ALPHA = BUILDER
+                .comment("Alpha channel for lava preview mesh.")
+                .defineInRange("lavaAlpha", 140, 10, 255);
+
+        BUILDER.pop();
+        CONFIG_SPEC = BUILDER.build();
+    }
+
+    private VolumetricFluidRenderConfig() {
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceClientCache.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceClientCache.java
@@ -1,0 +1,75 @@
+package com.thunder.wildernessodysseyapi.watersystem.volumetric.client;
+
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager.SimulatedFluid;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager.SurfaceSample;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Client-side cache for synchronized volumetric fluid surface samples.
+ */
+public final class VolumetricSurfaceClientCache {
+    private static final Map<ResourceLocation, Map<SimulatedFluid, Map<Long, SurfaceSample>>> CACHE_BY_DIMENSION = new ConcurrentHashMap<>();
+    private static volatile long lastUpdateGameTime;
+
+    private VolumetricSurfaceClientCache() {
+    }
+
+    public static void replace(ResourceLocation dimensionId, SimulatedFluid fluidType, List<SurfaceSample> samples, long gameTime) {
+        Map<Long, SurfaceSample> map = getOrCreateFluidMap(dimensionId, fluidType);
+        map.clear();
+        for (SurfaceSample sample : samples) {
+            map.put(columnKey(sample.blockX(), sample.blockZ()), sample);
+        }
+        lastUpdateGameTime = gameTime;
+    }
+
+    public static List<SurfaceSample> snapshot(ResourceLocation dimensionId, SimulatedFluid fluidType) {
+        Map<Long, SurfaceSample> fluidMap = getFluidMapOrNull(dimensionId, fluidType);
+        if (fluidMap == null) {
+            return List.of();
+        }
+        return new ArrayList<>(fluidMap.values());
+    }
+
+    public static int size(ResourceLocation dimensionId, SimulatedFluid fluidType) {
+        Map<Long, SurfaceSample> fluidMap = getFluidMapOrNull(dimensionId, fluidType);
+        return fluidMap == null ? 0 : fluidMap.size();
+    }
+
+    public static long lastUpdateGameTime() {
+        return lastUpdateGameTime;
+    }
+
+    public static boolean isStale(long currentGameTime, int maxStaleAgeTicks) {
+        return (currentGameTime - lastUpdateGameTime) > maxStaleAgeTicks;
+    }
+
+    public static void clearAll() {
+        CACHE_BY_DIMENSION.clear();
+    }
+
+    private static long columnKey(int x, int z) {
+        return (((long) x) << 32) ^ (z & 0xffffffffL);
+    }
+
+    private static Map<Long, SurfaceSample> getOrCreateFluidMap(ResourceLocation dimensionId, SimulatedFluid fluidType) {
+        Map<SimulatedFluid, Map<Long, SurfaceSample>> byFluid = CACHE_BY_DIMENSION.computeIfAbsent(
+                dimensionId, ignored -> new EnumMap<>(SimulatedFluid.class)
+        );
+        return byFluid.computeIfAbsent(fluidType, ignored -> new ConcurrentHashMap<>());
+    }
+
+    private static Map<Long, SurfaceSample> getFluidMapOrNull(ResourceLocation dimensionId, SimulatedFluid fluidType) {
+        Map<SimulatedFluid, Map<Long, SurfaceSample>> byFluid = CACHE_BY_DIMENSION.get(dimensionId);
+        if (byFluid == null) {
+            return null;
+        }
+        return byFluid.get(fluidType);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceClientEvents.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceClientEvents.java
@@ -1,0 +1,21 @@
+package com.thunder.wildernessodysseyapi.watersystem.volumetric.client;
+
+import com.thunder.wildernessodysseyapi.core.ModConstants;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+
+/**
+ * Lifecycle hooks for surface cache maintenance.
+ */
+@EventBusSubscriber(modid = ModConstants.MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.GAME)
+public final class VolumetricSurfaceClientEvents {
+    private VolumetricSurfaceClientEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event) {
+        VolumetricSurfaceClientCache.clearAll();
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceRenderTypes.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceRenderTypes.java
@@ -1,0 +1,63 @@
+package com.thunder.wildernessodysseyapi.watersystem.volumetric.client;
+
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.RenderStateShard;
+import net.minecraft.client.renderer.RenderType;
+
+/**
+ * Custom render types for volumetric preview surfaces.
+ */
+public final class VolumetricSurfaceRenderTypes {
+    private static final RenderType WATER_SURFACE = RenderType.create(
+            "wildernessodysseyapi_volumetric_water",
+            DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP,
+            VertexFormat.Mode.TRIANGLES,
+            262_144,
+            false,
+            true,
+            RenderType.CompositeState.builder()
+                    .setShaderState(new RenderStateShard.ShaderStateShard(() -> {
+                        if (VolumetricSurfaceShaders.waterShader() != null) {
+                            return VolumetricSurfaceShaders.waterShader();
+                        }
+                        return GameRenderer.getPositionColorTexLightmapShader();
+                    }))
+                    .setTransparencyState(RenderType.TRANSLUCENT_TRANSPARENCY)
+                    .setLightmapState(RenderType.LIGHTMAP)
+                    .setCullState(RenderType.NO_CULL)
+                    .createCompositeState(true)
+    );
+
+    private static final RenderType LAVA_SURFACE = RenderType.create(
+            "wildernessodysseyapi_volumetric_lava",
+            DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP,
+            VertexFormat.Mode.TRIANGLES,
+            262_144,
+            false,
+            true,
+            RenderType.CompositeState.builder()
+                    .setShaderState(new RenderStateShard.ShaderStateShard(() -> {
+                        if (VolumetricSurfaceShaders.lavaShader() != null) {
+                            return VolumetricSurfaceShaders.lavaShader();
+                        }
+                        return GameRenderer.getPositionColorTexLightmapShader();
+                    }))
+                    .setTransparencyState(RenderType.TRANSLUCENT_TRANSPARENCY)
+                    .setLightmapState(RenderType.LIGHTMAP)
+                    .setCullState(RenderType.NO_CULL)
+                    .createCompositeState(true)
+    );
+
+    private VolumetricSurfaceRenderTypes() {
+    }
+
+    public static RenderType waterSurface() {
+        return WATER_SURFACE;
+    }
+
+    public static RenderType lavaSurface() {
+        return LAVA_SURFACE;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceRenderer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceRenderer.java
@@ -1,0 +1,195 @@
+package com.thunder.wildernessodysseyapi.watersystem.volumetric.client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.thunder.wildernessodysseyapi.core.ModConstants;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager.SimulatedFluid;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricSurfaceMesher;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricSurfaceMesher.Triangle;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricSurfaceMesher.Vertex;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import org.joml.Matrix4f;
+
+import java.util.List;
+
+/**
+ * First-pass client preview renderer for synced volumetric fluid surfaces.
+ */
+@EventBusSubscriber(modid = ModConstants.MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.GAME)
+public final class VolumetricSurfaceRenderer {
+    private static final double MAX_EDGE_DELTA = 1.5D;
+
+    private VolumetricSurfaceRenderer() {
+    }
+
+    @SubscribeEvent
+    public static void onRenderLevelStage(RenderLevelStageEvent event) {
+        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
+            return;
+        }
+
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.level == null || minecraft.player == null) {
+            return;
+        }
+        if (!VolumetricFluidRenderConfig.ENABLE_PREVIEW_RENDERER.get()) {
+            return;
+        }
+
+        PoseStack poseStack = event.getPoseStack();
+        Vec3 camera = event.getCamera().getPosition();
+        MultiBufferSource.BufferSource bufferSource = minecraft.renderBuffers().bufferSource();
+        VertexConsumer waterConsumer = bufferSource.getBuffer(VolumetricSurfaceRenderTypes.waterSurface());
+        VertexConsumer lavaConsumer = bufferSource.getBuffer(VolumetricSurfaceRenderTypes.lavaSurface());
+        Matrix4f pose = poseStack.last().pose();
+
+        double time = minecraft.level.getGameTime();
+        int maxTrianglesPerFluid = VolumetricFluidRenderConfig.MAX_TRIANGLES_PER_FLUID.get();
+        int maxRenderDistance = VolumetricFluidRenderConfig.MAX_RENDER_DISTANCE.get();
+        double maxRenderDistanceSq = maxRenderDistance * (double) maxRenderDistance;
+        double waveStrength = VolumetricFluidRenderConfig.WAVE_STRENGTH.get();
+        double foamStrength = VolumetricFluidRenderConfig.FOAM_STRENGTH.get();
+
+        if (VolumetricSurfaceClientCache.isStale((long) time, VolumetricFluidRenderConfig.MAX_STALE_AGE_TICKS.get())) {
+            return;
+        }
+
+        renderFluid(
+                VolumetricSurfaceMesher.buildTriangles(
+                        VolumetricSurfaceClientCache.snapshot(minecraft.level.dimension().location(), SimulatedFluid.WATER), MAX_EDGE_DELTA),
+                waterConsumer,
+                pose,
+                camera,
+                time,
+                maxTrianglesPerFluid,
+                maxRenderDistanceSq,
+                waveStrength,
+                foamStrength,
+                55,
+                130,
+                220,
+                VolumetricFluidRenderConfig.WATER_ALPHA.get()
+        );
+
+        renderFluid(
+                VolumetricSurfaceMesher.buildTriangles(
+                        VolumetricSurfaceClientCache.snapshot(minecraft.level.dimension().location(), SimulatedFluid.LAVA), MAX_EDGE_DELTA),
+                lavaConsumer,
+                pose,
+                camera,
+                time,
+                maxTrianglesPerFluid,
+                maxRenderDistanceSq,
+                waveStrength,
+                foamStrength,
+                255,
+                120,
+                40,
+                VolumetricFluidRenderConfig.LAVA_ALPHA.get()
+        );
+
+        bufferSource.endBatch(VolumetricSurfaceRenderTypes.waterSurface());
+        bufferSource.endBatch(VolumetricSurfaceRenderTypes.lavaSurface());
+    }
+
+    private static void renderFluid(List<Triangle> triangles,
+                                    VertexConsumer consumer,
+                                    Matrix4f pose,
+                                    Vec3 camera,
+                                    double time,
+                                    int maxTrianglesPerFluid,
+                                    double maxRenderDistanceSq,
+                                    double waveStrength,
+                                    double foamStrength,
+                                    int red,
+                                    int green,
+                                    int blue,
+                                    int alpha) {
+        int rendered = 0;
+        for (Triangle triangle : triangles) {
+            if (rendered++ >= maxTrianglesPerFluid) {
+                break;
+            }
+            if (!isTriangleNearCamera(triangle, camera, maxRenderDistanceSq)) {
+                continue;
+            }
+            float foam = foamIntensity(triangle, foamStrength);
+            addVertex(consumer, pose, triangle.a(), camera, time, waveStrength, foam, red, green, blue, alpha);
+            addVertex(consumer, pose, triangle.b(), camera, time, waveStrength, foam, red, green, blue, alpha);
+            addVertex(consumer, pose, triangle.c(), camera, time, waveStrength, foam, red, green, blue, alpha);
+        }
+    }
+
+    private static boolean isTriangleNearCamera(Triangle triangle, Vec3 camera, double maxRenderDistanceSq) {
+        double cx = (triangle.a().x() + triangle.b().x() + triangle.c().x()) / 3.0D;
+        double cy = (triangle.a().y() + triangle.b().y() + triangle.c().y()) / 3.0D;
+        double cz = (triangle.a().z() + triangle.b().z() + triangle.c().z()) / 3.0D;
+        double dx = cx - camera.x;
+        double dy = cy - camera.y;
+        double dz = cz - camera.z;
+        return (dx * dx + dy * dy + dz * dz) <= maxRenderDistanceSq;
+    }
+
+    private static void addVertex(VertexConsumer consumer,
+                                  Matrix4f pose,
+                                  Vertex vertex,
+                                  Vec3 camera,
+                                  double time,
+                                  double waveStrength,
+                                  float foam,
+                                  int red,
+                                  int green,
+                                  int blue,
+                                  int alpha) {
+        float x = (float) (vertex.x() - camera.x);
+        float z = (float) (vertex.z() - camera.z);
+        double beachBoost = 1.0D + (vertex.shorelineFactor() * 1.25D);
+        double moonBoost = Math.max(0.75D, Math.min(1.3D, vertex.moonPhaseFactor()));
+        float wave = (float) (Math.sin((vertex.x() * 0.65D) + (vertex.z() * 0.35D) + (time * 0.07D))
+                * waveStrength * beachBoost * moonBoost);
+        float y = (float) (vertex.y() - camera.y + wave);
+        int shadedRed = shadeWithFoam(red, foam);
+        int shadedGreen = shadeWithFoam(green, foam);
+        int shadedBlue = shadeWithFoam(blue, foam);
+
+        consumer.addVertex(pose, x, y, z)
+                .setColor(shadedRed, shadedGreen, shadedBlue, alpha)
+                .setUv(0.0F, 0.0F)
+                .setLight(0x00F000F0);
+    }
+
+    private static int shadeWithFoam(int baseChannel, float foam) {
+        float blended = (baseChannel / 255.0F) * (1.0F - foam) + foam;
+        return Math.max(0, Math.min(255, Math.round(blended * 255.0F)));
+    }
+
+    private static float foamIntensity(Triangle triangle, double foamStrength) {
+        double ux = triangle.b().x() - triangle.a().x();
+        double uy = triangle.b().y() - triangle.a().y();
+        double uz = triangle.b().z() - triangle.a().z();
+
+        double vx = triangle.c().x() - triangle.a().x();
+        double vy = triangle.c().y() - triangle.a().y();
+        double vz = triangle.c().z() - triangle.a().z();
+
+        double nx = uy * vz - uz * vy;
+        double ny = uz * vx - ux * vz;
+        double nz = ux * vy - uy * vx;
+
+        double len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+        if (len <= 1.0E-6D) {
+            return 0.0F;
+        }
+        double upward = Math.abs(ny / len);
+        double steepness = 1.0D - upward;
+        double shoreline = (triangle.a().shorelineFactor() + triangle.b().shorelineFactor() + triangle.c().shorelineFactor()) / 3.0D;
+        double foam = (steepness * foamStrength) + (shoreline * 0.25D);
+        return (float) Math.max(0.0D, Math.min(1.0D, foam));
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceShaders.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceShaders.java
@@ -1,0 +1,43 @@
+package com.thunder.wildernessodysseyapi.watersystem.volumetric.client;
+
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.thunder.wildernessodysseyapi.core.ModConstants;
+import net.minecraft.client.renderer.ShaderInstance;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RegisterShadersEvent;
+
+import java.io.IOException;
+
+/**
+ * Registers custom volumetric fluid shaders.
+ */
+@EventBusSubscriber(modid = ModConstants.MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+public final class VolumetricSurfaceShaders {
+    public static final ResourceLocation WATER_SHADER = ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "core/volumetric_surface_water");
+    public static final ResourceLocation LAVA_SHADER = ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "core/volumetric_surface_lava");
+
+    private static ShaderInstance waterShader;
+    private static ShaderInstance lavaShader;
+
+    private VolumetricSurfaceShaders() {
+    }
+
+    @SubscribeEvent
+    public static void onRegisterShaders(RegisterShadersEvent event) throws IOException {
+        event.registerShader(new ShaderInstance(event.getResourceProvider(), WATER_SHADER, DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP),
+                shader -> waterShader = shader);
+        event.registerShader(new ShaderInstance(event.getResourceProvider(), LAVA_SHADER, DefaultVertexFormat.POSITION_COLOR_TEX_LIGHTMAP),
+                shader -> lavaShader = shader);
+    }
+
+    public static ShaderInstance waterShader() {
+        return waterShader;
+    }
+
+    public static ShaderInstance lavaShader() {
+        return lavaShader;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/network/VolumetricSurfaceSyncManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/network/VolumetricSurfaceSyncManager.java
@@ -1,0 +1,54 @@
+package com.thunder.wildernessodysseyapi.watersystem.volumetric.network;
+
+import com.thunder.wildernessodysseyapi.core.ModConstants;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager.SimulatedFluid;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager.SurfaceSample;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+import java.util.List;
+
+/**
+ * Periodically ships compact surface samples to clients for mesh rendering.
+ */
+@EventBusSubscriber(modid = ModConstants.MOD_ID)
+public final class VolumetricSurfaceSyncManager {
+    private static final int SYNC_INTERVAL_TICKS = 4;
+    private static final int SAMPLE_RADIUS = 40;
+    private static final int MAX_SAMPLES_PER_FLUID = 2048;
+
+    private VolumetricSurfaceSyncManager() {
+    }
+
+    @SubscribeEvent
+    public static void onServerTick(ServerTickEvent.Post event) {
+        if (!event.hasTime()) {
+            return;
+        }
+
+        long gameTime = event.getServer().getTickCount();
+        if (gameTime % SYNC_INTERVAL_TICKS != 0L) {
+            return;
+        }
+
+        for (ServerLevel level : event.getServer().getAllLevels()) {
+            for (ServerPlayer player : level.players()) {
+                BlockPos center = player.blockPosition();
+                var water = VolumetricFluidManager.sampleSurface(level, SimulatedFluid.WATER, center, SAMPLE_RADIUS, MAX_SAMPLES_PER_FLUID);
+                var lava = VolumetricFluidManager.isLavaSimulationEnabled()
+                        ? VolumetricFluidManager.sampleSurface(level, SimulatedFluid.LAVA, center, SAMPLE_RADIUS, MAX_SAMPLES_PER_FLUID)
+                        : List.<SurfaceSample>of();
+                if (water.isEmpty() && lava.isEmpty()) {
+                    continue;
+                }
+                PacketDistributor.sendToPlayer(player, new VolumetricSurfaceSyncPayload(level.dimension().location(), gameTime, water, lava));
+            }
+        }
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/network/VolumetricSurfaceSyncPayload.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/network/VolumetricSurfaceSyncPayload.java
@@ -1,0 +1,92 @@
+package com.thunder.wildernessodysseyapi.watersystem.volumetric.network;
+
+import com.thunder.wildernessodysseyapi.core.ModConstants;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager.SimulatedFluid;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.VolumetricFluidManager.SurfaceSample;
+import com.thunder.wildernessodysseyapi.watersystem.volumetric.client.VolumetricSurfaceClientCache;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Server -> client payload containing sampled surfaces for water/lava mesh reconstruction.
+ */
+public record VolumetricSurfaceSyncPayload(
+        ResourceLocation dimensionId,
+        long gameTime,
+        List<SurfaceSample> waterSamples,
+        List<SurfaceSample> lavaSamples
+) implements CustomPacketPayload {
+
+    public static final Type<VolumetricSurfaceSyncPayload> TYPE = new Type<>(
+            ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "volumetric_surface_sync")
+    );
+
+    public static final StreamCodec<FriendlyByteBuf, VolumetricSurfaceSyncPayload> STREAM_CODEC = StreamCodec.of(
+            VolumetricSurfaceSyncPayload::encode,
+            VolumetricSurfaceSyncPayload::decode
+    );
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    private static void encode(FriendlyByteBuf buf, VolumetricSurfaceSyncPayload payload) {
+        buf.writeResourceLocation(payload.dimensionId);
+        buf.writeVarLong(payload.gameTime);
+        writeSamples(buf, payload.waterSamples);
+        writeSamples(buf, payload.lavaSamples);
+    }
+
+    private static VolumetricSurfaceSyncPayload decode(FriendlyByteBuf buf) {
+        ResourceLocation dimensionId = buf.readResourceLocation();
+        long gameTime = buf.readVarLong();
+        List<SurfaceSample> water = readSamples(buf, SimulatedFluid.WATER);
+        List<SurfaceSample> lava = readSamples(buf, SimulatedFluid.LAVA);
+        return new VolumetricSurfaceSyncPayload(dimensionId, gameTime, water, lava);
+    }
+
+    private static void writeSamples(FriendlyByteBuf buf, List<SurfaceSample> samples) {
+        buf.writeVarInt(samples.size());
+        for (SurfaceSample sample : samples) {
+            buf.writeVarInt(sample.blockX());
+            buf.writeVarInt(sample.blockZ());
+            buf.writeFloat((float) sample.surfaceY());
+            buf.writeFloat((float) sample.volume());
+            buf.writeFloat((float) sample.shorelineFactor());
+            buf.writeFloat((float) sample.tideOffset());
+            buf.writeFloat((float) sample.moonPhaseFactor());
+        }
+    }
+
+    private static List<SurfaceSample> readSamples(FriendlyByteBuf buf, SimulatedFluid fluidType) {
+        int size = Math.max(0, buf.readVarInt());
+        List<SurfaceSample> samples = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            int x = buf.readVarInt();
+            int z = buf.readVarInt();
+            double y = buf.readFloat();
+            double volume = buf.readFloat();
+            double shorelineFactor = buf.readFloat();
+            double tideOffset = buf.readFloat();
+            double moonPhaseFactor = buf.readFloat();
+            samples.add(new SurfaceSample(x, z, y, volume, shorelineFactor, tideOffset, moonPhaseFactor, fluidType));
+        }
+        return samples;
+    }
+
+    public static void handle(VolumetricSurfaceSyncPayload payload, IPayloadContext context) {
+        context.enqueueWork(() -> {
+            if (context.player().level().dimension().location().equals(payload.dimensionId)) {
+                VolumetricSurfaceClientCache.replace(payload.dimensionId, SimulatedFluid.WATER, payload.waterSamples, payload.gameTime);
+                VolumetricSurfaceClientCache.replace(payload.dimensionId, SimulatedFluid.LAVA, payload.lavaSamples, payload.gameTime);
+            }
+        });
+    }
+}

--- a/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_lava.fsh
+++ b/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_lava.fsh
@@ -1,0 +1,23 @@
+#version 150
+
+in vec4 vertexColor;
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+uniform float GameTime;
+
+void main() {
+    float flow = 0.5 + 0.5 * sin((texCoord.x * 18.0) + (GameTime * 0.9));
+    float flow2 = 0.5 + 0.5 * sin((texCoord.y * 22.0) - (GameTime * 1.1));
+    float pattern = clamp((flow * 0.6 + flow2 * 0.4), 0.0, 1.0);
+
+    vec3 cool = vec3(0.34, 0.08, 0.02);
+    vec3 hot = vec3(1.0, 0.55, 0.06);
+    vec3 lavaColor = mix(cool, hot, pattern);
+
+    float rim = pow(1.0 - clamp(abs(texCoord.x - 0.5) * 2.0, 0.0, 1.0), 1.8);
+    vec3 emissive = lavaColor + vec3(0.15, 0.05, 0.0) * rim;
+
+    fragColor = vec4(emissive, vertexColor.a);
+}

--- a/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_lava.json
+++ b/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_lava.json
@@ -1,0 +1,21 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "wildernessodysseyapi:core/volumetric_surface_lava",
+  "fragment": "wildernessodysseyapi:core/volumetric_surface_lava",
+  "attributes": [
+    "Position",
+    "Color",
+    "UV0",
+    "UV2"
+  ],
+  "samplers": [],
+  "uniforms": [
+    { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] },
+    { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] },
+    { "name": "GameTime", "type": "float", "count": 1, "values": [0.0] }
+  ]
+}

--- a/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_lava.vsh
+++ b/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_lava.vsh
@@ -1,0 +1,18 @@
+#version 150
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+out vec4 vertexColor;
+out vec2 texCoord;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+    vertexColor = Color;
+    texCoord = UV0;
+}

--- a/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_water.fsh
+++ b/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_water.fsh
@@ -1,0 +1,18 @@
+#version 150
+
+in vec4 vertexColor;
+in vec2 texCoord;
+
+out vec4 fragColor;
+
+uniform float GameTime;
+
+void main() {
+    float fresnel = pow(1.0 - clamp(abs(texCoord.y - 0.5) * 2.0, 0.0, 1.0), 2.2);
+    float ripple = 0.5 + 0.5 * sin((texCoord.x + texCoord.y + GameTime * 0.2) * 24.0);
+    vec3 deepColor = vec3(0.08, 0.24, 0.52);
+    vec3 shallowColor = vec3(0.14, 0.55, 0.78);
+    vec3 waterColor = mix(deepColor, shallowColor, ripple * 0.35 + 0.35);
+    vec3 finalRgb = mix(waterColor, vec3(0.95, 0.98, 1.0), fresnel * 0.7);
+    fragColor = vec4(finalRgb, vertexColor.a);
+}

--- a/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_water.json
+++ b/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_water.json
@@ -1,0 +1,21 @@
+{
+  "blend": {
+    "func": "add",
+    "srcrgb": "srcalpha",
+    "dstrgb": "1-srcalpha"
+  },
+  "vertex": "wildernessodysseyapi:core/volumetric_surface_water",
+  "fragment": "wildernessodysseyapi:core/volumetric_surface_water",
+  "attributes": [
+    "Position",
+    "Color",
+    "UV0",
+    "UV2"
+  ],
+  "samplers": [],
+  "uniforms": [
+    { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] },
+    { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1] },
+    { "name": "GameTime", "type": "float", "count": 1, "values": [0.0] }
+  ]
+}

--- a/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_water.vsh
+++ b/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_water.vsh
@@ -1,0 +1,18 @@
+#version 150
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+
+out vec4 vertexColor;
+out vec2 texCoord;
+
+void main() {
+    gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
+    vertexColor = Color;
+    texCoord = UV0;
+}


### PR DESCRIPTION
### Motivation

- Replace block-placement visuals with a mesh-based volumetric fluid surface pipeline for richer water and lava visuals and client-side previewing.
- Extend the existing sparse volumetric water simulation to optionally simulate and replace vanilla lava behavior alongside water.

### Description

- Introduces multi-fluid support with `SimulatedFluid` and refactors grids to `Map<SimulatedFluid, FluidGrid>`; adds lava enable/replace toggles in `VolumetricFluidConfig` and helper accessors in `VolumetricFluidManager`.
- Adds sampling and surface generation: `VolumetricFluidManager.sampleSurface`, `sampleAtPosition`, shoreline/tide/moon-phase math, and `VolumetricSurfaceMesher` to convert column samples into triangle meshes and mesh statistics.
- Adds server->client sync and client cache: `VolumetricSurfaceSyncManager`, `VolumetricSurfaceSyncPayload`, and `VolumetricSurfaceClientCache` with payload registration in the main mod class.
- Adds client preview renderer and shader pipeline scaffolding: `VolumetricSurfaceRenderer`, `VolumetricSurfaceShaders`, `VolumetricSurfaceRenderTypes`, shader assets under `assets/.../shaders/core/*`, and client config `VolumetricFluidRenderConfig` for tuning preview rendering.
- Updates command surface `VolumetricFluidCommand` to support fluid-specific `seed`/`clear` and adds `volfluid tide` debug output that prints sampled tide/moon/shoreline values.
- Applies vanilla liquid interception for both water and lava via `LiquidBlockVolumetricMixin` (respecting config flags) and implements world-apply logic with proper `BlockState` level mapping.

### Testing

- Ran a full project build with `./gradlew build` which completed successfully.
- Executed `./gradlew test` (unit test suite) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb543edc8c8328b481f410538d410e)