### PR TITLE
Manage and sync server.properties templates (global and per-world)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ Loot tables defined inside the structure templates work the same way as vanilla
 NBT structures. The scanner now reads loot table references directly from the
 template data so datapacks can supply their own chest contents.
 
+Managed server.properties template
+--------------------------
+The mod now maintains `config/wildernessodysseyapi/server.properties` as a pack-shippable template and also mirrors a world-local copy at `<world>/server.properties.wildernessodyssey`.
+
+- On first dedicated-server boot, the global managed file is created from bundled defaults.
+- A world-local template is created from the global template (or current live file if needed).
+- On startup, the world-local template is preferred and synced into the live root `server.properties`, with a timestamped backup of the previous live file.
+- If the bundled template in the mod jar changes after an update, managed global/world templates are automatically replaced so new defaults switch over.
+- This means the managed settings can travel with the world folder when moving that world to another server.
+- Synced values still apply on the next restart because Minecraft reads `server.properties` before mod startup.
+
+Ship your own defaults with `config/wildernessodysseyapi/server.properties`, or distribute a preconfigured world containing `<world>/server.properties.wildernessodyssey`.
+
 World Generation Diagnostics
 --------------------------
 Use `/worldgenscan <radius>` to count nearby structures, features, and biomes and identify which mods add them.

