### PR TITLE
Add configurable surface slope, disable experimental preview by default, and add water artifact troubleshooting doc

### DIFF
--- a/docs/minecraft-water-artifact-troubleshooting.md
+++ b/docs/minecraft-water-artifact-troubleshooting.md
@@ -1,0 +1,58 @@
+# Minecraft/NeoForge Water Artifact Troubleshooting
+
+If you see large, translucent "walls" or sheet-like cubes in oceans/lakes (similar to the screenshots), the issue is usually one of these:
+
+## Most likely causes
+
+1. **Broken fluid mesh generation in a mod**
+   - A custom renderer or fluid optimization mod can submit incorrect quads for water.
+   - Symptoms: geometric sheets visible both above and below water.
+
+2. **Shader/renderer incompatibility**
+   - Shader packs or rendering mods can mis-handle fluid faces.
+   - Symptoms: artifacts change when enabling/disabling shader pipeline.
+
+3. **Chunk mesh cache desync**
+   - The client keeps stale chunk render data after mod reloads/world updates.
+   - Symptoms: artifact disappears after relog, F3+A, or changing video settings.
+
+4. **Mixed mod versions (client/server mismatch)**
+   - Different versions of rendering/worldgen mods can produce visual corruption.
+
+## Fast isolation workflow (NeoForge dev)
+
+1. Launch with **no shaders** and default video settings.
+2. Temporarily disable non-essential rendering/fluid mods.
+3. Rebuild and run with:
+
+```bash
+./gradlew clean runClient
+```
+
+4. In-game, force chunk rebuild (**F3 + A**) and re-enter the world.
+5. If still reproducible, test a clean profile with only:
+   - NeoForge
+   - Your mod
+   - Required libraries
+
+## Debugging checklist for mod authors
+
+- Verify fluid mesh builders only emit valid faces per block side.
+- Validate fluid height sampling and neighboring block checks.
+- Ensure render-layer assignment matches expected translucent layer.
+- Confirm no custom mixin cancels/overrides vanilla fluid tesselation unexpectedly.
+- Add debug logging around fluid chunk rebuild paths.
+
+## Practical next step in this repository
+
+Use this bug report template when tracking future visual artifacts:
+
+- Game version:
+- NeoForge version:
+- Modpack/mod list diff from baseline:
+- Shader pack + renderer mods:
+- Repro seed/coords:
+- Whether F3+A/relog changes behavior:
+- Screenshot/video:
+
+Capturing these details up-front usually cuts diagnosis time significantly.

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricFluidRenderConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricFluidRenderConfig.java
@@ -12,6 +12,7 @@ public final class VolumetricFluidRenderConfig {
     public static final ModConfigSpec.IntValue MAX_TRIANGLES_PER_FLUID;
     public static final ModConfigSpec.IntValue MAX_RENDER_DISTANCE;
     public static final ModConfigSpec.IntValue MAX_STALE_AGE_TICKS;
+    public static final ModConfigSpec.DoubleValue MAX_SURFACE_SLOPE_DELTA;
     public static final ModConfigSpec.DoubleValue WAVE_STRENGTH;
     public static final ModConfigSpec.DoubleValue FOAM_STRENGTH;
     public static final ModConfigSpec.IntValue WATER_ALPHA;
@@ -23,8 +24,8 @@ public final class VolumetricFluidRenderConfig {
         BUILDER.push("volumetricFluidRenderer");
 
         ENABLE_PREVIEW_RENDERER = BUILDER
-                .comment("Enable first-pass volumetric mesh preview rendering for synced water/lava surfaces.")
-                .define("enablePreviewRenderer", true);
+                .comment("Enable first-pass volumetric mesh preview rendering for synced water/lava surfaces. Disabled by default because this renderer is still experimental.")
+                .define("enablePreviewRenderer", false);
 
         MAX_TRIANGLES_PER_FLUID = BUILDER
                 .comment("Hard cap for rendered triangles per fluid type.")
@@ -37,6 +38,10 @@ public final class VolumetricFluidRenderConfig {
         MAX_STALE_AGE_TICKS = BUILDER
                 .comment("Skip rendering if no fresh sync packet was received in this many ticks.")
                 .defineInRange("maxStaleAgeTicks", 160, 20, 2000);
+
+        MAX_SURFACE_SLOPE_DELTA = BUILDER
+                .comment("Maximum allowed Y delta across a generated quad. Lower values reduce vertical wall artifacts from sparse samples.")
+                .defineInRange("maxSurfaceSlopeDelta", 0.55D, 0.05D, 2.0D);
 
         WAVE_STRENGTH = BUILDER
                 .comment("Simple sinusoidal wave amplitude applied to preview vertices.")

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceRenderer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceRenderer.java
@@ -23,8 +23,6 @@ import java.util.List;
  */
 @EventBusSubscriber(modid = ModConstants.MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.GAME)
 public final class VolumetricSurfaceRenderer {
-    private static final double MAX_EDGE_DELTA = 1.5D;
-
     private VolumetricSurfaceRenderer() {
     }
 
@@ -55,6 +53,11 @@ public final class VolumetricSurfaceRenderer {
         double maxRenderDistanceSq = maxRenderDistance * (double) maxRenderDistance;
         double waveStrength = VolumetricFluidRenderConfig.WAVE_STRENGTH.get();
         double foamStrength = VolumetricFluidRenderConfig.FOAM_STRENGTH.get();
+        double maxSurfaceSlopeDelta = VolumetricFluidRenderConfig.MAX_SURFACE_SLOPE_DELTA.get();
+
+        if (minecraft.player.isUnderWater()) {
+            return;
+        }
 
         if (VolumetricSurfaceClientCache.isStale((long) time, VolumetricFluidRenderConfig.MAX_STALE_AGE_TICKS.get())) {
             return;
@@ -62,7 +65,7 @@ public final class VolumetricSurfaceRenderer {
 
         renderFluid(
                 VolumetricSurfaceMesher.buildTriangles(
-                        VolumetricSurfaceClientCache.snapshot(minecraft.level.dimension().location(), SimulatedFluid.WATER), MAX_EDGE_DELTA),
+                        VolumetricSurfaceClientCache.snapshot(minecraft.level.dimension().location(), SimulatedFluid.WATER), maxSurfaceSlopeDelta),
                 waterConsumer,
                 pose,
                 camera,
@@ -79,7 +82,7 @@ public final class VolumetricSurfaceRenderer {
 
         renderFluid(
                 VolumetricSurfaceMesher.buildTriangles(
-                        VolumetricSurfaceClientCache.snapshot(minecraft.level.dimension().location(), SimulatedFluid.LAVA), MAX_EDGE_DELTA),
+                        VolumetricSurfaceClientCache.snapshot(minecraft.level.dimension().location(), SimulatedFluid.LAVA), maxSurfaceSlopeDelta),
                 lavaConsumer,
                 pose,
                 camera,


### PR DESCRIPTION
### Motivation

- Reduce vertical "wall" artifacts from sparse volumetric fluid sampling by limiting allowed Y delta across generated quads. 
- Prevent an experimental preview renderer from surprising users by disabling it by default. 
- Provide a troubleshooting guide for large translucent water artifacts seen with NeoForge/mapping packs.

### Description

- Added `MAX_SURFACE_SLOPE_DELTA` configuration (`double`, default `0.55`) to `VolumetricFluidRenderConfig` to limit per-quad Y deltas during meshing. 
- Changed `ENABLE_PREVIEW_RENDERER` default to `false` and updated its comment to mark the renderer as experimental. 
- Updated `VolumetricSurfaceRenderer` to read `MAX_SURFACE_SLOPE_DELTA` from config, remove the hardcoded `MAX_EDGE_DELTA`, pass the configurable slope limit into `VolumetricSurfaceMesher.buildTriangles`, and early-return when the player is underwater to avoid rendering previews while submerged. 
- Added `docs/minecraft-water-artifact-troubleshooting.md` with likely causes, a fast isolation workflow, a debugging checklist, and a bug-report template for visual water artifacts.

### Testing

- Performed a project build with `./gradlew build` to validate compilation and configuration changes, which completed successfully. 
- No new automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2a99fc0883288de04dcfa5fb2aa7)