### PR TITLE
Smooth tide updater and add client Tide HUD with toggle command

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/ocean/tide/TideWorldUpdater.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/ocean/tide/TideWorldUpdater.java
@@ -32,6 +32,7 @@ public class TideWorldUpdater {
     private static final int SEA_LEVEL        = 62;
     private static final int TIDE_CHECK_RANGE = 24;  // blocks around players
     private static final int TICK_INTERVAL    = 100; // ticks between updates
+    private static final int MAX_TIDE_STEPS   = 2;   // keep in sync with TideSystem amplitude
 
     private static float lastTideOffset = 0f;
     private static int   tickCounter    = 0;
@@ -67,24 +68,44 @@ public class TideWorldUpdater {
                     if (WaterBodyClassifier.classify(level, surface)
                             != WaterBodyClassifier.WaterType.OCEAN) continue;
 
-                    int targetY = SEA_LEVEL + Math.round(tideOffset);
-
-                    BlockPos above = surface.above();
-                    BlockState aboveState = level.getBlockState(above);
-
-                    if (tideOffset > 0.5f && aboveState.isAir()) {
-                        // High tide: fill one block above shoreline
-                        level.setBlock(above, Blocks.WATER.defaultBlockState(), 2);
-                    } else if (tideOffset < -0.5f) {
-                        // Low tide: drain topmost water block if it exists
-                        if (level.getFluidState(surface).is(Fluids.WATER)
-                                && surface.getY() > SEA_LEVEL - 1) {
-                            level.setBlock(surface, Blocks.AIR.defaultBlockState(), 2);
-                        }
-                    }
+                    int targetY = clampTargetY(SEA_LEVEL + Math.round(tideOffset));
+                    applyColumnTide(level, surface, targetY);
                 }
             }
         });