--- a/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/server/ServerPropertiesTemplateManager.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/ModPackPatches/server/ServerPropertiesTemplateManager.java
@@ -1,0 +1,178 @@
+package com.thunder.wildernessodysseyapi.ModPackPatches.server;
+
+import com.thunder.wildernessodysseyapi.core.ModConstants;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.storage.LevelResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Keeps a distributable server.properties template in sync with the live server file.
+ * <p>
+ * Workflow:
+ * 1. First run creates {@code config/<modid>/server.properties} from bundled defaults.
+ * 2. A world-local template is stored at {@code <world>/server.properties.wildernessodyssey}.
+ * 3. On start, world template (if present) is synced into live {@code server.properties}
+ * with backups. This lets world moves carry server settings with them.
+ */
+public final class ServerPropertiesTemplateManager {
+    private static final String BUNDLED_TEMPLATE = "/defaults/server.properties";
+    private static final String WORLD_TEMPLATE_FILE = "server.properties.wildernessodyssey";
+    private static final String BUNDLED_HASH_STATE = "server-properties-template.sha256";
+
+    private ServerPropertiesTemplateManager() {
+    }
+
+    public static void ensureManagedServerProperties(MinecraftServer server) {
+        if (!server.isDedicatedServer()) {
+            return;
+        }
+
+        Path liveFile = server.getFile("server.properties").toPath();
+        Path globalManagedFile = server.getFile("config/" + ModConstants.MOD_ID + "/server.properties").toPath();
+        Path hashStateFile = server.getFile("config/" + ModConstants.MOD_ID + "/" + BUNDLED_HASH_STATE).toPath();
+        Path worldManagedFile = server.getWorldPath(LevelResource.ROOT).resolve(WORLD_TEMPLATE_FILE);
+
+        try {
+            ensureGlobalManagedFileExists(globalManagedFile, liveFile);
+            ensureWorldManagedFileExists(worldManagedFile, globalManagedFile, liveFile);
+            applyBundledTemplateUpdates(globalManagedFile, worldManagedFile, hashStateFile);
+
+            Path preferredSource = Files.exists(worldManagedFile) ? worldManagedFile : globalManagedFile;
+            syncManagedToLive(preferredSource, liveFile);
+
+            if (Files.exists(globalManagedFile) && Files.exists(worldManagedFile)
+                    && Files.mismatch(globalManagedFile, worldManagedFile) != -1) {
+                Files.copy(worldManagedFile, globalManagedFile, StandardCopyOption.REPLACE_EXISTING);
+                ModConstants.LOGGER.info("[ServerProperties] Updated global managed template from world template: {}", globalManagedFile);
+            }
+        } catch (IOException e) {
+            ModConstants.LOGGER.warn("[ServerProperties] Failed to synchronize managed server.properties: {}", e.getMessage());
+        }
+    }
+
+    private static void applyBundledTemplateUpdates(Path globalManagedFile, Path worldManagedFile, Path hashStateFile) throws IOException {
+        byte[] bundledBytes = loadBundledTemplateBytes();
+        if (bundledBytes == null || bundledBytes.length == 0) {
+            return;
+        }
+
+        String newHash = sha256Hex(bundledBytes);
+        String existingHash = readHashState(hashStateFile);
+        if (newHash.equals(existingHash)) {
+            return;
+        }
+
+        Files.write(globalManagedFile, bundledBytes);
+        Files.write(worldManagedFile, bundledBytes);
+        writeHashState(hashStateFile, newHash);
+        ModConstants.LOGGER.info("[ServerProperties] Bundled template changed; replaced managed global/world templates.");
+    }
+
+    private static byte[] loadBundledTemplateBytes() throws IOException {
+        try (InputStream templateStream = ServerPropertiesTemplateManager.class.getResourceAsStream(BUNDLED_TEMPLATE)) {
+            if (templateStream == null) {
+                return null;
+            }
+            return templateStream.readAllBytes();
+        }
+    }
+
+    private static String readHashState(Path hashStateFile) throws IOException {
+        if (!Files.exists(hashStateFile)) {
+            return "";
+        }
+        return Files.readString(hashStateFile, StandardCharsets.UTF_8).trim();
+    }
+
+    private static void writeHashState(Path hashStateFile, String hash) throws IOException {
+        Path parent = hashStateFile.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        Files.writeString(hashStateFile, hash, StandardCharsets.UTF_8);
+    }
+
+    private static String sha256Hex(byte[] data) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(data);
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    private static void ensureGlobalManagedFileExists(Path managedFile, Path liveFile) throws IOException {
+        if (Files.exists(managedFile)) {
+            return;
+        }
+        Path parent = managedFile.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+
+        try (InputStream templateStream = ServerPropertiesTemplateManager.class.getResourceAsStream(BUNDLED_TEMPLATE)) {
+            if (templateStream != null) {
+                Files.copy(templateStream, managedFile, StandardCopyOption.REPLACE_EXISTING);
+                ModConstants.LOGGER.info("[ServerProperties] Created global managed template from bundled defaults: {}", managedFile);
+                return;
+            }
+        }
+
+        if (Files.exists(liveFile)) {
+            Files.copy(liveFile, managedFile, StandardCopyOption.REPLACE_EXISTING);
+            ModConstants.LOGGER.info("[ServerProperties] Created global managed template from live server.properties: {}", managedFile);
+        }
+    }
+
+    private static void ensureWorldManagedFileExists(Path worldManagedFile, Path globalManagedFile, Path liveFile) throws IOException {
+        if (Files.exists(worldManagedFile)) {
+            return;
+        }
+
+        if (Files.exists(globalManagedFile)) {
+            Files.copy(globalManagedFile, worldManagedFile, StandardCopyOption.REPLACE_EXISTING);
+            ModConstants.LOGGER.info("[ServerProperties] Created world template from global managed template: {}", worldManagedFile);
+            return;
+        }
+
+        if (Files.exists(liveFile)) {
+            Files.copy(liveFile, worldManagedFile, StandardCopyOption.REPLACE_EXISTING);
+            ModConstants.LOGGER.info("[ServerProperties] Created world template from live server.properties: {}", worldManagedFile);
+        }
+    }
+
+    private static void syncManagedToLive(Path managedFile, Path liveFile) throws IOException {
+        if (!Files.exists(managedFile)) {
+            return;
+        }
+
+        if (Files.exists(liveFile) && Files.mismatch(managedFile, liveFile) == -1) {
+            return;
+        }
+
+        if (Files.exists(liveFile)) {
+            String timestamp = DateTimeFormatter.ISO_INSTANT.format(Instant.now()).replace(':', '-');
+            Path backup = liveFile.resolveSibling("server.properties.backup-" + timestamp);
+            Files.copy(liveFile, backup, StandardCopyOption.REPLACE_EXISTING);
+            ModConstants.LOGGER.info("[ServerProperties] Backed up existing server.properties to {}", backup);
+        }
+
+        Files.copy(managedFile, liveFile, StandardCopyOption.REPLACE_EXISTING);
+        ModConstants.LOGGER.info("[ServerProperties] Synced {} into live server.properties (applies on next restart)", managedFile);
+    }
+}

