### PR TITLE
Fix volumetric surface shader path resolution

### DIFF
--- a/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_lava.json
+++ b/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_lava.json
@@ -4,8 +4,8 @@
     "srcrgb": "srcalpha",
     "dstrgb": "1-srcalpha"
   },
-  "vertex": "wildernessodysseyapi:core/volumetric_surface_lava",
-  "fragment": "wildernessodysseyapi:core/volumetric_surface_lava",
+  "vertex": "wildernessodysseyapi:volumetric_surface_lava",
+  "fragment": "wildernessodysseyapi:volumetric_surface_lava",
   "attributes": [
     "Position",
     "Color",

--- a/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_water.json
+++ b/src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_water.json
@@ -4,8 +4,8 @@
     "srcrgb": "srcalpha",
     "dstrgb": "1-srcalpha"
   },
-  "vertex": "wildernessodysseyapi:core/volumetric_surface_water",
-  "fragment": "wildernessodysseyapi:core/volumetric_surface_water",
+  "vertex": "wildernessodysseyapi:volumetric_surface_water",
+  "fragment": "wildernessodysseyapi:volumetric_surface_water",
   "attributes": [
     "Position",
     "Color",


### PR DESCRIPTION
### Motivation
- The mod failed during shader registration with `FileNotFoundException` because shader stage locations were resolved as `shaders/core/core/*.vsh|*.fsh` due to an extra `core/` path segment in the JSON program identifiers. 
- This caused resource-loading errors during `RegisterShadersEvent` and removed selected resourcepacks at runtime.

### Description
- Updated `vertex` and `fragment` entries in `src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_water.json` to use `"wildernessodysseyapi:volumetric_surface_water"` instead of `"wildernessodysseyapi:core/volumetric_surface_water"`.
- Updated `vertex` and `fragment` entries in `src/main/resources/assets/wildernessodysseyapi/shaders/core/volumetric_surface_lava.json` to use `"wildernessodysseyapi:volumetric_surface_lava"` instead of `"wildernessodysseyapi:core/volumetric_surface_lava"`.
- The change ensures shader stages are resolved relative to `assets/<modid>/shaders/core/` and prevents the duplicate `core/` lookup.

### Testing
- Ran `./gradlew -q processResources` and it completed successfully. 
- Confirmed the modified JSON files are syntactically unchanged except for the `vertex`/`fragment` identifier corrections and no further resource processing errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc91012bcc8328a2884a3cef4ecd36)