### PR TITLE
Add manual GitHub Pages workflow for website deployment

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,36 @@
+name: Deploy Website
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload website artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Provide a safe, manual release mechanism to publish the repository `website/` content to GitHub Pages using a dedicated workflow triggered by `workflow_dispatch`.

### Description
- Add `.github/workflows/deploy-site.yml` which runs only on manual dispatch, configures Pages permissions (`pages: write`, `id-token: write`), uses a `pages` concurrency group, and deploys the `website` directory via `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages`.

### Testing
- Verified the new workflow file contents with `nl -ba .github/workflows/deploy-site.yml` and confirmed the working tree was clean with `git status --short`, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea23cc4f08328a86897088ab1124f)