### PR TITLE
Fix volumetric surface render stage timing

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceRenderer.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/client/VolumetricSurfaceRenderer.java
@@ -30,7 +30,7 @@ public final class VolumetricSurfaceRenderer {
 
     @SubscribeEvent
     public static void onRenderLevelStage(RenderLevelStageEvent event) {
-        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
+        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_LEVEL) {
             return;
         }
 


### PR DESCRIPTION
### Motivation
- Move the volumetric surface preview draw pass out of the section-layer render phase to avoid calling into `VertexConsumer` when the underlying `BufferBuilder` is not in a building state, which was causing `IllegalStateException: Not building!` during render.

### Description
- Change the render event stage check in `VolumetricSurfaceRenderer.onRenderLevelStage` from `RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS` to `RenderLevelStageEvent.Stage.AFTER_LEVEL` so the custom water/lava surface pass runs after level rendering.

### Testing
- Ran `./gradlew compileJava -q`, which failed in this environment due to an SSL certificate handshake error when downloading Mojang launcher metadata and not because of a Java compile error in the edited file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf2cd20cf08328b3cd729a20ba660d)