### PR TITLE
Fix client crash by registering meteor entity type

### DIFF
--- a/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
+++ b/src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java
@@ -145,6 +145,7 @@ public class WildernessOdysseyAPIMainModClass {
         ModCreativeTabs.register(modEventBus);
         ModAttachments.ATTACHMENTS.register(modEventBus);
         ModEntities.ENTITY_TYPES.register(modEventBus);
+        com.thunder.wildernessodysseyapi.core.ModEntities.register(modEventBus);
         ModLootFunctions.LOOT_FUNCTIONS.register(modEventBus);
         ModLootConditions.LOOT_CONDITIONS.register(modEventBus);
 


### PR DESCRIPTION
### Motivation
- Prevent a client startup crash where `ClientSetup` calls `ModEntities.METEOR.get()` during `EntityRenderersEvent.RegisterRenderers` while the meteor `DeferredHolder` remained unbound.

### Description
- Register the meteor entity deferred register by adding `com.thunder.wildernessodysseyapi.core.ModEntities.register(modEventBus);` to `registerRegistries(...)` in `src/main/java/com/thunder/wildernessodysseyapi/core/WildernessOdysseyAPIMainModClass.java` so the `wildernessodysseyapi:meteor` `EntityType` is bound before renderer registration.

### Testing
- Ran `./gradlew compileJava`, which attempted to build but failed in this environment due to an SSL certificate trust error while downloading Mojang metadata, so the build did not complete (failure unrelated to the code change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb4fa90ec83289f4bf0cc6a5fa87b)