### PR TITLE
Add GitHub Pages starter website and README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,15 @@ World Generation Diagnostics
 Use `/worldgenscan <radius>` to count nearby structures, features, and biomes and identify which mods add them.
 
 For a roadmap on chunk lifecycle, async I/O, and networking improvements, see `docs/chunk-system-improvements.md`.
+
+Website (GitHub Pages)
+----------------------
+A starter website for the modpack hub is available in `website/`.
+
+Quick publish steps:
+1. Push this branch to GitHub.
+2. In repository settings, open **Pages**.
+3. Set source to your branch and `/website` folder (or copy files to root on a `gh-pages` branch).
+4. Replace placeholder links and sample content in `website/index.html`, `website/description.html`, `website/gallery.html`, `website/updates.html`, and `website/version-checker.html`.
+
+Tip: update the CurseForge and Discord badge links in `website/index.html` to your real project pages.

--- a/website/description.html
+++ b/website/description.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Wilderness Odyssey | Description</title><link rel="stylesheet" href="styles.css" /></head><body>
+<nav class="nav"><a class="brand" href="index.html">Wilderness Odyssey</a><div class="nav-links"><a href="description.html">Description</a><a href="gallery.html">Gallery</a><a href="updates.html">Updates</a><a href="version-checker.html">Version Checker</a></div></nav>
+<main>
+<section class="panel"><h1>Modpack Description</h1><p>Wilderness Odyssey is a curated Minecraft modpack focused on immersive survival, dangerous exploration, and guided early-game progression.</p></section>
+<section class="card-grid">
+<article class="card"><h2>Core Stack</h2><p>Minecraft + NeoForge, with gameplay systems tuned for long-term world progression.</p></article>
+<article class="card"><h2>Recommended Setup</h2><p>Allocate 6-8GB RAM, use Java 21 where supported, and keep drivers updated for shader-heavy packs.</p></article>
+<article class="card"><h2>First Launch Checklist</h2><p>Generate a test world, verify FPS stability, then back up before applying updates.</p></article>
+</section>
+</main><footer><p>© <span data-year></span> Wilderness Odyssey.</p></footer><script src="script.js"></script></body></html>