--- a/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
@@ -36,6 +36,7 @@ import com.thunder.wildernessodysseyapi.ai.AI_story.AIChatListener;
 import com.thunder.wildernessodysseyapi.donations.config.DonationReminderConfig;
 import com.thunder.wildernessodysseyapi.globalchat.GlobalChatManager;
 import com.thunder.wildernessodysseyapi.ModPackPatches.rules.GameRulesListManager;
+import com.thunder.wildernessodysseyapi.ModPackPatches.server.ServerPropertiesTemplateManager;
 import com.thunder.wildernessodysseyapi.ModPackPatches.telemetry.*;
 import com.thunder.wildernessodysseyapi.watersystem.water.fluid.WildernessFluidRegistry;
 import com.thunder.wildernessodysseyapi.watersystem.water.particle.WildernessParticleRegistry;
@@ -185,6 +186,7 @@ public class WildernessOdysseyAPIMainModClass {
     public void onServerStarting(ServerStartingEvent event) {
         AsyncTaskManager.initialize(AsyncThreadingConfig.values());
         globalChatManager.initialize(event.getServer(), event.getServer().getFile("config"));
+        ServerPropertiesTemplateManager.ensureManagedServerProperties(event.getServer());
         GameRulesListManager.ensureRulesFileExists(event.getServer());
         GameRulesListManager.applyConfiguredRules(event.getServer());
         ModpackStructureRegistry.loadAll();

--- a/src/main/resources/defaults/server.properties
+++ b/src/main/resources/defaults/server.properties
@@ -1,0 +1,38 @@
+# Wilderness Odyssey managed server.properties template
+#
+# Edit this file at: config/wildernessodysseyapi/server.properties
+# On server start, this file syncs into the root server.properties.
+# Changes apply after the next restart.
+
+allow-flight=true
+broadcast-console-to-ops=true
+difficulty=normal
+enable-command-block=true
+enable-query=false
+enable-rcon=false
+enforce-whitelist=false
+force-gamemode=false
+gamemode=survival
+generate-structures=true
+hardcore=false
+hide-online-players=false
+level-type=minecraft\:normal
+max-chained-neighbor-updates=1000000
+max-players=20
+max-tick-time=60000
+motd=A Wilderness Odyssey Server
+network-compression-threshold=256
+online-mode=true
+player-idle-timeout=0
+prevent-proxy-connections=false
+pvp=true
+rate-limit=0
+simulation-distance=10
+spawn-animals=true
+spawn-monsters=true
+spawn-npcs=true
+spawn-protection=16
+sync-chunk-writes=true
+use-native-transport=true
+view-distance=10
+white-list=false


### PR DESCRIPTION
### Motivation

- Provide a distributable, managed `server.properties` template so modpacks can ship sensible server defaults and let world folders carry their own server settings. 
- Ensure safe updates and predictable behavior by preferring a world-local template, backing up the live file, and replacing managed templates when the bundled defaults change.

### Description

- Added `ServerPropertiesTemplateManager` to create and synchronize a global managed template at `config/wildernessodysseyapi/server.properties` and a world-local template at `<world>/server.properties.wildernessodyssey`, and to sync the preferred template into the live `server.properties` with timestamped backups.  
- The manager writes a hash state (`server-properties-template.sha256`) and replaces managed files when the bundled `defaults/server.properties` changes, and it loads bundled bytes from `defaults/server.properties` in resources.  
- Hooked the manager into server startup by calling `ServerPropertiesTemplateManager.ensureManagedServerProperties` from `onServerStarting` in `WildernessOdysseyAPIMainModClass`.  
- Added a bundled default template at `src/main/resources/defaults/server.properties` and updated `README.md` to document the managed template behavior and location (`config/wildernessodysseyapi/server.properties` and `<world>/server.properties.wildernessodyssey`).

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ebe130bc8328b3c200ce7c5ef919)