+    }
+
+    private static int clampTargetY(int y) {
+        return Math.max(SEA_LEVEL - MAX_TIDE_STEPS, Math.min(SEA_LEVEL + MAX_TIDE_STEPS, y));
+    }
+
+    /**
+     * Raise or lower one sampled shoreline column to match the target tide height.
+     * This keeps transitions smoother than one-off threshold fills/drains and
+     * actually uses the computed targetY for both rising and falling tides.
+     */
+    private static void applyColumnTide(ServerLevel level, BlockPos surface, int targetY) {
+        int topY = surface.getY();
+
+        if (topY < targetY) {
+            for (int y = topY + 1; y <= targetY; y++) {
+                BlockPos pos = new BlockPos(surface.getX(), y, surface.getZ());
+                BlockState state = level.getBlockState(pos);
+                if (state.isAir()) {
+                    level.setBlock(pos, Blocks.WATER.defaultBlockState(), 2);
+                }
+            }
+            return;
+        }
+
+        if (topY > targetY) {
+            for (int y = topY; y > targetY; y--) {
+                BlockPos pos = new BlockPos(surface.getX(), y, surface.getZ());
+                if (level.getFluidState(pos).is(Fluids.WATER)) {
+                    level.setBlock(pos, Blocks.AIR.defaultBlockState(), 2);
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/water/render/TideHudClientCommand.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/water/render/TideHudClientCommand.java
@@ -1,0 +1,54 @@
+package com.thunder.wildernessodysseyapi.watersystem.water.render;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
+
+@EventBusSubscriber(value = Dist.CLIENT, modid = "wildernessodysseyapi")
+public final class TideHudClientCommand {
+
+    private TideHudClientCommand() {}
+
+    @SubscribeEvent
+    public static void onRegisterClientCommands(RegisterClientCommandsEvent event) {
+        CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
+
+        dispatcher.register(
+                Commands.literal("tidehud")
+                        .executes(ctx -> sendStatus(ctx.getSource()))
+                        .then(Commands.literal("on").executes(ctx -> setEnabled(ctx.getSource(), true)))
+                        .then(Commands.literal("off").executes(ctx -> setEnabled(ctx.getSource(), false)))
+                        .then(Commands.literal("toggle").executes(ctx -> toggle(ctx.getSource())))
+                        .then(Commands.literal("status").executes(ctx -> sendStatus(ctx.getSource())))
+        );
+    }
+
+    private static int setEnabled(CommandSourceStack source, boolean enabled) {
+        TideHudOverlay.setHudEnabled(enabled);
+        source.sendSuccess(() -> Component.literal(enabled
+                ? "🌊 Tide HUD enabled."
+                : "🌊 Tide HUD disabled."), false);
+        return 1;
+    }
+
+    private static int toggle(CommandSourceStack source) {
+        boolean enabled = TideHudOverlay.toggleHudEnabled();
+        source.sendSuccess(() -> Component.literal(enabled
+                ? "🌊 Tide HUD enabled."
+                : "🌊 Tide HUD disabled."), false);
+        return 1;
+    }
+
+    private static int sendStatus(CommandSourceStack source) {
+        boolean enabled = TideHudOverlay.isHudEnabled();
+        source.sendSuccess(() -> Component.literal("🌊 Tide HUD is currently "
+                + (enabled ? "enabled" : "disabled")
+                + ". Use /tidehud on|off|toggle."), false);
+        return 1;
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/watersystem/water/render/TideHudOverlay.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/watersystem/water/render/TideHudOverlay.java
@@ -3,6 +3,7 @@ package com.thunder.wildernessodysseyapi.watersystem.water.render;
 import com.thunder.wildernessodysseyapi.watersystem.ocean.tide.TideSystem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -25,10 +26,10 @@ import net.neoforged.neoforge.client.event.RenderGuiEvent;
 @EventBusSubscriber(modid = "wildernessodysseyapi", bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
 public class TideHudOverlay {
 
-    private static final boolean SHOW_HUD = true; // TODO: wire to config
+    private static boolean hudEnabled = false;
 
-    private static final int BAR_WIDTH  = 60;
-    private static final int BAR_HEIGHT = 4;
+    private static final int BAR_WIDTH  = 92;
+    private static final int BAR_HEIGHT = 6;
 
     private static final String[] MOON_NAMES = {
         "Full Moon", "Waning Gibbous", "Last Quarter", "Waning Crescent",
@@ -37,7 +38,7 @@ public class TideHudOverlay {
 
     @SubscribeEvent
     public static void onRenderGui(RenderGuiEvent.Post event) {
-        if (!SHOW_HUD) return;
+        if (!hudEnabled) return;
         Minecraft mc = Minecraft.getInstance();
         if (mc.level == null || mc.player == null) return;
         if (mc.options.hideGui) return;
@@ -48,34 +49,52 @@ public class TideHudOverlay {
         Level level  = mc.level;
         GuiGraphics g = event.getGuiGraphics();
         int screenH  = mc.getWindow().getGuiScaledHeight();
-        int x = 8, y = screenH - 40;
+        int x = 8, y = screenH - 54;
 
         // Tide name
-        String tideName  = TideSystem.getTideName(level);
-        String moonName  = MOON_NAMES[level.getMoonPhase()];
-        float  tideLevel = TideSystem.getTideNormalised(level); // 0–1
+        String moonName = MOON_NAMES[level.getMoonPhase()];
+        String tideName = TideSystem.getTideName(level);
+        float tideLevel = TideSystem.getTideNormalised(level); // 0–1
+        float tideRate = TideSystem.getTideRate(level);
+        float tideOffset = TideSystem.getTideOffset(level);
 
-        g.drawString(mc.font, "§b" + moonName,  x, y,      0xFFFFFFFF, false);
-        g.drawString(mc.font, "§7" + tideName,  x, y + 10, 0xFFFFFFFF, false);
+        String trend = tideRate > 0.001f ? "↑" : tideRate < -0.001f ? "↓" : "•";
+        String detail = String.format("§7%s %s  §8(%.2f)", trend, tideName, tideOffset);
 
-        // Tide bar background
-        g.fill(x, y + 22, x + BAR_WIDTH, y + 22 + BAR_HEIGHT, 0x88000000);
+        g.fill(x - 4, y - 4, x + BAR_WIDTH + 6, y + 34, 0x66000000);
+        g.drawString(mc.font, "§b" + moonName, x, y, 0xFFFFFFFF, false);
+        g.drawString(mc.font, detail, x, y + 11, 0xFFFFFFFF, false);
 
-        // Tide bar fill
-        int fillW = (int)(tideLevel * BAR_WIDTH);
-        int barCol = tideLevel > 0.65f ? 0xFF4488FF   // high tide — blue
-                   : tideLevel < 0.35f ? 0xFF886622   // low tide — brown
-                   : 0xFF2266AA;                        // mid tide
-        if (fillW > 0) {
-            g.fill(x, y + 22, x + fillW, y + 22 + BAR_HEIGHT, barCol);
-        }
+        int barY = y + 24;
+        g.fill(x, barY, x + BAR_WIDTH, barY + BAR_HEIGHT, 0xAA111111);
 
-        // Tick marks at low/mid/high
-        g.fill(x + BAR_WIDTH/2 - 1, y + 21, x + BAR_WIDTH/2 + 1, y + 28, 0x88FFFFFF);
+        int markerX = x + Mth.clamp(Math.round(tideLevel * BAR_WIDTH), 0, BAR_WIDTH);
+        int barCol = tideLevel > 0.66f ? 0xFF4B8BFF
+                   : tideLevel < 0.33f ? 0xFF9A6A33
+                   : 0xFF2D75C8;
+        g.fill(x, barY, markerX, barY + BAR_HEIGHT, barCol);
+        g.fill(markerX - 1, barY - 2, markerX + 1, barY + BAR_HEIGHT + 2, 0xFFEAF2FF);
+
+        // Midpoint marker
+        int centerX = x + BAR_WIDTH / 2;
+        g.fill(centerX - 1, barY - 2, centerX + 1, barY + BAR_HEIGHT + 2, 0x88FFFFFF);
     }
 
     private static boolean isNearOcean(Minecraft mc) {
         // Quick check: is the player within vertical range of sea level?
         return mc.player != null && Math.abs(mc.player.getY() - 62) < 8;
+    }
+
+    public static boolean isHudEnabled() {
+        return hudEnabled;
+    }
+
+    public static void setHudEnabled(boolean enabled) {
+        hudEnabled = enabled;
+    }
+
+    public static boolean toggleHudEnabled() {
+        hudEnabled = !hudEnabled;
+        return hudEnabled;
     }
 }


### PR DESCRIPTION
### Motivation
- Make shoreline tide changes smoother and bounded to avoid excessive block spawns by using a clamped target height and step-wise adjustments. 
- Provide a lightweight client-side HUD to visualize tide state and allow players to toggle it via a client command.

### Description
- Replace the one-off threshold fill/drain logic in `TideWorldUpdater` with a clamped target height via `MAX_TIDE_STEPS` and `clampTargetY`, and implement `applyColumnTide` to raise or lower sampled shoreline columns stepwise. 
- Add `TideHudOverlay` client UI improvements including a toggleable `hudEnabled` flag, larger tide bar (`BAR_WIDTH`/`BAR_HEIGHT`), tide rate/offset display, background panel, marker using `Mth.clamp`, repositioning, and public `isHudEnabled`/`setHudEnabled`/`toggleHudEnabled` methods. 
- Add a new client command `TideHudClientCommand` to register `/tidehud` with `on|off|toggle|status` subcommands that control and report the HUD state.

### Testing
- Ran a full project build with `./gradlew build` which completed successfully. 
- Ran the test task with `./gradlew test` and existing automated tests passed; no new unit tests were added for these UI/behavior changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e436c7023c83289e2c94f2a3dc8262)