--- a/website/gallery.html
+++ b/website/gallery.html
@@ -1,0 +1,11 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Wilderness Odyssey | Gallery</title><link rel="stylesheet" href="styles.css" /></head><body>
+<nav class="nav"><a class="brand" href="index.html">Wilderness Odyssey</a><div class="nav-links"><a href="description.html">Description</a><a href="gallery.html">Gallery</a><a href="updates.html">Updates</a><a href="version-checker.html">Version Checker</a></div></nav>
+<main>
+<section class="panel"><h1>Gallery</h1><p>Replace these placeholders with real screenshots from your modpack worlds.</p></section>
+<section class="gallery">
+<article class="shot"><div class="placeholder">Biome Showcase Screenshot</div><p>Unique terrain and atmosphere.</p></article>
+<article class="shot"><div class="placeholder">Starter Structure Screenshot</div><p>Early progression spawn setup.</p></article>
+<article class="shot"><div class="placeholder">Combat/Exploration Screenshot</div><p>Mid-game survival challenges.</p></article>
+<article class="shot"><div class="placeholder">Base Build Screenshot</div><p>Player creativity and tech growth.</p></article>
+</section>
+</main><footer><p>© <span data-year></span> Wilderness Odyssey.</p></footer><script src="script.js"></script></body></html>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Wilderness Odyssey | Home</title>
+  <meta name="description" content="Official central website for the Wilderness Odyssey Minecraft modpack." />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <nav class="nav">
+      <a class="brand" href="index.html">Wilderness Odyssey</a>
+      <div class="nav-links">
+        <a href="description.html">Description</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="updates.html">Updates</a>
+        <a href="version-checker.html">Version Checker</a>
+      </div>
+    </nav>
+    <section class="hero-content">
+      <h1>A survival-first Minecraft modpack built around progression and exploration</h1>
+      <p>Your central player portal for setup, screenshots, patch updates, and compatibility checks.</p>
+      <div class="btn-row">
+        <a class="btn primary" href="description.html">Read Modpack Overview</a>
+        <a class="btn" href="https://github.com/" target="_blank" rel="noreferrer">GitHub Repo</a>
+      </div>
+
+      <div class="badge-row" aria-label="Community and download badges">
+        <a class="badge curseforge" href="https://www.curseforge.com/minecraft/modpacks" target="_blank" rel="noreferrer" aria-label="Open CurseForge modpack page">CurseForge Modpack</a>
+        <a class="badge discord" href="https://discord.com/" target="_blank" rel="noreferrer" aria-label="Join Discord server">Join Discord</a>
+      </div>
+    </section>
+  </header>
+
+  <main>
+    <section class="card-grid">
+      <article class="card"><h2>Install Fast</h2><p>Launcher setup, Java/RAM recommendations, and first launch checklist are on the Description page.</p></article>
+      <article class="card"><h2>Track Releases</h2><p>Use Updates for changelogs and breaking changes before moving your world to new versions.</p></article>
+      <article class="card"><h2>Verify Compatibility</h2><p>Use Version Checker to quickly compare your installed pack against latest release target.</p></article>
+    </section>
+
+    <section class="panel">
+      <h2>What else this site now includes</h2>
+      <ul>
+        <li>Direct launch badges for CurseForge and Discord.</li>
+        <li>Dedicated pages for description, gallery, updates, and version checks.</li>
+        <li>Simple structure that is GitHub Pages friendly and easy to extend.</li>
+      </ul>
+    </section>
+  </main>
+
+  <footer>
+    <p>© <span data-year></span> Wilderness Odyssey. Hosted via GitHub Pages.</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/website/script.js
+++ b/website/script.js
@@ -1,0 +1,23 @@
+document.querySelectorAll('[data-year]').forEach((el) => {
+  el.textContent = new Date().getFullYear();
+});
+
+const checkForm = document.getElementById('version-checker-form');
+if (checkForm) {
+  checkForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const latest = document.getElementById('latestVersion').value.trim();
+    const installed = document.getElementById('installedVersion').value.trim();
+    const result = document.getElementById('versionResult');
+
+    if (!latest || !installed) {
+      result.textContent = 'Enter both latest and installed versions first.';
+      return;
+    }
+    if (latest === installed) {
+      result.textContent = `✅ You're up to date on ${installed}.`;
+    } else {
+      result.textContent = `⬆️ Update available: installed ${installed}, latest ${latest}. Back up your world before upgrading.`;
+    }
+  });
+}

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,99 @@
+:root {
+  --bg: #0d1320;
+  --panel: #151e31;
+  --text: #e8eefc;
+  --muted: #b8c6e7;
+  --accent: #67d5ff;
+  --border: #24344f;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--text);
+  background: linear-gradient(180deg, #0a0f1b, #101a2c);
+}
+a { color: var(--accent); }
+
+.nav {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 1rem 1.2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+.brand { color: var(--accent); text-decoration: none; font-weight: 700; }
+.nav-links { display: flex; flex-wrap: wrap; }
+.nav-links a { color: var(--muted); text-decoration: none; margin-left: 1rem; }
+
+.hero { min-height: 48vh; padding-bottom: 2rem; }
+.hero-content { max-width: 1080px; margin: 4rem auto 0; padding: 0 1.2rem; }
+.hero h1 { font-size: clamp(2rem, 5vw, 3.2rem); margin-bottom: .5rem; }
+.hero p { color: var(--muted); max-width: 68ch; }
+
+main { max-width: 1080px; margin: 0 auto 2rem; padding: 0 1.2rem; }
+.card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: .9rem; }
+.card, .panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem;
+}
+.panel { margin-top: .9rem; }
+
+.btn-row { margin-top: 1.2rem; display: flex; flex-wrap: wrap; gap: .8rem; }
+.btn {
+  border: 1px solid #314362;
+  padding: .65rem 1rem;
+  border-radius: 10px;
+  text-decoration: none;
+  color: var(--text);
+  background: transparent;
+}
+.btn.primary { background: var(--accent); color: #022130; border-color: var(--accent); font-weight: 600; }
+
+.gallery { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: .9rem; }
+.shot {
+  background: #0b1322;
+  border: 1px solid #2a3b57;
+  border-radius: 10px;
+  padding: .7rem;
+}
+.placeholder {
+  border-radius: 8px;
+  height: 140px;
+  background: linear-gradient(135deg, #1b2b46, #203a63);
+  display: grid;
+  place-items: center;
+  color: #d8e7ff;
+  font-size: .9rem;
+}
+
+.form-row { display: grid; gap: .8rem; max-width: 460px; }
+input {
+  width: 100%;
+  padding: .6rem .7rem;
+  border: 1px solid #395176;
+  border-radius: 8px;
+  background: #0f192d;
+  color: var(--text);
+}
+.result { margin-top: .8rem; color: #d9ecff; }
+
+footer { text-align: center; color: var(--muted); padding: 2rem 1rem; }
+
+
+.badge-row { margin-top: 1rem; display: flex; flex-wrap: wrap; gap: .7rem; }
+.badge {
+  display: inline-block;
+  text-decoration: none;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: .5rem .9rem;
+  border: 1px solid transparent;
+}
+.badge.curseforge { background: #f16436; color: #fff; }
+.badge.discord { background: #5865F2; color: #fff; }
+.badge:hover { filter: brightness(1.06); }

--- a/website/updates.html
+++ b/website/updates.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Wilderness Odyssey | Updates</title><link rel="stylesheet" href="styles.css" /></head><body>
+<nav class="nav"><a class="brand" href="index.html">Wilderness Odyssey</a><div class="nav-links"><a href="description.html">Description</a><a href="gallery.html">Gallery</a><a href="updates.html">Updates</a><a href="version-checker.html">Version Checker</a></div></nav>
+<main>
+<section class="panel"><h1>Update Notes</h1><p>Post release notes here for each modpack version. Keep compatibility notes clear.</p></section>
+<section class="card-grid">
+<article class="card"><h2>v0.9.0 (Example)</h2><ul><li>Added worldgen balancing pass.</li><li>Improved starter flow messaging.</li><li>Updated utility dependencies.</li></ul></article>
+<article class="card"><h2>Before Updating</h2><ul><li>Back up saves.</li><li>Read breaking change notes.</li><li>Check server/client version parity.</li></ul></article>
+</section>
+</main><footer><p>© <span data-year></span> Wilderness Odyssey.</p></footer><script src="script.js"></script></body></html>

--- a/website/version-checker.html
+++ b/website/version-checker.html
@@ -1,0 +1,13 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Wilderness Odyssey | Version Checker</title><link rel="stylesheet" href="styles.css" /></head><body>
+<nav class="nav"><a class="brand" href="index.html">Wilderness Odyssey</a><div class="nav-links"><a href="description.html">Description</a><a href="gallery.html">Gallery</a><a href="updates.html">Updates</a><a href="version-checker.html">Version Checker</a></div></nav>
+<main>
+<section class="panel"><h1>Version Checker</h1><p>Quickly compare your installed version with the latest published modpack version.</p></section>
+<section class="panel">
+<form id="version-checker-form" class="form-row">
+<label for="latestVersion">Latest Version</label><input id="latestVersion" placeholder="e.g. 1.0.3" />
+<label for="installedVersion">Installed Version</label><input id="installedVersion" placeholder="e.g. 1.0.1" />
+<button class="btn primary" type="submit">Compare Versions</button>
+</form>
+<p id="versionResult" class="result">Enter values and click compare.</p>
+</section>
+</main><footer><p>© <span data-year></span> Wilderness Odyssey.</p></footer><script src="script.js"></script></body></html>


### PR DESCRIPTION
### Motivation
- Provide a lightweight, GitHub Pages–friendly starter website for the modpack hub so users can publish project pages and centralize install, gallery, and update information.
- Make it easy to ship release information and simple compatibility checks alongside the mod by including a local `website/` folder and publishing instructions.

### Description
- Add a `website/` directory with `index.html`, `description.html`, `gallery.html`, `updates.html`, `version-checker.html`, `styles.css`, and `script.js` implementing a themed starter site and UI components.
- Implement a small client-side version checker and dynamic copyright year in `script.js` and include a basic responsive layout and styling in `styles.css`.
- Update `README.md` with a new "Website (GitHub Pages)" section that documents quick publish steps and points to the `website/` folder and files.
- Provide placeholder content and badges in the pages with notes to replace links and screenshots for a production site.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdfeb21d0c8328b3f0c48c48eb2cfb)