### PR TITLE
Add ownership config and startup attribution logging

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/Core/WildernessOdysseyAPIMainModClass.java
@@ -20,6 +20,7 @@ import com.thunder.wildernessodysseyapi.command.WorldGenScanCommand;
 import com.thunder.wildernessodysseyapi.command.StructurePlacementDebugCommand;
 import com.thunder.wildernessodysseyapi.command.TideInfoCommand;
 import com.thunder.wildernessodysseyapi.config.ConfigRegistrationValidator;
+import com.thunder.wildernessodysseyapi.config.OwnershipConfig;
 import com.thunder.wildernessodysseyapi.config.StructureBlockConfig;
 import com.thunder.wildernessodysseyapi.item.ModCreativeTabs;
 import com.thunder.wildernessodysseyapi.item.ModItems;
@@ -127,6 +128,8 @@ public class WildernessOdysseyAPIMainModClass {
                 CONFIG_FOLDER + "wildernessodysseyapi-tides-server.toml");
         ConfigRegistrationValidator.register(container, ModConfig.Type.SERVER, PlayerTelemetryConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-telemetry-server.toml");
+        ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, OwnershipConfig.CONFIG_SPEC,
+                CONFIG_FOLDER + "wildernessodysseyapi-ownership.toml");
         // Previously registered client-only events have been removed
         DonationReminderConfig.validateVersion();
 
@@ -157,6 +160,13 @@ public class WildernessOdysseyAPIMainModClass {
         globalChatManager.initialize(event.getServer(), event.getServer().getFile("config"));
         GameRulesListManager.ensureRulesFileExists(event.getServer());
         GameRulesListManager.applyConfiguredRules(event.getServer());
+
+        if (OwnershipConfig.CONFIG.showNoticeOnStartup()) {
+            LOGGER.info("[Ownership] Project: {}", OwnershipConfig.CONFIG.projectName());
+            LOGGER.info("[Ownership] Owner: {}", OwnershipConfig.CONFIG.ownerName());
+            LOGGER.info("[Ownership] Notice: {}", OwnershipConfig.CONFIG.ownershipNotice());
+            LOGGER.info("[Ownership] Contact: {}", OwnershipConfig.CONFIG.supportContact());
+        }
     }
 
     /**

--- a/src/main/java/com/thunder/wildernessodysseyapi/config/OwnershipConfig.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/config/OwnershipConfig.java
@@ -1,0 +1,67 @@
+package com.thunder.wildernessodysseyapi.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Common configuration that lets modpack creators declare ownership/credit details.
+ */
+public final class OwnershipConfig {
+
+    public static final OwnershipConfig CONFIG;
+    public static final ModConfigSpec CONFIG_SPEC;
+
+    static {
+        Pair<OwnershipConfig, ModConfigSpec> pair = new ModConfigSpec.Builder()
+                .configure(OwnershipConfig::new);
+        CONFIG = pair.getLeft();
+        CONFIG_SPEC = pair.getRight();
+    }
+
+    private final ModConfigSpec.ConfigValue<String> ownerName;
+    private final ModConfigSpec.ConfigValue<String> projectName;
+    private final ModConfigSpec.ConfigValue<String> ownershipNotice;
+    private final ModConfigSpec.ConfigValue<String> supportContact;
+    private final ModConfigSpec.BooleanValue showNoticeOnStartup;
+
+    private OwnershipConfig(ModConfigSpec.Builder builder) {
+        builder.push("ownership");
+
+        ownerName = builder.comment("Primary owner/creator name shown in the ownership notice.")
+                .define("ownerName", "thunderrock424242");
+
+        projectName = builder.comment("Project or modpack name to display in the ownership notice.")
+                .define("projectName", "Wilderness Odyssey");
+
+        ownershipNotice = builder.comment("Custom statement shown in logs to identify ownership and authorship.")
+                .define("ownershipNotice", "This modpack is owned by thunderrock424242. Do not repost without permission.");
+
+        supportContact = builder.comment("Optional support/contact info (Discord, email, website).")
+                .define("supportContact", "Set your support contact here");
+
+        showNoticeOnStartup = builder.comment("If true, logs the ownership notice every time the server starts.")
+                .define("showNoticeOnStartup", true);
+
+        builder.pop();
+    }
+
+    public String ownerName() {
+        return ownerName.get();
+    }
+
+    public String projectName() {
+        return projectName.get();
+    }
+
+    public String ownershipNotice() {
+        return ownershipNotice.get();
+    }
+
+    public String supportContact() {
+        return supportContact.get();
+    }
+
+    public boolean showNoticeOnStartup() {
+        return showNoticeOnStartup.get();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide modpack creators a configurable place to declare ownership/attribution so servers and logs show who created the pack and discourage casual reposting.
- Ship sensible defaults (owner defaulted to `thunderrock424242`) so attribution appears immediately without code edits.

### Description
- Add a new common config spec `OwnershipConfig` with fields `ownerName`, `projectName`, `ownershipNotice`, `supportContact`, and `showNoticeOnStartup` (file: `src/main/java/com/thunder/wildernessodysseyapi/config/OwnershipConfig.java`).
- Register the new config as `config/wildernessodysseyapi/wildernessodysseyapi-ownership.toml` via `ConfigRegistrationValidator` (registered as `ModConfig.Type.COMMON`).
- Log ownership/attribution details on server start when `showNoticeOnStartup` is true by reading values from `OwnershipConfig` in `WildernessOdysseyAPIMainModClass`.

### Testing
- Ran `./gradlew compileJava`, but the build failed due to an SSL certificate handshake error while downloading Mojang metadata (PKIX path building failed), which is an environment/network issue and not a Java compilation error in the changes.
- No other automated tests were run in this environment; the config addition is limited to pure Java changes and was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11625c8b8832886dc03d3b434bb29)