### PR TITLE
Enable vanilla water engine replacement by default and improve world application/cleanup

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidConfig.java
@@ -55,7 +55,7 @@ public final class VolumetricFluidConfig {
                         && VALID_PRESETS.contains(preset.toLowerCase(java.util.Locale.ROOT)));
 
         REPLACE_VANILLA_ENGINE = BUILDER.comment("If true, cancels vanilla water fluid ticks and routes behavior through the volumetric solver.")
-                .define("replaceVanillaWaterEngine", false);
+                .define("replaceVanillaWaterEngine", true);
 
         ENABLE_LAVA = BUILDER.comment("If true, runs the hybrid volumetric solver for lava in addition to water.")
                 .define("enableLava", false);
@@ -183,7 +183,7 @@ public final class VolumetricFluidConfig {
                     3,
                     64,
                     "safe",
-                    false,
+                    true,
                     false,
                     false,
                     0.25D,

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
@@ -421,6 +421,11 @@ public final class VolumetricFluidManager {
 
     private static void applyToWorld(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config, SimulatedFluid fluidType) {
         Set<Long> controlledNow = new HashSet<>();
+        boolean replacingVanillaEngine = switch (fluidType) {
+            case WATER -> config.replaceVanillaWaterEngine();
+            case LAVA -> config.replaceVanillaLavaEngine();
+        };
+        double placeThreshold = replacingVanillaEngine ? config.minCellVolume() : config.placeThreshold();
 
         for (Map.Entry<Long, FluidCell> entry : grid.cells.entrySet()) {
             long packedPos = entry.getKey();
@@ -431,7 +436,7 @@ public final class VolumetricFluidManager {
                 continue;
             }
 
-            if (cell.volume >= config.placeThreshold()) {
+            if (cell.volume >= placeThreshold) {
                 BlockState state = level.getBlockState(pos);
                 BlockState simulatedState = fluidStateForVolume(fluidType, cell.volume);
                 if (state.isAir() || state.is(fluidType.block())) {
@@ -452,6 +457,18 @@ public final class VolumetricFluidManager {
             BlockPos pos = BlockPos.of(packedPos);
             if (level.isLoaded(pos) && level.getBlockState(pos).is(fluidType.block())) {
                 level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
+            }
+        }
+
+        if (replacingVanillaEngine) {
+            for (Map.Entry<Long, FluidCell> entry : grid.cells.entrySet()) {
+                if (entry.getValue().volume > config.removeThreshold()) {
+                    continue;
+                }
+                BlockPos pos = BlockPos.of(entry.getKey());
+                if (level.isLoaded(pos) && level.getBlockState(pos).is(fluidType.block())) {
+                    level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
+                }
             }
         }
 


### PR DESCRIPTION
### Motivation
- Make the volumetric solver take over vanilla water behavior by default and ensure consistent block placement/removal when the engine is replaced.
- Ensure block placement uses the stricter `minCellVolume` threshold while replacing the vanilla engine to avoid sparse artifacts.
- Remove lingering vanilla fluid blocks that fall below the removal threshold when the volumetric engine is active.

### Description
- Change the default configuration to enable `replaceVanillaWaterEngine` by setting the builder define to `true` and setting the default `Values` field to `true`.
- Add a `replacingVanillaEngine` switch in `applyToWorld` that maps `WATER` and `LAVA` to `config.replaceVanillaWaterEngine()` and `config.replaceVanillaLavaEngine()` respectively.
- Use `minCellVolume()` as the placement threshold when `replacingVanillaEngine` is `true`, otherwise use `config.placeThreshold()`.
- Add an extra cleanup pass that removes vanilla fluid blocks for all grid cells below `removeThreshold()` when `replacingVanillaEngine` is enabled.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdac3914e48328966e2f1a5dc827cf)