### PR TITLE
Wrap LiquidBlockRenderer VertexConsumer to restore Gerstner water waves

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/mixin/GerstnerWaveRenderMixin.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/mixin/GerstnerWaveRenderMixin.java
@@ -1,6 +1,8 @@
 package com.thunder.wildernessodysseyapi.mixin;
 
 import com.thunder.wildernessodysseyapi.watersystem.water.wave.GerstnerWaveAnimator;
+import com.thunder.wildernessodysseyapi.watersystem.water.wave.GerstnerVertexConsumer;
+import com.thunder.wildernessodysseyapi.watersystem.water.wave.WaterBodyClassifier;
 import net.minecraft.client.renderer.block.LiquidBlockRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockAndTintGetter;
@@ -11,6 +13,7 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
@@ -48,5 +51,25 @@ public class GerstnerWaveRenderMixin {
             GerstnerWaveAnimator.update();
             lastUpdateNanos = now;
         }
+    }
+
+    @ModifyVariable(
+        method = "tesselate",
+        at = @At("HEAD"),
+        argsOnly = true,
+        index = 3
+    )
+    private VertexConsumer wrapWaterVertexConsumer(VertexConsumer originalConsumer,
+                                                   BlockAndTintGetter level,
+                                                   BlockPos pos,
+                                                   VertexConsumer consumer,
+                                                   BlockState blockState,
+                                                   FluidState fluidState) {
+        if (!fluidState.is(Fluids.WATER) && !fluidState.is(Fluids.FLOWING_WATER)) {
+            return originalConsumer;
+        }
+
+        WaterBodyClassifier.WaterType waterType = WaterBodyClassifier.classify(level, pos);
+        return new GerstnerVertexConsumer(originalConsumer, pos.getX(), pos.getZ(), waterType);
     }
 }


### PR DESCRIPTION
### Motivation
- In-game water waves were invisible because the renderer hook only advanced wave timing and never replaced the `VertexConsumer` used to build water vertices. 
- The displacement must use a water-body-specific Gerstner profile (ocean/river/pond) so amplitudes and push behave correctly. 
- The existing per-frame throttled animator update should be preserved while ensuring vertex displacement is performed.

### Description
- Added imports and a `@ModifyVariable` handler on `LiquidBlockRenderer#tesselate` that wraps the incoming `VertexConsumer` and returns a `GerstnerVertexConsumer` so top-face vertices receive Y-displacement. 
- The wrapper calls `WaterBodyClassifier.classify(level, pos)` and passes the resulting `WaterType` and block coordinates to `GerstnerVertexConsumer` so the correct profile is applied. 
- Kept the existing `@Inject` at `tesselate` head which throttles and calls `GerstnerWaveAnimator.update()` to maintain time updates per frame.

### Testing
- Attempted a compile check with `./gradlew compileJava -x test`, but the build failed in this environment due to NeoForge artifact download failing with an SSL certificate trust error (`PKIX path building failed`). 
- No automated tests were run successfully in this environment as a result of the artifact download failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e436d59c7c832887c3cc0f629efd1b)