### PR TITLE
Fix volumetric shader resource locations

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceShaders.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceShaders.java
@@ -16,8 +16,8 @@ import java.io.IOException;
  */
 @EventBusSubscriber(modid = ModConstants.MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
 public final class VolumetricSurfaceShaders {
-    public static final ResourceLocation WATER_SHADER = ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "core/volumetric_surface_water");
-    public static final ResourceLocation LAVA_SHADER = ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "core/volumetric_surface_lava");
+    public static final ResourceLocation WATER_SHADER = ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "volumetric_surface_water");
+    public static final ResourceLocation LAVA_SHADER = ResourceLocation.fromNamespaceAndPath(ModConstants.MOD_ID, "volumetric_surface_lava");
 
     private static ShaderInstance waterShader;
     private static ShaderInstance lavaShader;


### PR DESCRIPTION
### Motivation
- Fix a startup shader registration failure where shader lookups were requesting `shaders/core/core/...` (causing `FileNotFoundException`) due to a duplicated `core/` segment in the resource IDs.

### Description
- Update the `WATER_SHADER` and `LAVA_SHADER` `ResourceLocation`s in `VolumetricSurfaceShaders` from `"core/volumetric_surface_*"` to `"volumetric_surface_*"` so the engine resolves `assets/<modid>/shaders/core/volumetric_surface_*.json` correctly.

### Testing
- Ran `./gradlew -q compileJava`, which could not complete in this environment because the build failed while downloading Mojang metadata with an SSL certificate error (`PKIX path building failed`), so compilation could not be fully verified but the change is a small resource-path correction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc82618a6083288269b1c279983e60)