### PR TITLE
Fix meteor impact worldgen registry namespace mismatch

### DIFF
--- a/src/main/resources/data/neoforge/biome_modifier/add_meteor_impact.json
+++ b/src/main/resources/data/neoforge/biome_modifier/add_meteor_impact.json
@@ -1,6 +1,6 @@
 {
   "type": "neoforge:add_features",
   "biomes": "#minecraft:is_overworld",
-  "features": "meteormod:meteor_impact",
+  "features": "wildernessodysseyapi:meteor_impact",
   "step": "surface_structures"
 }

--- a/src/main/resources/data/wildernessodysseyapi/worldgen/configured_feature/meteor_impact.json
+++ b/src/main/resources/data/wildernessodysseyapi/worldgen/configured_feature/meteor_impact.json
@@ -1,4 +1,4 @@
 {
-  "type": "meteormod:meteor_impact",
+  "type": "wildernessodysseyapi:meteor_impact",
   "config": {}
 }

--- a/src/main/resources/data/wildernessodysseyapi/worldgen/placed_feature/meteor_impact.json
+++ b/src/main/resources/data/wildernessodysseyapi/worldgen/placed_feature/meteor_impact.json
@@ -1,5 +1,5 @@
 {
-  "feature": "meteormod:meteor_impact",
+  "feature": "wildernessodysseyapi:meteor_impact",
   "placement": [
     {
       "type": "minecraft:rarity_filter",


### PR DESCRIPTION
### Motivation
- Fix a worldgen registry resolution failure caused by the meteor impact data files referencing the wrong namespace (`meteormod`) which produced unknown/unbound registry keys and crashed world creation.

### Description
- Replaced `meteormod:meteor_impact` with `wildernessodysseyapi:meteor_impact` in `src/main/resources/data/wildernessodysseyapi/worldgen/configured_feature/meteor_impact.json`, `src/main/resources/data/wildernessodysseyapi/worldgen/placed_feature/meteor_impact.json`, and `src/main/resources/data/neoforge/biome_modifier/add_meteor_impact.json` so the data files point at the mod's registered feature key.

### Testing
- Attempted to run `./gradlew compileJava`; the task ran but the build failed in this environment due to Java 21 toolchain auto-provisioning being unavailable (foojay error), so no successful compile could be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc6869f3c8328b300059d2acdba27)