### PR TITLE
Use player-centered sampling for water fluid registry and avoid chunk-map internals

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/water/fluid/WildernessFluidRegistry.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/water/fluid/WildernessFluidRegistry.java
@@ -4,17 +4,20 @@ import com.thunder.wildernessodysseyapi.core.ModConstants;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.neoforge.event.level.LevelTickEvent;
+import net.neoforged.neoforge.event.tick.LevelTickEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.bus.api.SubscribeEvent;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * WildernessFluidRegistry
@@ -59,24 +62,46 @@ public class WildernessFluidRegistry {
      * Collect a sample of loaded water blocks near active chunks.
      */
     private static List<BlockPos> gatherSurfaceWaterBlocks(ServerLevel level, int limit) {
-        List<BlockPos> result = new ArrayList<>();
-        level.getChunkSource().chunkMap.getChunks().forEach(chunk -> {
-            if (result.size() >= limit) return;
-            BlockPos center = chunk.getPos().getMiddleBlockPosition(64);
-            for (int dx = -8; dx <= 8 && result.size() < limit; dx += 2) {
-                for (int dz = -8; dz <= 8 && result.size() < limit; dz += 2) {
-                    for (int dy = -4; dy <= 4; dy++) {
-                        BlockPos check = center.offset(dx, dy, dz);
-                        FluidState fs = level.getFluidState(check);
-                        if (fs.is(Fluids.WATER) || fs.is(Fluids.FLOWING_WATER)) {
-                            result.add(check);
-                            break;
+        Set<BlockPos> uniquePositions = new LinkedHashSet<>();
+        List<ServerPlayer> players = level.players();
+        int playerCount = Math.max(1, players.size());
+        int perPlayerLimit = Math.max(8, limit / playerCount);
+
+        // Sample around active players first (works across NeoForge updates without chunk-map internals).
+        for (ServerPlayer player : players) {
+            if (uniquePositions.size() >= limit) {
+                break;
+            }
+            collectNearbyWater(level, player.blockPosition(), perPlayerLimit, limit, uniquePositions);
+        }
+
+        // If no players are present, still process a small sample around world spawn.
+        if (uniquePositions.isEmpty()) {
+            collectNearbyWater(level, level.getSharedSpawnPos(), limit, limit, uniquePositions);
+        }
+
+        return new ArrayList<>(uniquePositions);
+    }
+
+    private static void collectNearbyWater(ServerLevel level, BlockPos center, int scanLimit, int totalLimit, Set<BlockPos> result) {
+        int added = 0;
+        for (int dx = -8; dx <= 8 && result.size() < totalLimit && added < scanLimit; dx += 2) {
+            for (int dz = -8; dz <= 8 && result.size() < totalLimit && added < scanLimit; dz += 2) {
+                for (int dy = -4; dy <= 4; dy++) {
+                    BlockPos check = center.offset(dx, dy, dz);
+                    if (!level.hasChunkAt(check)) {
+                        continue;
+                    }
+                    FluidState fs = level.getFluidState(check);
+                    if (fs.is(Fluids.WATER) || fs.is(Fluids.FLOWING_WATER)) {
+                        if (result.add(check)) {
+                            added++;
                         }
+                        break;
                     }
                 }
             }
-        });
-        return result;
+        }
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Replace fragile access to `chunkMap.getChunks()` which relied on internal chunk-map internals and could break across NeoForge updates.
- Ensure the finite-fluid simulation samples loaded water blocks near active players and still processes a small sample when no players are present.

### Description
- Replaced `gatherSurfaceWaterBlocks` with a player-centered sampler that iterates `level.players()` and collects nearby water positions into a `LinkedHashSet` to deduplicate and respect `MAX_BLOCKS_PER_TICK`.
- Added `collectNearbyWater` helper which checks `level.hasChunkAt(check)` before calling `getFluidState` and enforces both a per-player scan limit and an overall total limit.
- Added `ServerPlayer` import and updated the `LevelTickEvent` import to `net.neoforged.neoforge.event.tick.LevelTickEvent`.
- Kept the rest of the equalization logic intact and returned a `List<BlockPos>` as before.

### Testing
- Ran `./gradlew build` which completed successfully.
- Executed an automated headless server tick smoke test that triggers `LevelTickEvent.Post`, verifying no crashes and that water positions are sampled around players and spawn, which passed.
- All automated tests in the repository passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ca8449908328b3e0731b95a1632b)