### PR TITLE
Improve fluid sampling and controlled-block removal for vanilla engine replacement

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/volumetric/VolumetricFluidManager.java
@@ -269,6 +269,13 @@ public final class VolumetricFluidManager {
     private static void ingestFluidNearPlayers(ServerLevel level, FluidGrid grid, VolumetricFluidConfig.Values config, SimulatedFluid fluidType) {
         int radius = config.playerSampleRadius();
         int step = Math.max(1, config.playerSampleStep());
+        if (fluidType == SimulatedFluid.WATER && config.replaceVanillaWaterEngine()) {
+            // Full-density sampling avoids checkerboard artifacts when vanilla ticks are cancelled.
+            step = 1;
+            radius = Math.max(radius, 24);
+        } else if (fluidType == SimulatedFluid.LAVA && config.replaceVanillaLavaEngine()) {
+            step = 1;
+        }
         BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
 
         for (ServerPlayer player : level.players()) {
@@ -455,25 +462,35 @@ public final class VolumetricFluidManager {
                 continue;
             }
             BlockPos pos = BlockPos.of(packedPos);
-            if (level.isLoaded(pos) && level.getBlockState(pos).is(fluidType.block())) {
-                level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
+            if (!shouldRemoveControlledFluidBlock(level, pos, fluidType, replacingVanillaEngine)) {
+                continue;
             }
+            level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
         }
 
-        if (replacingVanillaEngine) {
-            for (Map.Entry<Long, FluidCell> entry : grid.cells.entrySet()) {
-                if (entry.getValue().volume > config.removeThreshold()) {
-                    continue;
-                }
-                BlockPos pos = BlockPos.of(entry.getKey());
-                if (level.isLoaded(pos) && level.getBlockState(pos).is(fluidType.block())) {
-                    level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
-                }
-            }
-        }
 
         grid.controlledBlocks.clear();
         grid.controlledBlocks.addAll(controlledNow);
+    }
+
+
+    private static boolean shouldRemoveControlledFluidBlock(ServerLevel level,
+                                                            BlockPos pos,
+                                                            SimulatedFluid fluidType,
+                                                            boolean replacingVanillaEngine) {
+        if (!level.isLoaded(pos)) {
+            return false;
+        }
+        BlockState state = level.getBlockState(pos);
+        if (!state.is(fluidType.block())) {
+            return false;
+        }
+        if (!replacingVanillaEngine) {
+            return true;
+        }
+        // In replacement mode, keep source blocks so oceans/lakes remain stable while allowing low-volume
+        // flowing water to dissipate naturally.
+        return !state.getFluidState().isSource();
     }
 
     private static BlockState fluidStateForVolume(SimulatedFluid fluidType, double volume) {


### PR DESCRIPTION
### Motivation
- Avoid checkerboard sampling artifacts when the vanilla fluid tick engine is being replaced by ensuring denser sampling near players.  
- Preserve natural large bodies of water by keeping source blocks when operating in replacement mode so oceans and lakes remain stable.  
- Ensure lava replacement also uses full-density sampling to prevent sparse detection issues.

### Description
- In `ingestFluidNearPlayers` force `step = 1` and increase `radius` for water when `replaceVanillaWaterEngine()` is enabled, and force `step = 1` for lava when `replaceVanillaLavaEngine()` is enabled.  
- Introduced `shouldRemoveControlledFluidBlock` to centralize the logic that decides whether a controlled fluid block should be removed, including checks for chunk loading, block type, and source preservation when `replacingVanillaEngine` is true.  
- Reworked the controlled-block removal loop to call `shouldRemoveControlledFluidBlock` and removed the previous additional sweep that unconditionally removed low-volume blocks when replacing the vanilla engine.  
- Minor refactor to make removal conditions clearer and avoid racey removal of source blocks in replacement mode.

### Testing
- Ran the project automated test suite with `./gradlew test` and mod integration smoke tests; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1f160a3a08328bb9d3a0ff549bd0e)