### PR TITLE
Fix NeoForge 1.21 API mismatches for meteor persistence and radiation effect

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/effect/RadiationEffect.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/effect/RadiationEffect.java
@@ -9,7 +9,6 @@ import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.ai.attributes.AttributeMap;
 
 public class RadiationEffect extends MobEffect {
 
@@ -79,8 +78,8 @@ public class RadiationEffect extends MobEffect {
     }
 
     @Override
-    public void onEffectAdded(LivingEntity entity, AttributeMap attributes) {
-        super.onEffectAdded(entity, attributes);
+    public void onEffectAdded(LivingEntity entity, int amplifier) {
+        super.onEffectAdded(entity, amplifier);
         if (entity.level() instanceof ServerLevel serverLevel) {
             serverLevel.playSound(
                 null,

--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/meteor/MeteorFeature.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/meteor/MeteorFeature.java
@@ -364,6 +364,11 @@ public class MeteorFeature extends Feature<NoneFeatureConfiguration> {
     // =========================================================
     //  Helpers
     // =========================================================
+    private BlockPos snapToSurface(WorldGenLevel world, BlockPos pos) {
+        int y = getSurfaceY(world, pos.getX(), pos.getZ());
+        return new BlockPos(pos.getX(), y, pos.getZ());
+    }
+
     private int getSurfaceY(WorldGenLevel world, int x, int z) {
         int y = world.getMaxBuildHeight() - 1;
         while (y > world.getMinBuildHeight() && world.getBlockState(new BlockPos(x, y, z)).isAir()) {

--- a/src/main/java/com/thunder/wildernessodysseyapi/worldgen/meteor/MeteorSavedData.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/worldgen/meteor/MeteorSavedData.java
@@ -1,6 +1,7 @@
 package com.thunder.wildernessodysseyapi.worldgen.meteor;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -31,8 +32,7 @@ public class MeteorSavedData extends SavedData {
         return level.getDataStorage().computeIfAbsent(
             new Factory<>(
                 MeteorSavedData::new,
-                MeteorSavedData::load,
-                null
+                MeteorSavedData::load
             ),
             DATA_NAME
         );
@@ -40,7 +40,7 @@ public class MeteorSavedData extends SavedData {
 
     // ---- NBT ----
 
-    private static MeteorSavedData load(CompoundTag nbt) {
+    private static MeteorSavedData load(CompoundTag nbt, HolderLookup.Provider registries) {
         MeteorSavedData data = new MeteorSavedData();
         ListTag list = nbt.getList("meteors", Tag.TAG_COMPOUND);
         for (int i = 0; i < list.size(); i++) {
@@ -56,7 +56,7 @@ public class MeteorSavedData extends SavedData {
     }
 
     @Override
-    public CompoundTag save(CompoundTag nbt) {
+    public CompoundTag save(CompoundTag nbt, HolderLookup.Provider registries) {
         ListTag list = new ListTag();
         for (MeteorRecord m : meteors) {
             CompoundTag entry = new CompoundTag();


### PR DESCRIPTION
### Motivation
- Bring code up to NeoForge / Minecraft 1.21 saved-data and mob-effect API signatures to fix compiler errors caused by mismatched method signatures and missing helpers. 
- Ensure meteor generation and persisted meteor data work with the current `SavedData` factory/serialization expectations and that the radiation effect overrides the correct `MobEffect` hook.

### Description
- Update `RadiationEffect` to match the current signature `onEffectAdded(LivingEntity, int)` and call `super.onEffectAdded(entity, amplifier)` instead of the old `AttributeMap` variant. (`src/main/java/com/thunder/wildernessodysseyapi/effect/RadiationEffect.java`)
- Add the missing helper `snapToSurface(WorldGenLevel, BlockPos)` used by meteor placement to correctly snap generated features to the surface. (`src/main/java/com/thunder/wildernessodysseyapi/worldgen/meteor/MeteorFeature.java`)
- Migrate `MeteorSavedData` to the modern `SavedData` API by importing `HolderLookup`, changing the loader to `load(CompoundTag, HolderLookup.Provider)`, overriding `save(CompoundTag, HolderLookup.Provider)`, and constructing the `SavedData.Factory` with the current constructor form. (`src/main/java/com/thunder/wildernessodysseyapi/worldgen/meteor/MeteorSavedData.java`)

### Testing
- Ran `./gradlew compileJava --no-daemon` which failed in this environment due to an SSL truststore issue while NeoForge tried to download Mojang metadata (`SSLHandshakeException: certificate_unknown`), not due to source-level compile errors. 
- Re-ran `./gradlew compileJava --offline --no-daemon` with the same SSL/NeoForm download failure preventing a full build/verification in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb271b77483288b45df93a4f02edd)